### PR TITLE
Support for linter via clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,56 @@
+# See https://clang.llvm.org/extra/clang-tidy/ for a list of available checks.
+# Disable everything first, then enable individual checks.
+Checks: >-
+  -*,
+  readability-braces-around-statements
+# Candidate checks that are not (yet) enabled:
+# bugprone-branch-clone,
+# bugprone-copy-constructor-init,
+# bugprone-dangling-handle,
+# bugprone-infinite-loop,
+# bugprone-misplaced-widening-cast,
+# bugprone-redundant-expression,
+# bugprone-signed-char-misuse,
+# bugprone-unused-return-value,
+# bugprone-use-after-move,
+# bugprone-virtual-near-miss,
+# clang-analyzer-core.*,
+# clang-analyzer-cplusplus.*,
+# clang-analyzer-deadcode.*,
+# clang-analyzer-nullability.*,
+# clang-analyzer-security.*,
+# clang-analyzer-unix.*,
+# misc-misplaced-const,
+# misc-static-assert,
+# misc-throw-by-value-catch-by-reference,
+# misc-unused-using-decls,
+# modernize-deprecated-headers,
+# modernize-make-shared,
+# modernize-make-unique,
+# modernize-return-braced-init-list,
+# modernize-use-default-member-init,
+# modernize-use-nullptr,
+# modernize-use-using,
+# performance-for-range-copy,
+# performance-implicit-conversion-in-loop,
+# performance-move-constructor-init,
+# performance-unnecessary-copy-initialization,
+# performance-unnecessary-value-param,
+# readability-container-size-empty,
+# readability-else-after-return,
+# readability-non-const-parameter,
+# readability-redundant-member-init,
+# readability-redundant-smartptr-get,
+# readability-redundant-string-cstr,
+# readability-simplify-boolean-expr,
+# readability-static-accessed-through-instance
+
+# Only report diagnostics in src/ but not third-party or system headers.
+# The regex also matches storm-*
+HeaderFilterRegex: 'src/(storm|test)'
+# Exclude any bundled third-party code.
+# Avoids potential problems if its paths contains "src/storm/" as a substring.
+ExcludeHeaderFilterRegex: '(_deps|resources/3rdparty)/'
+SystemHeaders: false
+FormatStyle: file
+WarningsAsErrors: ''

--- a/.github/workflows/formatapply.yml
+++ b/.github/workflows/formatapply.yml
@@ -9,17 +9,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      - name: Read pinned clang versions
+        id: clang-versions
+        run: |
+          echo "FORMAT_VERSION=$(grep '^CLANG_FORMAT_VERSION=' resources/scripts/clang-versions | cut -d= -f2)" >> "$GITHUB_OUTPUT"
       # apply the formatting twice as a workaround for a clang-format bug
       - uses: DoozyX/clang-format-lint-action@v0.20
         with:
           source: './src'
-          clangFormatVersion: 20
+          clangFormatVersion: ${{ steps.clang-versions.outputs.FORMAT_VERSION }}
           style: file
           inplace: True
       - uses: DoozyX/clang-format-lint-action@v0.20
         with:
           source: './src'
-          clangFormatVersion: 20
+          clangFormatVersion: ${{ steps.clang-versions.outputs.FORMAT_VERSION }}
           style: file
           inplace: True
       - name: Commit Formatting

--- a/.github/workflows/formatcheck.yml
+++ b/.github/workflows/formatcheck.yml
@@ -11,8 +11,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+    - name: Read pinned clang versions
+      id: clang-versions
+      run: |
+        echo "FORMAT_VERSION=$(grep '^CLANG_FORMAT_VERSION=' resources/scripts/clang-versions | cut -d= -f2)" >> "$GITHUB_OUTPUT"
     - uses: DoozyX/clang-format-lint-action@v0.20
       with:
         source: './src'
-        clangFormatVersion: 20
+        clangFormatVersion: ${{ steps.clang-versions.outputs.FORMAT_VERSION }}
         style: file

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -1,0 +1,55 @@
+name: Lint check
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-check:
+    name: clang-format & clang-tidy
+    runs-on: ubuntu-latest
+    container: movesrwth/storm-dependencies:latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Configure to generate compile_commands.json
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DSTORM_PORTABLE=ON \
+            -DSTORM_DEVELOPER=ON \
+            -DSTORM_COMPILE_WITH_PCH=OFF
+
+      - name: Run cpp-linter
+        id: cpp-linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: cpp-linter/cpp-linter-action@v2.20.0
+        with:
+          style: file
+          tidy-checks: ''
+          version: '22'
+          database: build
+          files-changed-only: true
+          lines-changed-only: diff
+          step-summary: true
+          thread-comments: false
+          format-review: true
+          tidy-review: true
+          passive-reviews: true
+          no-lgtm: true
+          ignore-format: 'build|resources|.github'
+          ignore-tidy: 'resources/3rdparty'
+
+      - name: Fail on lint errors
+        if: steps.cpp-linter.outputs.checks-failed != 0
+        run: exit 1

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -24,6 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Read pinned clang versions
+        id: clang-versions
+        run: |
+          echo "TIDY_VERSION=$(grep '^CLANG_TIDY_VERSION=' resources/scripts/clang-versions | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+
       - name: Configure to generate compile_commands.json
         run: |
           cmake -S . -B build \
