### PR TITLE
fix for absorbing states in state elim

### DIFF
--- a/src/storm/solver/EliminationLinearEquationSolver.cpp
+++ b/src/storm/solver/EliminationLinearEquationSolver.cpp
@@ -49,9 +49,10 @@ void EliminationLinearEquationSolver<ValueType>::setMatrix(storm::storage::Spars
 template<typename ValueType>
 bool EliminationLinearEquationSolver<ValueType>::internalSolveEquations(Environment const& env, std::vector<ValueType>& x,
                                                                         std::vector<ValueType> const& b) const {
-    // FIXME: This solver will not work for all input systems. More concretely, the current implementation will
-    // not work for systems that have a 1 on the diagonal. This is not a restriction of this technique in general
-    // but arbitrary matrices require pivoting, which is not currently implemented.
+    // This solver computes the least fixed point of systems of the form x = A*x + b. Systems that have a one on
+    // the diagonal (i.e., absorbing states) are handled by the state eliminator: the value of an absorbing state
+    // is zero. However, arbitrary matrices that are not such fixed-point systems would require pivoting, which is
+    // not currently implemented.
 
     STORM_LOG_INFO("Solving linear equation system (" << x.size() << " rows) with elimination");
 

--- a/src/storm/solver/stateelimination/EliminatorBase.cpp
+++ b/src/storm/solver/stateelimination/EliminatorBase.cpp
@@ -51,10 +51,16 @@ void EliminatorBase<ValueType, Mode>::eliminate(uint64_t row, uint64_t column, b
         columnValue = storm::utility::one<ValueType>() / columnValue;
     } else if (Mode == ScalingMode::DivideOneMinus) {
         if (hasEntryInColumn) {
-            STORM_LOG_ASSERT(columnValue != storm::utility::one<ValueType>(),
-                             "The scaling mode 'divide-one-minus' requires a non-one value in the given column.");
-            columnValue = storm::utility::one<ValueType>() / (storm::utility::one<ValueType>() - columnValue);
-            columnValue = storm::utility::simplify(columnValue);
+            if (storm::utility::isOne(columnValue)) {
+                // The state is absorbing, i.e., it has a self-loop with probability one. In this case, the
+                // solution for this state is zero (least fixed point), and it does not contribute anything to
+                // its predecessors. Record this by setting the scaling factor to zero.
+                STORM_LOG_TRACE("State is absorbing, its value will be zero.");
+                columnValue = storm::utility::zero<ValueType>();
+            } else {
+                columnValue = storm::utility::one<ValueType>() / (storm::utility::one<ValueType>() - columnValue);
+                columnValue = storm::utility::simplify(columnValue);
+            }
         }
     }
 
@@ -280,10 +286,15 @@ void EliminatorBase<ValueType, Mode>::eliminateLoop(uint64_t state) {
         columnValue = storm::utility::one<ValueType>() / columnValue;
     } else if (Mode == ScalingMode::DivideOneMinus) {
         if (hasEntryInColumn) {
-            STORM_LOG_ASSERT(columnValue != storm::utility::one<ValueType>(),
-                             "The scaling mode 'divide-one-minus' requires a non-one value in the given column.");
-            columnValue = storm::utility::one<ValueType>() / (storm::utility::one<ValueType>() - columnValue);
-            columnValue = storm::utility::simplify(columnValue);
+            if (storm::utility::isOne(columnValue)) {
+                // The state is absorbing, i.e., it has a self-loop with probability one. Its value is zero
+                // (least fixed point) and it does not contribute anything to its predecessors.
+                STORM_LOG_TRACE("State is absorbing, its value will be zero.");
+                columnValue = storm::utility::zero<ValueType>();
+            } else {
+                columnValue = storm::utility::one<ValueType>() / (storm::utility::one<ValueType>() - columnValue);
+                columnValue = storm::utility::simplify(columnValue);
+            }
         }
     }
 

--- a/src/test/storm/solver/LinearEquationSolverTest.cpp
+++ b/src/test/storm/solver/LinearEquationSolverTest.cpp
@@ -5,7 +5,9 @@
 #include "storm/environment/solver/GmmxxSolverEnvironment.h"
 #include "storm/environment/solver/NativeSolverEnvironment.h"
 #include "storm/environment/solver/TopologicalSolverEnvironment.h"
+#include "storm/solver/EliminationLinearEquationSolver.h"
 #include "storm/solver/LinearEquationSolver.h"
+#include "storm/utility/constants.h"
 #include "storm/utility/vector.h"
 
 namespace {
@@ -391,5 +393,53 @@ TYPED_TEST(LinearEquationSolverTest, solveEquationSystem) {
     EXPECT_NEAR(x[0], this->parseNumber("481/9"), this->precision());
     EXPECT_NEAR(x[1], this->parseNumber("457/9"), this->precision());
     EXPECT_NEAR(x[2], this->parseNumber("875/18"), this->precision());
+}
+
+template<typename ValueType>
+void testEliminationWithAbsorbingStates(std::vector<std::vector<std::pair<uint64_t, ValueType>>> const& rows, std::vector<ValueType> const& b,
+                                        std::vector<ValueType> const& expected) {
+    storm::storage::SparseMatrixBuilder<ValueType> builder(rows.size(), rows.size(), 0);
+    for (uint64_t row = 0; row < rows.size(); ++row) {
+        for (auto const& entry : rows[row]) {
+            builder.addNextValue(row, entry.first, entry.second);
+        }
+    }
+    auto matrix = builder.build();
+
+    storm::Environment env;
+    env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Elimination);
+    storm::solver::EliminationLinearEquationSolver<ValueType> solver(matrix);
+    std::vector<ValueType> x(b.size());
+    ASSERT_NO_THROW(solver.solveEquations(env, x, b));
+    ASSERT_EQ(expected.size(), x.size());
+    for (uint64_t i = 0; i < x.size(); ++i) {
+        EXPECT_EQ(expected[i], x[i]);
+    }
+}
+
+TEST(EliminationLinearEquationSolver, AbsorbingState) {
+    // Regression test for issue #86: the elimination-based solver must handle a single absorbing state
+    // (a one on the diagonal), for which the least fixed point is zero.
+    auto zero = storm::utility::zero<storm::RationalNumber>();
+    testEliminationWithAbsorbingStates<storm::RationalNumber>({{{0, storm::utility::one<storm::RationalNumber>()}}}, {zero}, {zero});
+}
+
+TEST(EliminationLinearEquationSolver, AbsorbingTwoCycle) {
+    // Regression test for issue #86: when eliminating one state of a probability-1 cycle, the remaining state
+    // obtains a one on the diagonal (i.e., it becomes absorbing) and must be handled by the eliminator.
+    auto one = storm::utility::one<storm::RationalNumber>();
+    auto zero = storm::utility::zero<storm::RationalNumber>();
+    testEliminationWithAbsorbingStates<storm::RationalNumber>({{{1, one}}, {{0, one}}}, {zero, zero}, {zero, zero});
+
+    // Also check the double instantiation.
+    testEliminationWithAbsorbingStates<double>({{{1, 1.0}}, {{0, 1.0}}}, {0.0, 0.0}, {0.0, 0.0});
+}
+
+TEST(EliminationLinearEquationSolver, AbsorbingSinkReachability) {
+    // A transient state can either reach the target with probability one half or fall into an absorbing sink.
+    auto half = storm::utility::convertNumber<storm::RationalNumber, std::string>("1/2");
+    auto one = storm::utility::one<storm::RationalNumber>();
+    auto zero = storm::utility::zero<storm::RationalNumber>();
+    testEliminationWithAbsorbingStates<storm::RationalNumber>({{{1, half}}, {{2, one}}, {{1, one}}}, {half, zero, zero}, {half, zero, zero});
 }
 }  // namespace


### PR DESCRIPTION
Fixes underlying issue of #86 (which I cannot reproduce from cli, i would say it resolves #86)

Absorbing states should simply get a solution of 0, as we solve for the least fixed point in these problems. This is in line with what we do in other places.  