### PR TITLE
one approach to skipping a few expensive tests

### DIFF
--- a/src/test/storm/modelchecker/prctl/dtmc/DtmcPrctlModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/prctl/dtmc/DtmcPrctlModelCheckerTest.cpp
@@ -698,7 +698,7 @@ TYPED_TEST(DtmcPrctlModelCheckerTest, Die) {
     });
 }
 
-TYPED_TEST(DtmcPrctlModelCheckerTest, Crowds) {
+STORM_EXPENSIVE_TYPED_TEST(DtmcPrctlModelCheckerTest, Crowds) {
     std::string formulasString = "P=? [F observe0>1]";
     formulasString += "; P=? [F \"observeIGreater1\"]";
     formulasString += "; P=? [F observe1>1]";

--- a/src/test/storm/modelchecker/prctl/mdp/MdpPrctlModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/prctl/mdp/MdpPrctlModelCheckerTest.cpp
@@ -740,7 +740,7 @@ TYPED_TEST(MdpPrctlModelCheckerTest, Dice) {
     });
 }
 
-TYPED_TEST(MdpPrctlModelCheckerTest, AsynchronousLeader) {
+STORM_EXPENSIVE_TYPED_TEST(MdpPrctlModelCheckerTest, AsynchronousLeader) {
     std::string formulasString = "Pmin=? [F \"elected\"]";
     formulasString += "; Pmax=? [F \"elected\"]";
     formulasString += "; Pmin=? [F<=25 \"elected\"]";
@@ -778,7 +778,7 @@ TYPED_TEST(MdpPrctlModelCheckerTest, AsynchronousLeader) {
     });
 }
 
-TYPED_TEST(MdpPrctlModelCheckerTest, consensus) {
+STORM_EXPENSIVE_TYPED_TEST(MdpPrctlModelCheckerTest, consensus) {
     std::string formulasString = "Pmax=? [F \"finished\"]";
     formulasString += "; Pmax=? [F \"all_coins_equal_1\"]";
     formulasString += "; P<0.8 [F \"all_coins_equal_1\"]";

--- a/src/test/storm/modelchecker/reachability/SparseDtmcEliminationModelCheckerTest.cpp
+++ b/src/test/storm/modelchecker/reachability/SparseDtmcEliminationModelCheckerTest.cpp
@@ -107,7 +107,7 @@ TEST(SparseDtmcEliminationModelCheckerTest, Crowds) {
     EXPECT_NEAR(0.96592521978041668, quantitativeResult5[0], storm::settings::getModule<storm::settings::modules::GeneralSettings>().getPrecision());
 }
 
-TEST(SparseDtmcEliminationModelCheckerTest, SynchronousLeader) {
+STORM_EXPENSIVE_TEST(SparseDtmcEliminationModelCheckerTest, SynchronousLeader) {
     std::shared_ptr<storm::models::sparse::Model<double>> abstractModel =
         storm::parser::AutoParser<>::parseModel(STORM_TEST_RESOURCES_DIR "/tra/leader4_8.tra", STORM_TEST_RESOURCES_DIR "/lab/leader4_8.lab", "",
                                                 STORM_TEST_RESOURCES_DIR "/rew/leader4_8.pick.trans.rew");

--- a/src/test/storm_gtest.h
+++ b/src/test/storm_gtest.h
@@ -21,6 +21,15 @@
     EXPECT_THROW(statement, expected_exception);                 \
     storm::test::enableErrorOutput()
 
+// Annotate test cases that are too expensive to run in every CI run (identified via profiling) with STORM_EXPENSIVE_*.
+// These macros expand to gtest's DISABLED_ prefix, so the tests are skipped by default and can be re-enabled at run time
+// without reconfiguring the build, either via --gtest_also_run_disabled_tests or the GTEST_ALSO_RUN_DISABLED_TESTS=1
+// environment variable.
+#define STORM_EXPENSIVE_TEST(test_suite_name, test_name) TEST(test_suite_name, DISABLED_##test_name)
+#define STORM_EXPENSIVE_TEST_F(test_suite_name, test_name) TEST_F(test_suite_name, DISABLED_##test_name)
+#define STORM_EXPENSIVE_TEST_P(test_suite_name, test_name) TEST_P(test_suite_name, DISABLED_##test_name)
+#define STORM_EXPENSIVE_TYPED_TEST(test_suite_name, test_name) TYPED_TEST(test_suite_name, DISABLED_##test_name)
+
 namespace testing {
 namespace internal {
 


### PR DESCRIPTION
Very few tests are causing >80% of the test run time. If we disable them like this, our CI runs much faster.