@@ -44,7 +49,7 @@ jobs:
         with:
           style: file
           tidy-checks: ''
-          version: '22'
+          version: ${{ steps.clang-versions.outputs.TIDY_VERSION }}
           database: build
           files-changed-only: true
           lines-changed-only: diff

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # GitHub runners currently have 4 cores
+  NR_JOBS: "4"
+
 jobs:
   lint-check:
     name: clang-format & clang-tidy
@@ -28,6 +32,9 @@ jobs:
             -DSTORM_PORTABLE=ON \
             -DSTORM_DEVELOPER=ON \
             -DSTORM_COMPILE_WITH_PCH=OFF
+
+      - name: Build external resources to populate include directories
+        run: cmake --build build --target storm_resources -j ${NR_JOBS}
 
       - name: Run cpp-linter
         id: cpp-linter
@@ -47,8 +54,7 @@ jobs:
           tidy-review: true
           passive-reviews: true
           no-lgtm: true
-          ignore-format: 'build|resources|.github'
-          ignore-tidy: 'resources/3rdparty'
+          ignore: 'build|resources|.github'
 
       - name: Fail on lint errors
         if: steps.cpp-linter.outputs.checks-failed != 0

--- a/.github/workflows/lint-full.yml
+++ b/.github/workflows/lint-full.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Read pinned clang versions
+        id: clang-versions
+        run: |
+          echo "TIDY_VERSION=$(grep '^CLANG_TIDY_VERSION=' resources/scripts/clang-versions | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+
       - name: Configure to generate compile_commands.json
         run: |
           cmake -S . -B build \
@@ -43,7 +48,7 @@ jobs:
         with:
           style: file
           tidy-checks: ''
-          version: '22'
+          version: ${{ steps.clang-versions.outputs.TIDY_VERSION }}
           database: build
           files-changed-only: false
           lines-changed-only: false

--- a/.github/workflows/lint-full.yml
+++ b/.github/workflows/lint-full.yml
@@ -1,0 +1,48 @@
+name: Full lint check
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-full:
+    name: clang-format & clang-tidy (full codebase)
+    runs-on: ubuntu-latest
+    container: movesrwth/storm-dependencies:latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Configure to generate compile_commands.json
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DSTORM_PORTABLE=ON \
+            -DSTORM_DEVELOPER=ON \
+            -DSTORM_COMPILE_WITH_PCH=OFF
+
+      - name: Run cpp-linter
+        id: cpp-linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: cpp-linter/cpp-linter-action@v2.20.0
+        with:
+          style: file
+          tidy-checks: ''
+          version: '22'
+          database: build
+          files-changed-only: false
+          lines-changed-only: false
+          step-summary: true
+          ignore: 'build|resources|.github'
+
+      - name: Fail on lint errors
+        if: steps.cpp-linter.outputs.checks-failed != 0
+        run: exit 1

--- a/.github/workflows/lint-full.yml
+++ b/.github/workflows/lint-full.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # GitHub runners currently have 4 cores
+  NR_JOBS: "4"
+
 jobs:
   lint-full:
     name: clang-format & clang-tidy (full codebase)
@@ -27,6 +31,9 @@ jobs:
             -DSTORM_PORTABLE=ON \
             -DSTORM_DEVELOPER=ON \
             -DSTORM_COMPILE_WITH_PCH=OFF
+
+      - name: Build external resources to populate include directories
+        run: cmake --build build --target storm_resources -j ${NR_JOBS}
 
       - name: Run cpp-linter
         id: cpp-linter

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ option(STORM_COMPILE_WITH_PCH "Enable pre-compiled headers" ON)
 mark_as_advanced(STORM_COMPILE_WITH_PCH)
 option(STORM_ENABLE_CLANG_TIDY "Sets whether a target for running clang-tidy is added." OFF)
 MARK_AS_ADVANCED(STORM_ENABLE_CLANG_TIDY)
+option(STORM_ENABLE_CLANG_FORMAT "Sets whether a target for running clang-format is added." OFF)
+MARK_AS_ADVANCED(STORM_ENABLE_CLANG_FORMAT)
 option(STORM_LOG_DISABLE_DEBUG "Disable log and trace message support" OFF)
 option(STORM_COMPILE_WITH_ADDRESS_SANITIZER "Sets whether to compile with AddressSanitizer enabled" OFF)
 option(STORM_COMPILE_WITH_ALL_SANITIZERS "Sets whether to compile with all sanitizers enabled" OFF)
@@ -158,6 +160,8 @@ if (STORM_DEVELOPER)
     set(STORM_DEBUG_SPOT ON)
     set(STORM_DEBUG_SYLVAN ON)
     set(STORM_WARNING_AS_ERROR ON)
+    set(STORM_ENABLE_CLANG_FORMAT ON)
+    set(STORM_ENABLE_CLANG_TIDY ON)
 else()
     set(STORM_LOG_DISABLE_DEBUG ON)
     if (NOT CMAKE_BUILD_TYPE)
@@ -526,45 +530,9 @@ if(PROJECT_IS_TOP_LEVEL AND STORM_BUILD_TESTS)
 	add_dependencies(check-verbose tests)
 endif()
 
+# Developer tools for formatting and static analysis
 if(PROJECT_IS_TOP_LEVEL)
