### PR TITLE
Add missing <map> include in Formula.h

### DIFF
--- a/src/storm/logic/Formula.h
+++ b/src/storm/logic/Formula.h
@@ -2,6 +2,7 @@
 #define STORM_LOGIC_FORMULA_H_
 
 #include <iosfwd>
+#include <map>
 #include <memory>
 #include <set>
 #include <vector>


### PR DESCRIPTION
Formula.h uses `std::map` but did not include `<map>` directly, relying on transitive includes.