### PR TITLE
Cleanup for clang-tidy

### DIFF
--- a/src/storm-cli-utilities/model-handling.h
+++ b/src/storm-cli-utilities/model-handling.h
@@ -3,11 +3,11 @@
 #include <boost/algorithm/string/join.hpp>
 #include <type_traits>
 
-#include "storm/api/storm.h"
-
 #include "storm-cli-utilities/AutomaticSettings.h"
 #include "storm-cli-utilities/print.h"
 #include "storm-parsers/api/storm-parsers.h"
+#include "storm/adapters/RationalFunctionAdapter.h"
+#include "storm/api/storm.h"
 #include "storm/builder/BuilderType.h"
 #include "storm/environment/Environment.h"
 #include "storm/exceptions/OptionParserException.h"

--- a/src/storm-counterexamples/counterexamples/SMTMinimalLabelSetGenerator.h
+++ b/src/storm-counterexamples/counterexamples/SMTMinimalLabelSetGenerator.h
@@ -1,11 +1,18 @@
 #pragma once
 
+#include <algorithm>
 #include <chrono>
+#include <iterator>
+#include <memory>
 #include <queue>
+#include <set>
+#include <sstream>
+#include <utility>
 
 #include "storm-counterexamples/counterexamples/GuaranteedLabelSet.h"
 #include "storm-counterexamples/counterexamples/HighLevelCounterexample.h"
 #include "storm/exceptions/InvalidArgumentException.h"
+#include "storm/exceptions/InvalidPropertyException.h"
 #include "storm/exceptions/InvalidStateException.h"
 #include "storm/exceptions/MissingLibraryException.h"
 #include "storm/exceptions/NotSupportedException.h"
@@ -13,6 +20,10 @@
 #include "storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.h"
 #include "storm/modelchecker/propositional/SparsePropositionalModelChecker.h"
 #include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
+#include "storm/models/ModelType.h"
+#include "storm/models/sparse/Dtmc.h"
+#include "storm/models/sparse/Mdp.h"
+#include "storm/models/sparse/Model.h"
 #include "storm/settings/SettingsManager.h"
 #include "storm/settings/modules/CounterexampleGeneratorSettings.h"
 #include "storm/settings/modules/GeneralSettings.h"
@@ -20,7 +31,9 @@
 #include "storm/storage/BoostTypes.h"
 #include "storm/storage/expressions/Expression.h"
 #include "storm/storage/prism/Program.h"
+#include "storm/storage/sparse/JaniChoiceOrigins.h"
 #include "storm/storage/sparse/PrismChoiceOrigins.h"