-	# Apply code formatting
-	add_custom_target(format COMMAND ${PROJECT_SOURCE_DIR}/resources/scripts/auto-format.sh)
-endif()
-
-if(PROJECT_IS_TOP_LEVEL AND STORM_ENABLE_CLANG_TIDY)
-	# Ensure that a compile_commands.json is generated, since clang-tidy relies on it.
-	set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-	find_program(STORM_CLANG_TIDY_BINARY
-		NAMES clang-tidy-22 clang-tidy-21 clang-tidy-20 clang-tidy-19 clang-tidy-18
-		      clang-tidy-17 clang-tidy-16 clang-tidy-15 clang-tidy
-		HINTS ${LLVM_ROOT}/bin)
-	find_program(STORM_RUN_CLANG_TIDY_BINARY
-		NAMES run-clang-tidy-22 run-clang-tidy-21 run-clang-tidy-20 run-clang-tidy-19 run-clang-tidy-18
-		      run-clang-tidy-17 run-clang-tidy-16 run-clang-tidy-15 run-clang-tidy
-		HINTS ${LLVM_ROOT}/bin)
-	if(NOT STORM_CLANG_TIDY_BINARY)
-		message(FATAL_ERROR "STORM_ENABLE_CLANG_TIDY was set, but no clang-tidy executable could be found.")
-	endif()
-	if(NOT STORM_RUN_CLANG_TIDY_BINARY)
-		message(FATAL_ERROR "STORM_ENABLE_CLANG_TIDY was set, but no run-clang-tidy executable could be found.")
-	endif()
-	set(STORM_CLANG_TIDY_JOBS "${STORM_RESOURCES_BUILD_JOBCOUNT}")
-	# Bake the compiler's implicit include directories into the recorded compile commands. Fixes problems with e.g. Nix.
-	set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
-	set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
-	# Runs clang-tidy (as configured in .clang-tidy) over the Storm sources.
-	# USES_TERMINAL and PYTHONUNBUFFERED keep the progress of clang-tidy visible
-	add_custom_target(clang-tidy
-		COMMAND ${CMAKE_COMMAND} -E env PYTHONUNBUFFERED=1
-			${STORM_RUN_CLANG_TIDY_BINARY} -p ${CMAKE_BINARY_DIR} -j ${STORM_CLANG_TIDY_JOBS} -source-filter=${CMAKE_SOURCE_DIR}/src
-		USES_TERMINAL
-		COMMENT "Running clang-tidy over the Storm sources.")
-	# Like clang-tidy, but automatically applies the suggested fixes.
-	add_custom_target(clang-tidy-fix
-		COMMAND ${CMAKE_COMMAND} -E env PYTHONUNBUFFERED=1
-			${STORM_RUN_CLANG_TIDY_BINARY} -p ${CMAKE_BINARY_DIR} -j ${STORM_CLANG_TIDY_JOBS} -source-filter=${CMAKE_SOURCE_DIR}/src -fix
-		USES_TERMINAL
-		COMMENT "Running clang-tidy with automatic fixes over the Storm sources.")
+	include(${PROJECT_SOURCE_DIR}/resources/cmake/ClangTools.cmake)
 endif()
 
 set(STORM_TARGETS "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ option(STORM_COMPILE_WITH_CCACHE "Compile using CCache [if found]" ON)
 mark_as_advanced(STORM_COMPILE_WITH_CCACHE)
 option(STORM_COMPILE_WITH_PCH "Enable pre-compiled headers" ON)
 mark_as_advanced(STORM_COMPILE_WITH_PCH)
+option(STORM_ENABLE_CLANG_TIDY "Sets whether a target for running clang-tidy is added." OFF)
+MARK_AS_ADVANCED(STORM_ENABLE_CLANG_TIDY)
 option(STORM_LOG_DISABLE_DEBUG "Disable log and trace message support" OFF)
 option(STORM_COMPILE_WITH_ADDRESS_SANITIZER "Sets whether to compile with AddressSanitizer enabled" OFF)
 option(STORM_COMPILE_WITH_ALL_SANITIZERS "Sets whether to compile with all sanitizers enabled" OFF)
@@ -527,6 +529,42 @@ endif()
 if(PROJECT_IS_TOP_LEVEL)
 	# Apply code formatting
 	add_custom_target(format COMMAND ${PROJECT_SOURCE_DIR}/resources/scripts/auto-format.sh)
+endif()
+
+if(PROJECT_IS_TOP_LEVEL AND STORM_ENABLE_CLANG_TIDY)
+	# Ensure that a compile_commands.json is generated, since clang-tidy relies on it.
+	set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+	find_program(STORM_CLANG_TIDY_BINARY
+		NAMES clang-tidy-22 clang-tidy-21 clang-tidy-20 clang-tidy-19 clang-tidy-18
+		      clang-tidy-17 clang-tidy-16 clang-tidy-15 clang-tidy
+		HINTS ${LLVM_ROOT}/bin)
+	find_program(STORM_RUN_CLANG_TIDY_BINARY
+		NAMES run-clang-tidy-22 run-clang-tidy-21 run-clang-tidy-20 run-clang-tidy-19 run-clang-tidy-18
+		      run-clang-tidy-17 run-clang-tidy-16 run-clang-tidy-15 run-clang-tidy
+		HINTS ${LLVM_ROOT}/bin)
+	if(NOT STORM_CLANG_TIDY_BINARY)
+		message(FATAL_ERROR "STORM_ENABLE_CLANG_TIDY was set, but no clang-tidy executable could be found.")
+	endif()
+	if(NOT STORM_RUN_CLANG_TIDY_BINARY)
+		message(FATAL_ERROR "STORM_ENABLE_CLANG_TIDY was set, but no run-clang-tidy executable could be found.")
+	endif()
+	set(STORM_CLANG_TIDY_JOBS "${STORM_RESOURCES_BUILD_JOBCOUNT}")
+	# Bake the compiler's implicit include directories into the recorded compile commands. Fixes problems with e.g. Nix.
+	set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+	set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
+	# Runs clang-tidy (as configured in .clang-tidy) over the Storm sources.
+	# USES_TERMINAL and PYTHONUNBUFFERED keep the progress of clang-tidy visible
+	add_custom_target(clang-tidy
+		COMMAND ${CMAKE_COMMAND} -E env PYTHONUNBUFFERED=1
+			${STORM_RUN_CLANG_TIDY_BINARY} -p ${CMAKE_BINARY_DIR} -j ${STORM_CLANG_TIDY_JOBS} -source-filter=${CMAKE_SOURCE_DIR}/src
+		USES_TERMINAL
+		COMMENT "Running clang-tidy over the Storm sources.")
+	# Like clang-tidy, but automatically applies the suggested fixes.
+	add_custom_target(clang-tidy-fix
+		COMMAND ${CMAKE_COMMAND} -E env PYTHONUNBUFFERED=1
+			${STORM_RUN_CLANG_TIDY_BINARY} -p ${CMAKE_BINARY_DIR} -j ${STORM_CLANG_TIDY_JOBS} -source-filter=${CMAKE_SOURCE_DIR}/src -fix
+		USES_TERMINAL
+		COMMENT "Running clang-tidy with automatic fixes over the Storm sources.")
 endif()
 
 set(STORM_TARGETS "")

--- a/resources/cmake/ClangTools.cmake
+++ b/resources/cmake/ClangTools.cmake
@@ -1,0 +1,52 @@
+# Developer-tooling targets for clang-format and clang-tidy.
+# Included from the top-level CMakeLists.txt (only when PROJECT_IS_TOP_LEVEL).
+# The STORM_ENABLE_CLANG_FORMAT / STORM_ENABLE_CLANG_TIDY options are defined there.
+
+if(STORM_ENABLE_CLANG_FORMAT)
+	# Runs clang-format (as configured in .clang-format) over the Storm sources.
+	# Delegates to auto-format.sh, which picks the clang-format version pinned in
+	# resources/scripts/clang-versions and honors .clang-format-ignore.
+	add_custom_target(format
+		COMMAND ${CMAKE_SOURCE_DIR}/resources/scripts/auto-format.sh
+		USES_TERMINAL
+		COMMENT "Running clang-format over the Storm sources.")
+	# Like format, but only checks the sources without modifying them.
+	add_custom_target(format-check
+		COMMAND ${CMAKE_SOURCE_DIR}/resources/scripts/auto-format.sh --check
+		USES_TERMINAL
+		COMMENT "Checking the code formatting.")
+endif()
+
+if(STORM_ENABLE_CLANG_TIDY)
+	# Ensure that a compile_commands.json is generated, since clang-tidy relies on it.
+	set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+	# Bake the compiler's implicit include directories into the recorded compile commands. Fixes problems with e.g. Nix.
+	set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
+	set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES ${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES})
+	# Runs clang-tidy (as configured in .clang-tidy) over the Storm sources.
+	# Delegates to clang-tidy.sh, which picks the run-clang-tidy version pinned in
+	# resources/scripts/clang-versions. USES_TERMINAL keeps the progress of clang-tidy visible.
+	add_custom_target(clang-tidy
+		COMMAND ${CMAKE_SOURCE_DIR}/resources/scripts/clang-tidy.sh -p ${CMAKE_BINARY_DIR} -j ${STORM_RESOURCES_BUILD_JOBCOUNT}
+			-source-filter ${CMAKE_SOURCE_DIR}/src --source-dir ${CMAKE_SOURCE_DIR}
+		USES_TERMINAL
+		COMMENT "Running clang-tidy over the Storm sources.")
+	# Like clang-tidy, but automatically applies the suggested fixes.
+	add_custom_target(clang-tidy-fix
+		COMMAND ${CMAKE_SOURCE_DIR}/resources/scripts/clang-tidy.sh -p ${CMAKE_BINARY_DIR} -j ${STORM_RESOURCES_BUILD_JOBCOUNT}
+			-source-filter ${CMAKE_SOURCE_DIR}/src --source-dir ${CMAKE_SOURCE_DIR} --fix
+		USES_TERMINAL
+		COMMENT "Running clang-tidy with automatic fixes over the Storm sources.")
+	# Like clang-tidy, but only checks the files changed in git (staged, unstaged and untracked).
+	add_custom_target(clang-tidy-changed
+		COMMAND ${CMAKE_SOURCE_DIR}/resources/scripts/clang-tidy.sh -p ${CMAKE_BINARY_DIR} -j ${STORM_RESOURCES_BUILD_JOBCOUNT}
+			-source-filter ${CMAKE_SOURCE_DIR}/src --source-dir ${CMAKE_SOURCE_DIR} --git-ref=HEAD
+		USES_TERMINAL
+		COMMENT "Running clang-tidy over the files changed in git.")
+	# Like clang-tidy-changed, but automatically applies the suggested fixes.
+	add_custom_target(clang-tidy-changed-fix
+		COMMAND ${CMAKE_SOURCE_DIR}/resources/scripts/clang-tidy.sh -p ${CMAKE_BINARY_DIR} -j ${STORM_RESOURCES_BUILD_JOBCOUNT}
+			-source-filter ${CMAKE_SOURCE_DIR}/src --source-dir ${CMAKE_SOURCE_DIR} --git-ref=HEAD --fix
+		USES_TERMINAL
+		COMMENT "Running clang-tidy with automatic fixes over the files changed in git.")
+endif()

