### PR TITLE
Fixed bugs revealed by clang-tidy

### DIFF
--- a/src/storm/modelchecker/AbstractModelChecker.cpp
+++ b/src/storm/modelchecker/AbstractModelChecker.cpp
@@ -284,8 +284,6 @@ std::unique_ptr<CheckResult> AbstractModelChecker<ModelType>::checkStateFormula(
         return this->checkAtomicExpressionFormula(env, checkTask.substituteFormula(stateFormula.asAtomicExpressionFormula()));
     } else if (stateFormula.isAtomicLabelFormula()) {
         return this->checkAtomicLabelFormula(env, checkTask.substituteFormula(stateFormula.asAtomicLabelFormula()));
-    } else if (stateFormula.isBooleanLiteralFormula()) {
-        return this->checkBooleanLiteralFormula(env, checkTask.substituteFormula(stateFormula.asBooleanLiteralFormula()));
     } else if (stateFormula.isGameFormula()) {
         return this->checkGameFormula(env, checkTask.substituteFormula(stateFormula.asGameFormula()));
     } else if (stateFormula.isMultiObjectiveFormula()) {

--- a/src/storm/modelchecker/prctl/helper/HybridMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/HybridMdpPrctlHelper.cpp
@@ -300,7 +300,7 @@ std::unique_ptr<CheckResult> HybridMdpPrctlHelper<DdType, ValueType>::computeGlo
     Environment const& env, OptimizationDirection dir, storm::models::symbolic::NondeterministicModel<DdType, ValueType> const& model,
     storm::dd::Add<DdType, ValueType> const& transitionMatrix, storm::dd::Bdd<DdType> const& psiStates, bool qualitative) {
     std::unique_ptr<CheckResult> result =
-        computeUntilProbabilities(env, dir == OptimizationDirection::Minimize ? OptimizationDirection::Maximize : OptimizationDirection::Maximize, model,
+        computeUntilProbabilities(env, dir == OptimizationDirection::Minimize ? OptimizationDirection::Maximize : OptimizationDirection::Minimize, model,
                                   transitionMatrix, model.getReachableStates(), !psiStates && model.getReachableStates(), qualitative);
     result->asQuantitativeCheckResult<ValueType>().oneMinus();
     return result;

--- a/src/storm/settings/ArgumentBase.cpp
+++ b/src/storm/settings/ArgumentBase.cpp
@@ -34,10 +34,10 @@ bool ArgumentBase::convertFromString<bool>(std::string const& s, bool& ok) {
 
     std::string lowerInput = boost::algorithm::to_lower_copy(s);
 
-    if (s.compare(lowerTrueString) == 0 || s.compare(lowerYesString) == 0) {
+    if (lowerInput.compare(lowerTrueString) == 0 || lowerInput.compare(lowerYesString) == 0) {
         ok = true;
         return true;
-    } else if (s.compare(lowerFalseString) == 0 || s.compare(lowerNoString) == 0) {
+    } else if (lowerInput.compare(lowerFalseString) == 0 || lowerInput.compare(lowerNoString) == 0) {
         ok = true;
         return false;
     }

--- a/src/storm/solver/SolverGuarantee.cpp
+++ b/src/storm/solver/SolverGuarantee.cpp
@@ -9,7 +9,7 @@ std::ostream& operator<<(std::ostream& out, SolverGuarantee const& guarantee) {
             out << "greater-or-equal";
             break;
         case SolverGuarantee::LessOrEqual:
-            out << "greater-or-equal";
+            out << "less-or-equal";
             break;
         case SolverGuarantee::None:
             out << "none";

--- a/src/storm/storage/SparseMatrix.cpp
+++ b/src/storm/storage/SparseMatrix.cpp
@@ -2144,7 +2144,8 @@ typename SparseMatrix<ValueType>::const_rows SparseMatrix<ValueType>::getRow(ind
     if (!this->hasTrivialRowGrouping()) {
         return getRow(this->getRowGroupIndices()[rowGroup] + offset);
     } else {
-        return getRow(this->getRowGroupIndices()[rowGroup] + offset);
+        STORM_LOG_ASSERT(offset == 0, "Invalid offset.");
+        return getRow(rowGroup + offset);
     }
 }
 


### PR DESCRIPTION
Please take a second look to check whether they now behave as expected.

The check `stateFormula.isBooleanLiteralFormula` occurred twice.