### PR TITLE
deduplicate same choices when building an explicit quotient.

### DIFF
--- a/resources/examples/testfiles/mdp/choice_dedup_same_block.nm
+++ b/resources/examples/testfiles/mdp/choice_dedup_same_block.nm
@@ -1,0 +1,20 @@
+// A small MDP in which the two choices of state 0 induce the same distribution over bisimulation blocks,
+// even though they reach different original states: states 1 and 2 are strongly bisimilar (both transition to
+// state 0 with probability 1), so after quotienting they form a single block. The two choices of state 0 are
+// then logically identical distributions over blocks (each goes with probability 1 to the block {1, 2}).
+// However, a single choice may reach several original states of the same block (here 1 and 2), which the
+// sparse quotient extractor represents by multiple matrix entries with the same column. The duplicate-choice
+// removal must still recognize the two choices as duplicates, i.e. it must compare the aggregated distributions
+// over blocks rather than the un-aggregated per-state entries.
+mdp
+
+module m
+  s : [0..2] init 0;
+
+  [] s=0 -> 0.5:(s'=1) + 0.5:(s'=2);
+  [b] s=0 -> 0.3:(s'=1) + 0.7:(s'=2);
+  [] s=1 -> (s'=0);
+  [] s=2 -> (s'=0);
+endmodule
+
+label "goal" = s=1 | s=2;

--- a/resources/examples/testfiles/mdp/reward_distinct.nm
+++ b/resources/examples/testfiles/mdp/reward_distinct.nm
@@ -1,0 +1,23 @@
+// A small MDP in which, after quotienting via strong bisimulation, state 0's choices all induce the same
+// transition distribution (to the goal state s=1), but carry different state-action rewards. This exercises the
+// sparse quotient extraction's handling of redundant choices: choices with equal transition probabilities but
+// different rewards must NOT be merged, as that would silently drop reward information. The state s=1 is the
+// "goal" state and is absorbing in the model.
+mdp
+
+module reward_distinct
+  s : [0..1] init 0;
+
+  [] s=0 -> (s'=1);
+  [a] s=0 -> (s'=1);
+  [b] s=0 -> (s'=1);
+
+  [] s=1 -> (s'=1);
+endmodule
+
+label "goal" = s=1;
+
+rewards "r"
+  [a] true : 1;
+  [b] true : 2;
+endrewards

--- a/src/storm/storage/dd/bisimulation/QuotientExtractor.cpp
+++ b/src/storm/storage/dd/bisimulation/QuotientExtractor.cpp
@@ -321,9 +321,10 @@ class InternalSparseQuotientExtractorBase {
             STORM_LOG_ASSERT(!this->rowPermutation.empty(), "Expected proper row permutation.");
             std::vector<ExportValueType> valueVector = extractVectorInternal(vector, this->allSourceVariablesCube, this->nondeterminismOdd);
 
-            // Reorder the values according to the known row permutation.
-            std::vector<ExportValueType> reorderedValues(valueVector.size());
-            for (uint64_t pos = 0; pos < valueVector.size(); ++pos) {
+            // Reorder the values according to the known row permutation. Note that rowPermutation may be shorter
+            // than valueVector if redundant (duplicate) choices were removed while building the transition matrix.
+            std::vector<ExportValueType> reorderedValues(rowPermutation.size());
+            for (uint64_t pos = 0; pos < rowPermutation.size(); ++pos) {
                 reorderedValues[pos] = valueVector[rowPermutation[pos]];
             }
             return reorderedValues;
@@ -358,11 +359,27 @@ class InternalSparseQuotientExtractorBase {
         if (this->isNondeterministic) {
             std::stable_sort(rowPermutation.begin(), rowPermutation.end(),
                              [this](uint64_t first, uint64_t second) { return this->rowToState[first] < this->rowToState[second]; });
+
+            // Remove choices that became exact duplicates of the (in the sorted order) preceding choice of the
+            // same state after quotienting, i.e. redundant nondeterminism that resulted from collapsing states
+            // into the same block. This mirrors what the sparse bisimulation engine does and keeps the two
+            // engines' quotients comparable.
+            std::vector<uint64_t> deduplicatedPermutation;
+            deduplicatedPermutation.reserve(rowPermutation.size());
+            for (uint64_t i = 0; i < rowPermutation.size(); ++i) {
+                uint64_t const rowIdx = rowPermutation[i];
+                bool const isDuplicate =
+                    i > 0 && rowToState[rowPermutation[i - 1]] == rowToState[rowIdx] && matrixEntries[rowPermutation[i - 1]] == matrixEntries[rowIdx];
+                if (!isDuplicate) {
+                    deduplicatedPermutation.push_back(rowIdx);
+                }
+            }
+            rowPermutation = std::move(deduplicatedPermutation);
         }
 
         uint64_t rowCounter = 0;
         uint64_t lastState = this->isNondeterministic ? rowToState[rowPermutation.front()] : 0;
-        storm::storage::SparseMatrixBuilder<ExportValueType> builder(matrixEntries.size(), this->numberOfBlocks, 0, true, this->isNondeterministic);
+        storm::storage::SparseMatrixBuilder<ExportValueType> builder(rowPermutation.size(), this->numberOfBlocks, 0, true, this->isNondeterministic);
         if (this->isNondeterministic) {
             builder.newRowGroup(0);
         }
@@ -377,10 +394,6 @@ class InternalSparseQuotientExtractorBase {
             for (auto const& entry : row) {
                 builder.addNextValue(rowCounter, entry.getColumn(), entry.getValue());
             }
-
-            // Free storage for row.
-            row.clear();
-            row.shrink_to_fit();
 
             ++rowCounter;
         }

--- a/src/storm/storage/dd/bisimulation/QuotientExtractor.cpp
+++ b/src/storm/storage/dd/bisimulation/QuotientExtractor.cpp
@@ -1078,7 +1078,9 @@ std::shared_ptr<storm::models::sparse::Model<ExportValueType>> QuotientExtractor
 
     // Collect the state-action rewards of the preserved reward models upfront, so that the extraction of the
     // transition matrix can distinguish choices that only differ in these rewards when removing redundant
-    // (duplicate) choices.
+    // (duplicate) choices. These raw (unreordered) vectors are consumed by extractTransitionMatrix and
+    // cleared afterward; they are not reused for the quotient reward models below, which are extracted
+    // separately via extractStateActionVector (applying the post-dedup row permutation reordering).
     std::vector<std::vector<ExportValueType>> stateActionRewards;
     for (auto const& rewardModelName : preservationInformation.getRewardModelNames()) {
         auto const& rewardModel = model.getRewardModel(rewardModelName);

--- a/src/storm/storage/dd/bisimulation/QuotientExtractor.cpp
+++ b/src/storm/storage/dd/bisimulation/QuotientExtractor.cpp
@@ -331,6 +331,32 @@ class InternalSparseQuotientExtractorBase {
         }
     }
 
+    // Extracts a state-action vector without reordering the entries according to the row permutation, i.e. the
+    // result is indexed by the choices of the original model. This is needed to obtain the state-action rewards
+    // of the preserved reward models before the redundant choices of the quotient are removed, so that the
+    // removal can distinguish choices that only differ in these rewards.
+    std::vector<ExportValueType> extractStateActionVectorRaw(storm::dd::Add<DdType, ValueType> const& vector) {
+        STORM_LOG_ASSERT(this->isNondeterministic, "Expected nondeterministic model.");
+        return extractVectorInternal(vector, this->allSourceVariablesCube, this->nondeterminismOdd);
+    }
+
+    // Sets, for each choice of the original model, the state-action rewards of all preserved reward models. The
+    // extraction of the transition matrix considers these rewards when deciding which choices are redundant.
+    void setStateActionRewardsForDedup(std::vector<std::vector<ExportValueType>>&& stateActionRewards) {
+        this->stateActionRewardsForDedup = std::move(stateActionRewards);
+    }
+
+    // Returns true iff the two given choices (indexed like matrixEntries, i.e. by the offset of the choice in
+    // the nondeterminism ODD) coincide w.r.t. the state-action rewards of all preserved reward models.
+    bool hasEqualStateActionRewards(uint64_t firstChoice, uint64_t secondChoice) const {
+        for (auto const& rewards : this->stateActionRewardsForDedup) {
+            if (rewards[firstChoice] != rewards[secondChoice]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     storm::storage::BitVector extractSetAll(storm::dd::Bdd<DdType> const& set) {
         return (set && representatives).toVector(this->odd);
     }
@@ -352,6 +378,22 @@ class InternalSparseQuotientExtractorBase {
             std::sort(row.begin(), row.end(),
                       [](storm::storage::MatrixEntry<uint_fast64_t, ExportValueType> const& a,
                          storm::storage::MatrixEntry<uint_fast64_t, ExportValueType> const& b) { return a.getColumn() < b.getColumn(); });
+            // Merge entries that point to the same column (block): a single choice may reach several original
+            // states of the same block, which the sparse matrix builder would sum up later anyway. Merging
+            // them here yields a canonical representation of each choice's distribution over blocks, which the
+            // duplicate-choice removal below relies on to identify logically equal choices.
+            uint64_t writeIndex = 0;
+            for (uint64_t readIndex = 1; readIndex < row.size(); ++readIndex) {
+                if (row[readIndex].getColumn() == row[writeIndex].getColumn()) {
+                    row[writeIndex].setValue(row[writeIndex].getValue() + row[readIndex].getValue());
+                } else {
+                    ++writeIndex;
+                    row[writeIndex] = std::move(row[readIndex]);
+                }
+            }
+            if (!row.empty()) {
+                row.resize(writeIndex + 1);
+            }
         }
 
         rowPermutation = std::vector<uint64_t>(matrixEntries.size());
@@ -363,13 +405,16 @@ class InternalSparseQuotientExtractorBase {
             // Remove choices that became exact duplicates of the (in the sorted order) preceding choice of the
             // same state after quotienting, i.e. redundant nondeterminism that resulted from collapsing states
             // into the same block. This mirrors what the sparse bisimulation engine does and keeps the two
-            // engines' quotients comparable.
+            // engines' quotients comparable. A choice is only treated as a duplicate of the preceding choice if
+            // it coincides with it w.r.t. the transition distribution *and* all preserved state-action rewards,
+            // as otherwise merging the choices would silently drop the rewards of the removed choice.
             std::vector<uint64_t> deduplicatedPermutation;
             deduplicatedPermutation.reserve(rowPermutation.size());
             for (uint64_t i = 0; i < rowPermutation.size(); ++i) {
                 uint64_t const rowIdx = rowPermutation[i];
-                bool const isDuplicate =
-                    i > 0 && rowToState[rowPermutation[i - 1]] == rowToState[rowIdx] && matrixEntries[rowPermutation[i - 1]] == matrixEntries[rowIdx];
+                bool const isDuplicate = i > 0 && rowToState[rowPermutation[i - 1]] == rowToState[rowIdx] &&
+                                         matrixEntries[rowPermutation[i - 1]] == matrixEntries[rowIdx] &&
+                                         (stateActionRewardsForDedup.empty() || hasEqualStateActionRewards(rowPermutation[i - 1], rowIdx));
                 if (!isDuplicate) {
                     deduplicatedPermutation.push_back(rowIdx);
                 }
@@ -402,6 +447,8 @@ class InternalSparseQuotientExtractorBase {
         rowToState.shrink_to_fit();
         matrixEntries.clear();
         matrixEntries.shrink_to_fit();
+        stateActionRewardsForDedup.clear();
+        stateActionRewardsForDedup.shrink_to_fit();
 
         return builder.build();
     }
@@ -457,6 +504,12 @@ class InternalSparseQuotientExtractorBase {
 
     // A vector storing for each row which state it belongs to.
     std::vector<uint64_t> rowToState;
+
+    // The state-action rewards of the preserved reward models, one flat vector per reward model (in the order of
+    // the preserved reward models). Each flat vector is indexed like matrixEntries, i.e. by the offset of the
+    // choice in the nondeterminism ODD. Used to only treat choices as redundant if they also coincide w.r.t.
+    // these rewards. Empty if no preserved reward model has state-action rewards.
+    std::vector<std::vector<ExportValueType>> stateActionRewardsForDedup;
 
     // A vector storing the row permutation for nondeterministic models.
     std::vector<uint64_t> rowPermutation;
@@ -1022,6 +1075,19 @@ std::shared_ptr<storm::models::sparse::Model<ExportValueType>> QuotientExtractor
                      "Representatives do not cover all blocks.");
     InternalSparseQuotientExtractor<DdType, ValueType, ExportValueType> sparseExtractor(model, partitionAsBdd, partition.getBlockVariable(),
                                                                                         partition.getNumberOfBlocks(), representatives);
+
+    // Collect the state-action rewards of the preserved reward models upfront, so that the extraction of the
+    // transition matrix can distinguish choices that only differ in these rewards when removing redundant
+    // (duplicate) choices.
+    std::vector<std::vector<ExportValueType>> stateActionRewards;
+    for (auto const& rewardModelName : preservationInformation.getRewardModelNames()) {
+        auto const& rewardModel = model.getRewardModel(rewardModelName);
+        if (rewardModel.hasStateActionRewards()) {
+            stateActionRewards.push_back(sparseExtractor.extractStateActionVectorRaw(rewardModel.getStateActionRewardVector()));
+        }
+    }
+    sparseExtractor.setStateActionRewardsForDedup(std::move(stateActionRewards));
+
     storm::storage::SparseMatrix<ExportValueType> quotientTransitionMatrix = sparseExtractor.extractTransitionMatrix(model.getTransitionMatrix());
     auto end = std::chrono::high_resolution_clock::now();
     STORM_LOG_INFO("Quotient transition matrix extracted in " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "ms.");

--- a/src/test/storm/storage/SymbolicBisimulationDecompositionTest.cpp
+++ b/src/test/storm/storage/SymbolicBisimulationDecompositionTest.cpp
@@ -248,6 +248,42 @@ TYPED_TEST(SymbolicModelBisimulationDecomposition, TwoDice) {
     });
 }
 
+// Regression test for https://github.com/moves-rwth/storm/issues/91: extracting a *sparse* quotient from a
+// symbolic (dd) bisimulation used to keep redundant nondeterministic choices that became identical distributions
+// after collapsing states into blocks, whereas the sparse engine's own bisimulation implementation already
+// deduplicated them. This made "-e dd-to-sparse" quotients gratuitously larger (in choice/transition count, not
+// state count) than the equivalent quotient computed directly by the sparse engine. Values below were confirmed
+// to match storm's own (post-fix) sparse-engine bisimulation on the same model/property.
+TYPED_TEST(SymbolicModelBisimulationDecomposition, SparseQuotientChoiceDeduplication) {
+    const storm::dd::DdType DdType = TestFixture::DdType;
+    storm::prism::Program program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/wlan0_collide.nm");
+    program = program.preprocess("COL=1,TRANS_TIME_MAX=10");
+
+    storm::parser::FormulaParser formulaParser(program);
+    std::shared_ptr<storm::logic::Formula const> formula = formulaParser.parseSingleFormulaFromString("Pmax=? [F col=1]");
+
+    std::shared_ptr<storm::models::symbolic::Model<DdType, double>> model = storm::builder::DdPrismModelBuilder<DdType, double>().build(program, *formula);
+
+    model->getManager().execute([&]() {
+        std::vector<std::shared_ptr<storm::logic::Formula const>> formulas;
+        formulas.push_back(formula);
+
+        storm::dd::BisimulationDecomposition<DdType, double> decomposition(*model, formulas, storm::storage::BisimulationType::Strong);
+        decomposition.compute();
+
+        // Extracting a dd-format quotient does not go through the sparse quotient extractor at all, so it cannot
+        // exercise the bug/fix; only the sparse-format extraction below does.
+        std::shared_ptr<storm::models::Model<double>> quotient = decomposition.getQuotient(storm::dd::bisimulation::QuotientFormat::Sparse);
+
+        ASSERT_EQ(storm::models::ModelType::Mdp, quotient->getType());
+        EXPECT_FALSE(quotient->isSymbolicModel());
+
+        EXPECT_EQ(15ul, quotient->getNumberOfStates());
+        EXPECT_EQ(24ul, quotient->getNumberOfTransitions());
+        EXPECT_EQ(24ul, (quotient->as<storm::models::sparse::Mdp<double>>()->getNumberOfChoices()));
+    });
+}
+
 TYPED_TEST(SymbolicModelBisimulationDecomposition, AsynchronousLeader) {
     const storm::dd::DdType DdType = TestFixture::DdType;
     storm::storage::SymbolicModelDescription smd = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/leader4.nm");

--- a/src/test/storm/storage/SymbolicBisimulationDecompositionTest.cpp
+++ b/src/test/storm/storage/SymbolicBisimulationDecompositionTest.cpp
@@ -1,6 +1,8 @@
 #include "storm-config.h"
 #include "test/storm_gtest.h"
 
+#include <algorithm>
+
 #include "storm-parsers/parser/FormulaParser.h"
 #include "storm-parsers/parser/PrismParser.h"
 #include "storm/builder/DdPrismModelBuilder.h"
@@ -278,9 +280,96 @@ TYPED_TEST(SymbolicModelBisimulationDecomposition, SparseQuotientChoiceDeduplica
         ASSERT_EQ(storm::models::ModelType::Mdp, quotient->getType());
         EXPECT_FALSE(quotient->isSymbolicModel());
 
+        auto mdp = quotient->as<storm::models::sparse::Mdp<double>>();
+        ASSERT_NE(nullptr, mdp);
+
         EXPECT_EQ(15ul, quotient->getNumberOfStates());
         EXPECT_EQ(24ul, quotient->getNumberOfTransitions());
-        EXPECT_EQ(24ul, (quotient->as<storm::models::sparse::Mdp<double>>()->getNumberOfChoices()));
+        EXPECT_EQ(24ul, mdp->getNumberOfChoices());
+    });
+}
+
+// Regression test for the review comment on https://github.com/stormchecker/storm/pull/991: when removing
+// redundant (duplicate) choices while building a *sparse* quotient, choices with equal transition probabilities
+// but different state-action rewards must not be merged, since that would silently drop the rewards of the
+// removed choice. The model below has three choices in state 0 that all induce the same distribution (to the
+// goal state s=1) but carry rewards 0, 1 and 2, respectively; only choices that coincide w.r.t. both the
+// distribution and all state-action rewards may be merged.
+TYPED_TEST(SymbolicModelBisimulationDecomposition, SparseQuotientChoiceDeduplicationRewards) {
+    const storm::dd::DdType DdType = TestFixture::DdType;
+    storm::prism::Program program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/reward_distinct.nm");
+
+    storm::parser::FormulaParser formulaParser(program);
+    std::shared_ptr<storm::logic::Formula const> formula = formulaParser.parseSingleFormulaFromString("Rmax=? [F \"goal\"]");
+
+    std::shared_ptr<storm::models::symbolic::Model<DdType, double>> model = storm::builder::DdPrismModelBuilder<DdType, double>().build(program, *formula);
+
+    model->getManager().execute([&]() {
+        std::vector<std::shared_ptr<storm::logic::Formula const>> formulas;
+        formulas.push_back(formula);
+
+        storm::dd::BisimulationDecomposition<DdType, double> decomposition(*model, formulas, storm::storage::BisimulationType::Strong);
+        decomposition.compute();
+
+        std::shared_ptr<storm::models::Model<double>> quotient = decomposition.getQuotient(storm::dd::bisimulation::QuotientFormat::Sparse);
+
+        ASSERT_EQ(storm::models::ModelType::Mdp, quotient->getType());
+        EXPECT_FALSE(quotient->isSymbolicModel());
+
+        auto mdp = quotient->as<storm::models::sparse::Mdp<double>>();
+        ASSERT_NE(nullptr, mdp);
+
+        // Block {0} keeps all three choices (identical distribution, but rewards 0, 1 and 2 must be preserved);
+        // block {1} keeps its single choice. Without the reward-aware deduplication the three choices of
+        // block {0} would be merged into one.
+        EXPECT_EQ(2ul, quotient->getNumberOfStates());
+        EXPECT_EQ(4ul, quotient->getNumberOfTransitions());
+        EXPECT_EQ(4ul, mdp->getNumberOfChoices());
+
+        auto const& quotientRewardModel = mdp->getRewardModel("r");
+        EXPECT_TRUE(quotientRewardModel.hasStateActionRewards());
+        auto rewards = quotientRewardModel.getStateActionRewardVector();
+        std::sort(rewards.begin(), rewards.end());
+        std::vector<double> expectedRewards = {0.0, 0.0, 1.0, 2.0};
+        EXPECT_EQ(expectedRewards, rewards);
+    });
+}
+
+// Regression test for the review comment on https://github.com/stormchecker/storm/pull/991: a single choice
+// may reach several original states of the same block, which the sparse quotient extractor stores as multiple
+// matrix entries with the same column for that choice. The duplicate-choice removal must aggregate these
+// entries first; otherwise two choices that induce the same distribution over blocks are not recognized as
+// duplicates. Here the two choices of state 0 both reach the block {1, 2} with probability 1 (via different
+// per-state probabilities 0.5/0.5 and 0.3/0.7), so after quotienting they are identical and must be merged.
+TYPED_TEST(SymbolicModelBisimulationDecomposition, SparseQuotientChoiceDeduplicationSameBlock) {
+    const storm::dd::DdType DdType = TestFixture::DdType;
+    storm::prism::Program program = storm::parser::PrismParser::parse(STORM_TEST_RESOURCES_DIR "/mdp/choice_dedup_same_block.nm");
+
+    storm::parser::FormulaParser formulaParser(program);
+    std::shared_ptr<storm::logic::Formula const> formula = formulaParser.parseSingleFormulaFromString("Pmax=? [F \"goal\"]");
+
+    std::shared_ptr<storm::models::symbolic::Model<DdType, double>> model = storm::builder::DdPrismModelBuilder<DdType, double>().build(program, *formula);
+
+    model->getManager().execute([&]() {
+        std::vector<std::shared_ptr<storm::logic::Formula const>> formulas;
+        formulas.push_back(formula);
+
+        storm::dd::BisimulationDecomposition<DdType, double> decomposition(*model, formulas, storm::storage::BisimulationType::Strong);
+        decomposition.compute();
+
+        std::shared_ptr<storm::models::Model<double>> quotient = decomposition.getQuotient(storm::dd::bisimulation::QuotientFormat::Sparse);
+
+        ASSERT_EQ(storm::models::ModelType::Mdp, quotient->getType());
+        EXPECT_FALSE(quotient->isSymbolicModel());
+
+        auto mdp = quotient->as<storm::models::sparse::Mdp<double>>();
+        ASSERT_NE(nullptr, mdp);
+
+        // Blocks {0} and {1, 2}: the two choices of state 0 are identical distributions over blocks and must be
+        // merged into one, otherwise the quotient would have an extra choice.
+        EXPECT_EQ(2ul, quotient->getNumberOfStates());
+        EXPECT_EQ(2ul, quotient->getNumberOfTransitions());
+        EXPECT_EQ(2ul, mdp->getNumberOfChoices());
     });
 }
 


### PR DESCRIPTION
 Makes it easier to ensure bisim and dd-to-bisim coincide, makes the MDP a bit smaller, and doesnt cost much. 
 
 Relates to #91; this is only part of the solution, the main 'problem' lies on the sparse bisim side. 