--- a/resources/scripts/auto-format.sh
+++ b/resources/scripts/auto-format.sh
@@ -1,17 +1,45 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Settings
 auto_format_file_extensions=( .h .cpp )
 auto_format_src_dir=./src
-# Workflow file that pins the clang-format version CI actually checks against.
-auto_format_ci_workflow=.github/workflows/formatcheck.yml
+# File that pins the clang-format version
+auto_format_version_file=resources/scripts/clang-versions
+
+# Command-line flags
+auto_format_check_only=0
+case "${1:-}" in
+	--check)
+		auto_format_check_only=1
+		;;
+	--help|-h)
+		echo "Usage: auto-format.sh [--check]"
+		echo ""
+		echo "Formats (or with --check, only verifies) all source files under src/ using clang-format."
+		echo ""
+		echo "Options:"
+		echo "  --check     Do not modify any files; exit with a non-zero status if any file would be"
+		echo "              reformatted (uses clang-format's --dry-run -Werror)."
+		echo "  -h, --help  Show this help and exit."
+		exit 0
+		;;
+	"")
+		;;
+	*)
+		echo "ERROR: Unknown option '$1'."
+		echo "Usage: auto-format.sh [--check]"
+		exit 1
+		;;
+esac
 
 # Set-up directories
 script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 storm_root="$script_dir/../.."
 
 # Sanity checks