+#include "storm/utility/graph.h"
 #include "storm/utility/macros.h"
 
 namespace storm {

--- a/src/storm-gamebased-ar/api/verification.h
+++ b/src/storm-gamebased-ar/api/verification.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "storm/environment/Environment.h"
-
 #include "storm-gamebased-ar/modelchecker/abstraction/BisimulationAbstractionRefinementModelChecker.h"
 #include "storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.h"
+#include "storm/environment/Environment.h"
+#include "storm/exceptions/NotSupportedException.h"
+#include "storm/utility/macros.h"
 
 namespace storm::gbar {
 namespace api {

--- a/src/storm-gspn/storage/gspn/TimedTransition.h
+++ b/src/storm-gspn/storage/gspn/TimedTransition.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <cstdint>
+
 #include "storm-gspn/storage/gspn/Transition.h"
 #include "storm/exceptions/InvalidArgumentException.h"
+#include "storm/utility/macros.h"
 
 namespace storm {
 namespace gspn {

--- a/src/storm-pars/utility/parameterlifting.h
+++ b/src/storm-pars/utility/parameterlifting.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <cstdint>
+#include <set>
 #include <vector>
 
 #include "storm-pars/modelchecker/region/RegionCheckEngine.h"
 #include "storm-pars/utility/parametric.h"
 #include "storm/logic/Formula.h"
 #include "storm/logic/FragmentSpecification.h"
+#include "storm/logic/RewardOperatorFormula.h"
 #include "storm/models/sparse/MarkovAutomaton.h"
 #include "storm/models/sparse/Model.h"
 #include "storm/models/sparse/StandardRewardModel.h"

--- a/src/storm-permissive/analysis/PermissiveSchedulerPenalty.h
+++ b/src/storm-permissive/analysis/PermissiveSchedulerPenalty.h
@@ -2,8 +2,10 @@
 
 #include <cstdint>
 #include <unordered_map>
+#include <utility>
 
 #include "storm/storage/StateActionPair.h"
+#include "storm/utility/macros.h"
 
 namespace storm {
 namespace ps {

--- a/src/storm-permissive/analysis/SmtBasedPermissiveSchedulers.h
+++ b/src/storm-permissive/analysis/SmtBasedPermissiveSchedulers.h
@@ -1,6 +1,16 @@
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "storm-permissive/analysis/PermissiveSchedulerComputation.h"
 #include "storm/solver/SmtSolver.h"
+#include "storm/storage/StateActionPair.h"
+#include "storm/storage/StateActionTargetTuple.h"
+#include "storm/utility/macros.h"
 
 namespace storm {
 namespace ps {

--- a/src/storm-pomdp/api/verification.h
+++ b/src/storm-pomdp/api/verification.h
@@ -1,7 +1,16 @@
 #pragma once
 
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
 #include "storm-pomdp/modelchecker/BeliefExplorationPomdpModelChecker.h"
 #include "storm/environment/Environment.h"
+#include "storm/modelchecker/CheckTask.h"
+#include "storm/models/sparse/Model.h"
+#include "storm/models/sparse/Pomdp.h"
+#include "storm/storage/Scheduler.h"
+#include "storm/utility/constants.h"
 
 namespace storm {
 namespace pomdp {

--- a/src/storm/adapters/sylvan.h
+++ b/src/storm/adapters/sylvan.h
@@ -19,7 +19,7 @@
 #pragma GCC diagnostic pop
 
 #define cas(ptr, old, new) (__sync_bool_compare_and_swap((ptr), (old), (new)))
-#define ATOMIC_READ(x) (*(volatile decltype(x) *)&(x))
+#define ATOMIC_READ(x) (*(volatile decltype(x)*)&(x))
 
 namespace storm {
 namespace dd {

--- a/src/storm/adapters/sylvan.h
+++ b/src/storm/adapters/sylvan.h
@@ -7,12 +7,16 @@
 #ifdef STORM_HAVE_SYLVAN
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
-
-#pragma GCC system_header  // Only way to suppress some warnings atm.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wextra-semi-stmt"
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 
 #include "sylvan_obj.hpp"
 #include "sylvan_storm_rational_function.h"
 #include "sylvan_storm_rational_number.h"
+
+#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
 #define cas(ptr, old, new) (__sync_bool_compare_and_swap((ptr), (old), (new)))
 #define ATOMIC_READ(x) (*(volatile decltype(x) *)&(x))
@@ -42,7 +46,5 @@ bool sylvan_mtbdd_matches_variable_index(MTBDD node, uint64_t variableIndex, int
 
 }  // namespace dd
 }  // namespace storm
-
-#pragma GCC diagnostic pop
 
 #endif

--- a/src/storm/automata/HOAHeader.h
+++ b/src/storm/automata/HOAHeader.h
@@ -1,8 +1,12 @@
 #pragma once
 
 #include <boost/optional.hpp>
+#include <string>
+#include <vector>
 #include "cpphoafparser/consumer/hoa_consumer.hh"
+
 #include "storm/automata/APSet.h"
+#include "storm/automata/AcceptanceCondition.h"
 
 namespace storm {
 namespace automata {

--- a/src/storm/modelchecker/prctl/helper/rewardbounded/Dimension.h
+++ b/src/storm/modelchecker/prctl/helper/rewardbounded/Dimension.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <boost/optional.hpp>
+#include <cstdint>
+#include <memory>
+#include <string>
 
+#include "storm/logic/Formula.h"
 #include "storm/solver/OptimizationDirection.h"
 #include "storm/storage/BitVector.h"
 

--- a/src/storm/models/sparse/StateAnnotation.h
+++ b/src/storm/models/sparse/StateAnnotation.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "storm/storage/sparse/StateType.h"
 
 namespace storm {

--- a/src/storm/settings/SettingsManager.h
+++ b/src/storm/settings/SettingsManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <map>

--- a/src/storm/settings/modules/ModuleSettings.h
+++ b/src/storm/settings/modules/ModuleSettings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/storm/storage/dd/bisimulation/InternalSylvanSignatureRefiner.cpp
+++ b/src/storm/storage/dd/bisimulation/InternalSylvanSignatureRefiner.cpp
@@ -8,13 +8,6 @@
 
 #ifdef STORM_HAVE_SYLVAN
 #include "sylvan_cache.h"
-
-#pragma clang diagnostic push
-// The cas macro from storm/adapters/sylvan.h and the direct __sync_fetch_and_add expand to __sync_* builtins
-// -Watomic-implicit-seq-cst fires at these use sites, so suppress it here.
-#pragma clang diagnostic ignored "-Watomic-implicit-seq-cst"
-
-#pragma clang diagnostic ignored "-Wused-but-marked-unused"
 #endif
 
 namespace storm {
@@ -22,6 +15,14 @@ namespace dd {
 namespace bisimulation {
 
 #ifdef STORM_HAVE_SYLVAN
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Watomic-implicit-seq-cst"
+#pragma clang diagnostic ignored "-Wextra-semi-stmt"
+#pragma clang diagnostic ignored "-Wused-but-marked-unused"
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+
 static const uint64_t NO_ELEMENT_MARKER = -1ull;
 
 InternalSylvanSignatureRefinerBase::InternalSylvanSignatureRefinerBase(storm::dd::DdManager<storm::dd::DdType::Sylvan> const& manager,
@@ -126,10 +127,6 @@ static uint64_t sylvan_hash(uint64_t a, uint64_t b) {
  * The code was modified in minor places to account for necessary changes, for example to handle
  * nondeterminism variables.
  */
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-
 VOID_TASK_3(sylvan_rehash, size_t, first, size_t, count, InternalSylvanSignatureRefinerBase*, refiner) {
     if (count > 128) {
         SPAWN(sylvan_rehash, first, count / 2, refiner);
@@ -253,10 +250,7 @@ TASK_3(BDD, sylvan_assign_block, BDD, sig, BDD, previous_block, InternalSylvanSi
     STORM_LOG_ASSERT(previous_block != mtbdd_false, "Incorrect call: previous_block is mtbdd_false.");
 
     // maybe do garbage collection
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wextra-semi-stmt"
     sylvan_gc_test();
-#pragma clang diagnostic pop
 
     if (sig == sylvan_false) {
         // slightly different handling because sylvan_false == 0
@@ -308,10 +302,7 @@ TASK_5(BDD, sylvan_refine_partition, BDD, dd, BDD, previous_partition, BDD, nond
         return result;
     }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wextra-semi-stmt"
     sylvan_gc_test();
-#pragma clang diagnostic pop
 
     /* vars != sylvan_false */
     /* dd cannot be sylvan_true - if vars != sylvan_true, then dd is in a,B */
@@ -377,8 +368,8 @@ TASK_5(BDD, sylvan_refine_partition, BDD, dd, BDD, previous_partition, BDD, nond
     return result;
 }
 
-#pragma GCC diagnostic pop
 #pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
 #else
 InternalSylvanSignatureRefinerBase::InternalSylvanSignatureRefinerBase(storm::dd::DdManager<storm::dd::DdType::Sylvan> const& manager,

--- a/src/storm/storage/dd/sylvan/InternalSylvanDdManager.cpp
+++ b/src/storm/storage/dd/sylvan/InternalSylvanDdManager.cpp
@@ -13,9 +13,12 @@ namespace storm {
 namespace dd {
 
 #ifdef STORM_HAVE_SYLVAN
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc99-extensions"
 #pragma clang diagnostic ignored "-Wused-but-marked-unused"
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #pragma clang diagnostic ignored "-Wzero-length-array"
 
 #ifndef NDEBUG
@@ -37,6 +40,7 @@ VOID_TASK_2(execute_sylvan, std::function<void()> const*, f, std::exception_ptr*
 }
 
 #pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
 uint_fast64_t InternalDdManager<DdType::Sylvan>::numberOfInstances = 0;
 bool InternalDdManager<DdType::Sylvan>::suspended = false;

--- a/src/storm/transformer/Product.h
+++ b/src/storm/transformer/Product.h
@@ -1,6 +1,15 @@
 #pragma once
 
+#include <cstddef>
+#include <map>
 #include <memory>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "storm/storage/BitVector.h"
+#include "storm/storage/sparse/StateType.h"
 
 namespace storm {
 namespace transformer {

--- a/src/storm/transformer/ProductBuilder.h
+++ b/src/storm/transformer/ProductBuilder.h
@@ -1,12 +1,16 @@
 #pragma once
 
+#include <cstddef>
+#include <deque>
+#include <map>
+#include <utility>
+#include <vector>
+
 #include "storm/models/sparse/StateLabeling.h"
 #include "storm/storage/BitVector.h"
 #include "storm/storage/SparseMatrix.h"
-
-#include <deque>
-#include <map>
-#include <vector>
+#include "storm/storage/sparse/StateType.h"
+#include "storm/transformer/Product.h"
 
 namespace storm {
 namespace transformer {

--- a/src/storm/utility/FilteredRewardModel.h
+++ b/src/storm/utility/FilteredRewardModel.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
+#include <utility>
 
 #include "storm/exceptions/NotSupportedException.h"
+#include "storm/logic/RewardAccumulation.h"
 #include "storm/utility/macros.h"
 
 namespace storm {


### PR DESCRIPTION
- explicitly suppress some compiler warnings in Sylvan
- Added some missing includes to make header files self-contained
- Fixed minor formatting issue triggered for clang-format version 22

The includes are needed to fix the clang-tidy issues, which can be seen in [this CI run](https://github.com/stormchecker/storm/actions/runs/31471423273).