### PR TITLE
CI: revised deb workflow

### DIFF
--- a/.github/workflows/create_deb.yml
+++ b/.github/workflows/create_deb.yml
@@ -11,6 +11,11 @@ on:
         required: true
         type: string
         default: 'x.y.z'
+      build_type:
+        description: 'Build type (Release, Debug)'
+        required: false
+        type: string
+        default: 'Release'
   # needed to trigger the workflow manually
   workflow_dispatch:
     inputs:
@@ -19,6 +24,11 @@ on:
         required: true
         type: string
         default: 'x.y.z'
+      build_type:
+        description: 'Build type (Release, Debug)'
+        required: false
+        type: string
+        default: 'Release'
 
 env:
   # GitHub runners currently have 4 cores
@@ -32,15 +42,11 @@ jobs:
       fail-fast: false
       matrix:
         distro:
-          - {name: "debian:12",
-             tag: "debian-12",
-             build_type: "Release",
-             artifact: "debian12"
+          - {name: "debian12",
+             tag: "debian-12"
             }
-          - {name: "debian:13",
-             tag: "debian-13",
-             build_type: "Release",
-             artifact: "debian13"
+          - {name: "debian13",
+             tag: "debian-13"
             }
         platform:
           - { name: amd64, runner: "ubuntu-latest" }
@@ -55,9 +61,9 @@ jobs:
         run: |
           docker build -t movesrwth/storm:ci . \
             --build-arg BASE_IMAGE=movesrwth/storm-basesystem:${{ matrix.distro.tag }} \
-            --build-arg build_type="${{ matrix.distro.build_type }}" \
+            --build-arg build_type="${{ inputs.build_type }}" \
             --build-arg carl_tag=master \
-            --build-arg cmake_args="-DSTORM_BUILD_TESTS=OFF -DCPACK_DEBIAN_PACKAGE_VERSION=${{ inputs.version }}-${{ matrix.distro.artifact }}" \
+            --build-arg cmake_args="-DSTORM_BUILD_TESTS=OFF -DCPACK_DEBIAN_PACKAGE_VERSION=${{ inputs.version }}-${{ matrix.distro.name }} -DCPACK_PACKAGE_FILE_NAME=storm-${{ inputs.version }}-${{ matrix.distro.name }}-${{ matrix.platform.name }}" \
             --build-arg no_threads=${NR_JOBS}
             # Sets the debian version for CPack. CMake version remains unchanged because it must be numeric.
             # Omitting arguments developer, disable_*, cln_exact, cln_ratfunc, all_sanitizers
@@ -75,33 +81,33 @@ jobs:
       - name: Upload Debian package artifact
         uses: actions/upload-artifact@v7
         with:
-          name: storm-deb-${{ matrix.distro.artifact }}-${{ matrix.platform.name }}
+          name: storm-deb-${{ matrix.distro.name }}-${{ matrix.platform.name }}
           path: ./package/*.deb
 
 
   test_deb:
-    name: Test Debian package on ${{ matrix.distro.name }}-${{ matrix.platform.name }}
+    name: Test Debian package on ${{ matrix.distro.image }}-${{ matrix.platform.name }}
     needs: build_deb
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:
         distro:
-          - {name: "debian:12",
-             artifact: "debian12",
-            }
-          - {name: "debian:13",
-             artifact: "debian13",
-            }
-          - {name: "ubuntu:24.04",
-             artifact: "debian12",
-            }
-          - {name: "ubuntu:26.04",
-             artifact: "debian13",
-            }
-          - {name: "ubuntu:rolling",
-             artifact: "debian13",
-            }
+           - {image: "debian:12",
+              build_artifact: "debian12"
+             }
+           - {image: "debian:13",
+              build_artifact: "debian13"
+             }
+           - {image: "ubuntu:24.04",
+              build_artifact: "debian12"
+             }
+           - {image: "ubuntu:26.04",
+              build_artifact: "debian13"
+             }
+           - {image: "ubuntu:rolling",
+              build_artifact: "debian13"
+             }
         platform:
           - { name: amd64, runner: "ubuntu-latest" }
           - { name: arm64, runner: "ubuntu-24.04-arm" }
@@ -110,11 +116,11 @@ jobs:
       - name: Download .deb artifact
         uses: actions/download-artifact@v8
         with:
-          name: storm-deb-${{matrix.distro.artifact }}-${{ matrix.platform.name }}
+          name: storm-deb-${{ matrix.distro.build_artifact }}-${{ matrix.platform.name }}
           path: package
       - name: Install package
         run: |
-          docker run -d -it --name ci-test ${{ matrix.distro.name }}
+          docker run -d -it --name ci-test ${{ matrix.distro.image }}
           docker cp package/*.deb ci-test:/opt/
           docker exec ci-test bash -c "
             set -e

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -1,0 +1,37 @@
+name: Get Storm version
+on:
+  workflow_call:
+    outputs:
+      version:
+        description: Version from CMakeLists
+        value: ${{ jobs.get-version.outputs.version }}
+      sha:
+        description: Storm commit SHA
+        value: ${{ jobs.get-version.outputs.sha }}
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      sha: ${{ steps.sha.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          fetch-depth: 1
+          sparse-checkout: CMakeLists.txt
+
+      - id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - id: version
+        run: |
+          VERSION=$(sed -n '/^project(storm$/,/^)/{/^[[:space:]]*VERSION[[:space:]]/s/.*VERSION[[:space:]]*//p}' CMakeLists.txt)
+          BASE=$(echo "$VERSION" | cut -d. -f1-3)
+          if [ -z "$BASE" ]; then
+            echo "Failed to extract version from CMakeLists.txt" >&2
+            exit 1
+          fi
+          echo "version=$BASE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -28,7 +28,7 @@ jobs:
 
       - id: version
         run: |
-          VERSION=$(sed -n '/^project(storm$/,/^)/{/^[[:space:]]*VERSION[[:space:]]/s/.*VERSION[[:space:]]*//p}' CMakeLists.txt)
+          VERSION=$(sed -n '/^project(storm[[:space:]]*$/,/^)/{/^[[:space:]]*VERSION[[:space:]]/s/.*VERSION[[:space:]]*//p}' CMakeLists.txt)
           BASE=$(echo "$VERSION" | cut -d. -f1-3)
           if [ -z "$BASE" ]; then
             echo "Failed to extract version from CMakeLists.txt" >&2


### PR DESCRIPTION
Allow for different build types in the `create-deb` workflow.
Also added a workflow for getting the Storm version. This can be used by workflows in other repos, e.g. storm-apt.