-for expected_file in .clang-format .clang-format-ignore $auto_format_ci_workflow
+for expected_file in .clang-format .clang-format-ignore $auto_format_version_file
 do
 	if [ ! -f $storm_root/$expected_file ]; then
     	echo "ERROR: There does not seem to be a file '$storm_root/$expected_file'. Have you moved this script?"
@@ -22,17 +50,18 @@ done
 # go to correct directory
 cd $storm_root
 
-# Determine which clang-format version CI actually checks against, so we can try to match it.
+# Determine which clang-format version should be used.
 # Different clang-format versions can format identical input differently, which is a common
 # source of "it's formatted locally but CI still complains" confusion.
-required_clang_format_version=$(grep -m1 'clangFormatVersion:' "$auto_format_ci_workflow" | grep -o '[0-9]\+')
+source "$storm_root/$auto_format_version_file"
+required_clang_format_version=${CLANG_FORMAT_VERSION:-}
 if [ -z "$required_clang_format_version" ]; then
-	echo "WARNING: Could not determine the clang-format version pinned by CI from '$auto_format_ci_workflow'."
+	echo "WARNING: Could not determine the clang-format version from '$auto_format_version_file'."
 	echo "         Falling back to whatever 'clang-format' resolves to on PATH."
 fi
 
 # Allow an explicit override, e.g. CLANG_FORMAT_BIN=/opt/homebrew/opt/llvm@20/bin/clang-format
-clang_format_bin="$CLANG_FORMAT_BIN"
+clang_format_bin="${CLANG_FORMAT_BIN:-}"
 
 # Otherwise, search for a version-matching binary in a few common locations before falling
 # back to a plain, unversioned 'clang-format' on PATH.
@@ -42,7 +71,7 @@ if [ -z "$clang_format_bin" ] && [ -n "$required_clang_format_version" ]; then
 		clang_format_bin="clang-format-$required_clang_format_version"
 	# 2. Homebrew's keg-only versioned llvm formula (llvm@20), common on macOS.
 	elif command -v brew &> /dev/null; then
-		brew_llvm_prefix=$(brew --prefix "llvm@$required_clang_format_version" 2> /dev/null)
+		brew_llvm_prefix=$(brew --prefix "llvm@$required_clang_format_version" 2> /dev/null || true)
 		if [ -n "$brew_llvm_prefix" ] && [ -x "$brew_llvm_prefix/bin/clang-format" ]; then
 			clang_format_bin="$brew_llvm_prefix/bin/clang-format"
 		fi
@@ -61,9 +90,9 @@ if [ -z "$clang_format_bin" ]; then
 	fi
 	clang_format_bin="clang-format"
 	if [ -n "$required_clang_format_version" ]; then
-		found_version=$("$clang_format_bin" --version | grep -o '[0-9]\+' | head -1)
+		found_version=$("$clang_format_bin" --version | grep -o '[0-9]\+' | head -1 || true)
 		if [ "$found_version" != "$required_clang_format_version" ]; then
