### PR TITLE
Enabled LOG_OUTPUT_ON_FAILURE for 3rdparty libraries

### DIFF
--- a/resources/3rdparty/CMakeLists.txt
+++ b/resources/3rdparty/CMakeLists.txt
@@ -25,8 +25,9 @@ ExternalProject_Add(
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
         INSTALL_COMMAND ""
-        LOG_INSTALL ON
         LOG_DOWNLOAD ON
+        LOG_INSTALL ON
+        LOG_OUTPUT_ON_FAILURE ON
 )
 add_library(l3pp INTERFACE) # Not imported, we are in control of the sources.
 add_dependencies(l3pp l3pp_ext)
@@ -69,7 +70,7 @@ if(NOT STORM_DISABLE_LIBARCHIVE)
     else()
         SET(STORM_HAVE_LIBARCHIVE OFF)
         message (STATUS "Storm - LibArchive not found. Loading and exporting UMB models and compressed files will not be supported.")
-	endif()
+    endif()
 else()
     SET(STORM_HAVE_LIBARCHIVE OFF)
     message (STATUS "Storm - Not linking with LibArchive. Loading and exporting UMB models and compressed files will not be supported.")
@@ -95,8 +96,9 @@ if(NOT STORM_DISABLE_GMM)
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""
             INSTALL_COMMAND ""
-            LOG_INSTALL ON
             LOG_DOWNLOAD ON
+            LOG_INSTALL ON
+            LOG_OUTPUT_ON_FAILURE ON
     )
     add_library(gmm INTERFACE) # Not imported, we are in control of the sources.
     add_dependencies(gmm gmm_src)
@@ -138,6 +140,7 @@ ExternalProject_Add(
         INSTALL_COMMAND ""
         LOG_DOWNLOAD ON
         LOG_INSTALL ON
+        LOG_OUTPUT_ON_FAILURE ON
 )
 add_library(eigenstorm INTERFACE) # Not imported, we are in control of the sources.
 add_dependencies(eigenstorm eigen_src)
@@ -186,6 +189,7 @@ if(${Boost_VERSION} VERSION_LESS "1.75.0") # Debian 12 ships with Boost 1.74.0
             INSTALL_COMMAND ""
             LOG_DOWNLOAD ON
             LOG_INSTALL ON
+            LOG_OUTPUT_ON_FAILURE ON
     )
     add_library(boost_pfr INTERFACE) # Not imported, we are in control of the sources.
     add_dependencies(boost_pfr boost_pfr_src)
@@ -520,7 +524,9 @@ if(STORM_LOAD_QVBS)
             CONFIGURE_COMMAND ""
             BUILD_COMMAND ""
             INSTALL_COMMAND ""
+            LOG_DOWNLOAD ON
             LOG_INSTALL ON
+            LOG_OUTPUT_ON_FAILURE ON
     )
     add_dependencies(storm_resources download_qvbs)
     set(STORM_HAVE_QVBS ON)

--- a/resources/3rdparty/include_cudd.cmake
+++ b/resources/3rdparty/include_cudd.cmake
@@ -47,8 +47,8 @@ ExternalProject_Add(
         LOG_CONFIGURE ON
         LOG_BUILD ON
         LOG_INSTALL ON
-        BUILD_BYPRODUCTS ${CUDD_LIB_DIR}/libcudd${STATIC_EXT}
         LOG_OUTPUT_ON_FAILURE ON
+        BUILD_BYPRODUCTS ${CUDD_LIB_DIR}/libcudd${STATIC_EXT}
 )
 
 # Do not use system CUDD, Storm has a modified version


### PR DESCRIPTION
Should provide more information into build failures.