-			echo "WARNING: Using 'clang-format' version $found_version, but CI checks formatting with version $required_clang_format_version."
+			echo "WARNING: Using 'clang-format' version $found_version, but expected formatting with version $required_clang_format_version."
 			echo "         Formatting may differ from what CI expects. To match CI exactly, install clang-format $required_clang_format_version"
 			echo "         (e.g. 'brew install llvm@$required_clang_format_version' on macOS) and either put it first on PATH or set"
 			echo "         CLANG_FORMAT_BIN=/path/to/clang-format-$required_clang_format_version."
@@ -96,5 +125,15 @@ auto_format_find_expression+=" -false ) ) -print"
 # disable bash expansion of *
 set -f 
 
-# find files and invoke clang-format with in-place option
-find $auto_format_find_expression | xargs "$clang_format_bin" -i -style=file
+# find files and invoke clang-format
+# (in check mode, do not modify anything, but fail if a file would be reformatted)
+if [ "$auto_format_check_only" = "1" ]; then
+	if find $auto_format_find_expression | xargs "$clang_format_bin" --dry-run -Werror -style=file; then
+		exit 0
+	else
+		echo "Some files are not properly formatted. Run 'auto-format.sh' (or 'make format') to fix them."
+		exit 1
+	fi
+else
+	find $auto_format_find_expression | xargs "$clang_format_bin" -i -style=file
+fi

--- a/resources/scripts/clang-tidy.sh
+++ b/resources/scripts/clang-tidy.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+#
+# Wrapper around run-clang-tidy that optionally restricts the analysis to a set
+# of selected files or to the files changed in git.
+
+set -euo pipefail
+
+die() {
+    echo "clang-tidy.sh: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat <<'EOF'
+Usage: clang-tidy.sh -p <build-dir> [-j <jobs>] [-source-filter <regex>]
+       [--fix] [--run-clang-tidy <binary>] [--source-dir <dir>]
+       [--git-ref <ref>] [<file>...]
+
+Selection:
+  --git-ref <ref>  Only check the files changed relative to <ref>.
+                   <ref>=HEAD checks the staged and unstaged changes plus
+                   untracked files. Any other ref checks the three-dot diff
+                   <ref>...HEAD plus untracked files.
+  <file>...        Only check the given files. Arguments are treated as
+                   literal paths (matched as a substring of the recorded
+                   absolute path), relative to the repository root or absolute.
+  (neither)        Check the whole code base (the default).
+
+Options:
+  -p <build-dir>          Build directory containing compile_commands.json.
+  -j <jobs>               Number of parallel jobs.
+  -source-filter <regex>  Restrict analysis to paths matching <regex>.
+  --fix                   Apply the suggested fixes.
+  --run-clang-tidy <bin>  run-clang-tidy executable (default: the version pinned in
+                          resources/scripts/clang-versions, falling back to PATH).
+                          May also be set via the RUN_CLANG_TIDY_BIN environment variable.
+  --source-dir <dir>      Repository root to resolve git refs and paths against
+                          (default: the current directory).
+  --dry-run               Only print the run-clang-tidy command that would run.
+
+Notes:
+  clang-tidy can only analyze translation units (typically .cpp files).
+  Headers are checked transitively through the TUs that include them, so a
+  selection containing only headers matches no TU.
+EOF
+}
+
+# Run git in the repository root, so that relative paths are consistent and
+# the script works even when invoked from outside the repository (e.g. from a
+# build directory).
+repo_dir=""
+git_() {
+    if [ -n "$repo_dir" ]; then
+        git -C "$repo_dir" "$@"
+    else
+        git "$@"
+    fi
+}
+
+# Escape the characters that are special in the Python regexes used by
+# run-clang-tidy to match file paths.
+escape_regex() {
+    printf '%s' "$1" | sed 's/[.[\*^$()+?{|]/\\&/g'
+}
+
+is_cpp_file() {
+    case "$1" in
+        *.c|*.cc|*.cpp|*.cxx) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_header_file() {
+    case "$1" in
+        *.h|*.hh|*.hpp|*.hxx) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_source_file() {
+    is_cpp_file "$1" || is_header_file "$1"
+}
+
+# Reads newline-separated repository-relative paths from stdin and fills the
+# globals $files (displayable) and $regex (escaped absolute paths, '|'-joined).
+files=()
+regex=""
+has_cpp=0
+has_header=0
+build_file_lists() {
+    local root file escaped
+    root=$(git_ rev-parse --show-toplevel) || die "not inside a git repository"
+    while IFS= read -r file; do
+        [ -z "$file" ] && continue
+        is_source_file "$file" || continue
+        case "$file" in
+            /*) escaped=$(escape_regex "$file") ;;
+            *) escaped=$(escape_regex "$root/$file") ;;
+        esac
+        regex="${regex:+$regex|}${escaped}"
+        files+=("$file")
+        is_cpp_file "$file" && has_cpp=1
+        is_header_file "$file" && has_header=1
+    done
+    return 0
+}
+
+# Prints the repository-relative paths of the files changed relative to $1.
+changed_files() {
+    if [ "$1" = "HEAD" ]; then
+        git_ diff --name-only HEAD
+    else
+        git_ merge-base "$1" HEAD >/dev/null 2>&1 || die "invalid git ref: $1"
+        git_ diff --name-only "$1"...HEAD
+    fi
+    git_ ls-files --others --exclude-standard
+}
+
+build_dir=""
+jobs=""
+source_filter=""
+fix=0
+git_ref=""
+git_ref_mode=0
+run_clang_tidy_bin=""
+dry_run=0
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -p) [ "$#" -ge 2 ] || die "option $1 requires an argument"; build_dir=$2; shift 2 ;;
+        -j) [ "$#" -ge 2 ] || die "option $1 requires an argument"; jobs=$2; shift 2 ;;
+        -source-filter) [ "$#" -ge 2 ] || die "option $1 requires an argument"; source_filter=$2; shift 2 ;;
+        -source-filter=*) source_filter=${1#-source-filter=}; shift ;;
+        --fix) fix=1; shift ;;
+        --git-ref) [ "$#" -ge 2 ] || die "option $1 requires an argument"; git_ref_mode=1; git_ref=${2:-HEAD}; shift 2 ;;
+        --git-ref=*) git_ref_mode=1; git_ref=${1#--git-ref=}; git_ref=${git_ref:-HEAD}; shift ;;
+        --run-clang-tidy) [ "$#" -ge 2 ] || die "option $1 requires an argument"; run_clang_tidy_bin=$2; shift 2 ;;
+        --source-dir) [ "$#" -ge 2 ] || die "option $1 requires an argument"; repo_dir=$2; shift 2 ;;
+        --dry-run) dry_run=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --) shift; break ;;
+        -*) die "unknown option: $1" ;;
+        *) break ;;
+    esac
+done
+
+# Resolve this script's location so that we can find resources/scripts/clang-versions
+# even when the script is invoked from a build directory.
+script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+storm_root="$script_dir/../.."
+clang_tidy_version_file=resources/scripts/clang-versions
+if [ ! -f "$storm_root/$clang_tidy_version_file" ]; then
+    die "could not find '$storm_root/$clang_tidy_version_file'. Have you moved this script?"
+fi
+
+# Determine which run-clang-tidy version should be used.
+# The version is pinned in resources/scripts/clang-versions so that local runs match CI.
+source "$storm_root/$clang_tidy_version_file"
+required_clang_tidy_version=$CLANG_TIDY_VERSION
+if [ -z "$required_clang_tidy_version" ]; then
+    echo "WARNING: Could not determine the clang-tidy version from '$clang_tidy_version_file'."
+    echo "         Falling back to whatever 'run-clang-tidy' resolves to on PATH."
+fi
+
+# Allow an explicit override, e.g. RUN_CLANG_TIDY_BIN=/opt/homebrew/opt/llvm@22/bin/run-clang-tidy
+if [ -z "$run_clang_tidy_bin" ]; then
+    run_clang_tidy_bin="${RUN_CLANG_TIDY_BIN:-}"
+fi
+
+if [ -n "$run_clang_tidy_bin" ] && [ ! -x "$run_clang_tidy_bin" ]; then
+    resolved=$(command -v "$run_clang_tidy_bin" 2>/dev/null || true)
+    if [ -n "$resolved" ]; then
+        run_clang_tidy_bin="$resolved"
+    else
+        die "run-clang-tidy binary not found or not executable: $run_clang_tidy_bin"
+    fi
+fi
+
+# Otherwise, search for a version-matching binary in a few common locations before falling
+# back to a plain, unversioned 'run-clang-tidy' on PATH.
+if [ -z "$run_clang_tidy_bin" ] && [ -n "$required_clang_tidy_version" ]; then
+    # 1. Versioned binary name, as installed by e.g. apt (run-clang-tidy-22) or some package managers.
+    if command -v "run-clang-tidy-$required_clang_tidy_version" &> /dev/null; then
+        run_clang_tidy_bin="run-clang-tidy-$required_clang_tidy_version"
+    # 2. Homebrew's keg-only versioned llvm formula (llvm@22), common on macOS.
+    elif command -v brew &> /dev/null; then
+        brew_llvm_prefix=$(brew --prefix "llvm@$required_clang_tidy_version" 2> /dev/null || true)
+        if [ -n "$brew_llvm_prefix" ] && [ -x "$brew_llvm_prefix/bin/run-clang-tidy" ]; then
+            run_clang_tidy_bin="$brew_llvm_prefix/bin/run-clang-tidy"
+        fi
+    fi
+fi
+
+# Fall back to whatever plain 'run-clang-tidy' is on PATH.
+if [ -z "$run_clang_tidy_bin" ]; then
+    if ! command -v run-clang-tidy &> /dev/null; then
+        die "no run-clang-tidy executable found on PATH (looked for a version-matching one and a plain 'run-clang-tidy'). Is it installed?"
+    fi
+    run_clang_tidy_bin="run-clang-tidy"
+    if [ -n "$required_clang_tidy_version" ]; then
+        echo "WARNING: Using 'run-clang-tidy' from PATH, but expected clang-tidy version $required_clang_tidy_version"
+        echo "         (pinned in resources/scripts/clang-versions). Checks may differ from CI. To match CI exactly,"
+        echo "         install run-clang-tidy $required_clang_tidy_version and put it first on PATH or set"
+        echo "         RUN_CLANG_TIDY_BIN=/path/to/run-clang-tidy-$required_clang_tidy_version."
+    fi
+fi
+
+echo "Using run-clang-tidy executable: $run_clang_tidy_bin"
+
+if [ "$git_ref_mode" -eq 1 ]; then
+    build_file_lists < <(changed_files "$git_ref")
+    if [ "${#files[@]}" -eq 0 ]; then
+        echo "No source files changed relative to $git_ref; nothing to check."
+        exit 0
+    fi
+    echo "Checking ${#files[@]} file(s) changed relative to $git_ref:"
+    printf '  %s\n' "${files[@]}"
+elif [ "$#" -gt 0 ]; then
+    build_file_lists < <(printf '%s\n' "$@")
+    if [ "${#files[@]}" -eq 0 ]; then
+        echo "No source files selected; nothing to check."
+        exit 0
+    fi
+    echo "Checking ${#files[@]} file(s):"
+    printf '  %s\n' "${files[@]}"
+fi
+
+if [ "$has_header" -eq 1 ] && [ "$has_cpp" -eq 0 ]; then
+    echo "Note: the selection contains only headers. clang-tidy checks headers transitively"
+    echo "through the translation units that include them, so nothing will be analyzed."
+    echo "Run the full target (without a file selection) to check them."
+fi
+
+args=()
+[ -n "$build_dir" ] && args+=(-p "$build_dir")
+[ -n "$jobs" ] && args+=(-j "$jobs")
+[ -n "$source_filter" ] && args+=(-source-filter "$source_filter")
+[ "$fix" -eq 1 ] && args+=(-fix)
+
+if [ "$dry_run" -eq 1 ]; then
+    printf 'PYTHONUNBUFFERED=1 %s' "$run_clang_tidy_bin"
+    printf ' %q' "${args[@]}"
+    if [ "${#files[@]}" -gt 0 ]; then
+        printf ' %q' "$regex"
+    fi
+    printf '\n'
+    exit 0
+fi
+
+if [ "${#files[@]}" -gt 0 ]; then
+    PYTHONUNBUFFERED=1 "$run_clang_tidy_bin" "${args[@]}" "$regex"
+else
+    PYTHONUNBUFFERED=1 "$run_clang_tidy_bin" "${args[@]}"
+fi

--- a/resources/scripts/clang-versions
+++ b/resources/scripts/clang-versions
@@ -1,0 +1,7 @@
+# Clang toolchain versions pinned for the whole project.
+# Read by the CI workflows and the local scripts (auto-format.sh, clang-tidy.sh).
+# Do not use inline comments or quoting; values are parsed line-wise.
+# CLANG_FORMAT_VERSION must be supported by DoozyX/clang-format-lint-action
+# CLANG_TIDY_VERSION must be supported by cpp-linter-action
+CLANG_FORMAT_VERSION=20
+CLANG_TIDY_VERSION=22


### PR DESCRIPTION
Linter support via clang-tidy.

Enable with `STORM_ENABLE_CLANG_TIDY` in CMake. Provides the following targets:
- `clang-tidy`: Runs clang-tidy (as configured in .clang-tidy) over the Storm sources.
- `clang-tidy-fix`: Like clang-tidy, but automatically applies the suggested fixes.
- `clang-tidy-changed`: Like clang-tidy, but only checks the files changed in git (staged, unstaged and untracked).
- `clang-tidy-changed-fix`: Like clang-tidy-changed, but automatically applies the suggested fixes.

As first step, I only activated one rule in `.clang-tidy`. Will add separate PRs enabling and fixing more checks.

CI support via [cpp-linter-action](https://cpp-linter.github.io/cpp-linter-action/). This does both linting and format check. The CI only checks the changed code and then uses review comments to indicate changes. An example can be seen [in my fork](https://github.com/volkm/storm/pull/8).
Note that these review comments are currently experimental and might be a bit noisy if too many things need to be changed. There is also the alternative of just a single comment, see [this PR example](https://github.com/volkm/storm/pull/6).

I personally liked the review comments, because they allow to directly apply the suggested changes. I recommend to apply changes in a batch though (tab `Files changed` and then select `Add suggestion to batch`).

The CI provides also a `lint-full.yml` workflow which can be manually triggered. It runs over the whole code base.

Clang-tidy can also be run locally with the script `resources/cmake/clang-tidy.sh`. This is similar to the auto-format scripts and provides several additional options (see help command).

I also slightly revised the auto-format scripts which now provides a check option (Cmake target `format-check`) to only check the formatting.
Both scripts take the clang-format and clang-tidy version from `resources/cmake/clang-versions`. This should ensure consistency between the local versions and the CI.

Note that the CI action for formatting only supports clang-format<=20 whereas the clang-tidy CI supports <=22. In particular, the clang-tidy CI also runs clang-formatting as an integrated check.
If things go smoothly we could remove the formatcheck we currently use and only use lint-check. Or at least we should use consistent versions.

Lastly, I added CMake options `STORM_ENABLE_CLANG_TIDY` and `STORM_ENABLE_CLANG_FORMAT`. The FORMAT option is not really necessary, I mainly added it for symmetry reasons. The TIDY option mainly guards `set(CMAKE_EXPORT_COMPILE_COMMANDS ON)` but this should not have a big impact in my view. So we could think about removing both options and simply always enabling the targets.