### PR TITLE
Second batch of clang-tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >-
   bugprone-dangling-handle,
   bugprone-infinite-loop,
   bugprone-misplaced-widening-cast,
+  bugprone-reserved-identifier,
   bugprone-signed-char-misuse,
   bugprone-unused-return-value,
   bugprone-use-after-move,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >-
   bugprone-inc-dec-in-conditions,
   bugprone-infinite-loop,
   bugprone-misplaced-widening-cast,
+  bugprone-redundant-expression,
   bugprone-reserved-identifier,
   bugprone-signed-char-misuse,
   bugprone-switch-missing-default-case,
@@ -28,7 +29,6 @@ Checks: >-
 # Candidate checks that are not (yet) enabled:
 # bugprone-branch-clone,
 # bugprone-copy-constructor-init,
-# bugprone-redundant-expression,
 # clang-analyzer-core.*,
 # clang-analyzer-cplusplus.*,
 # clang-analyzer-deadcode.*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,9 @@
 # See https://clang.llvm.org/extra/clang-tidy/ for a list of available checks.
 # Disable everything first, then enable individual checks.
+# - portability-avoid-pragma-once is deliberately disabled since Storm uses #pragma once everywhere.
 Checks: >-
   -*,
+  -portability-avoid-pragma-once,
   bugprone-dangling-handle,
   bugprone-infinite-loop,
   bugprone-misplaced-widening-cast,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >-
   boost-use-to-string,
   bugprone-dangling-handle,
   bugprone-empty-catch,
+  bugprone-inc-dec-in-conditions,
   bugprone-infinite-loop,
   bugprone-misplaced-widening-cast,
   bugprone-reserved-identifier,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: >-
   -*,
   -portability-avoid-pragma-once,
   boost-use-to-string,
+  bugprone-copy-constructor-init,
   bugprone-dangling-handle,
   bugprone-empty-catch,
   bugprone-implicit-widening-of-multiplication-result,
@@ -31,7 +32,6 @@ Checks: >-
   readability-static-accessed-through-instance
 # Candidate checks that are not (yet) enabled:
 # bugprone-branch-clone,
-# bugprone-copy-constructor-init,
 # clang-analyzer-core.*,
 # clang-analyzer-cplusplus.*,
 # clang-analyzer-deadcode.*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >-
   bugprone-misplaced-widening-cast,
   bugprone-reserved-identifier,
   bugprone-signed-char-misuse,
+  bugprone-switch-missing-default-case,
   bugprone-unused-local-non-trivial-variable,
   bugprone-unused-return-value,
   bugprone-use-after-move,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,6 +7,7 @@ Checks: >-
   boost-use-to-string,
   bugprone-dangling-handle,
   bugprone-empty-catch,
+  bugprone-implicit-widening-of-multiplication-result,
   bugprone-inc-dec-in-conditions,
   bugprone-infinite-loop,
   bugprone-misplaced-widening-cast,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: >-
   -portability-avoid-pragma-once,
   boost-use-to-string,
   bugprone-dangling-handle,
+  bugprone-empty-catch,
   bugprone-infinite-loop,
   bugprone-misplaced-widening-cast,
   bugprone-reserved-identifier,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,6 +25,7 @@ Checks: >-
   modernize-use-nullptr,
   readability-braces-around-statements,
   readability-redundant-smartptr-get,
+  readability-redundant-string-cstr,
   readability-static-accessed-through-instance
 # Candidate checks that are not (yet) enabled:
 # bugprone-branch-clone,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >-
   bugprone-misplaced-widening-cast,
   bugprone-reserved-identifier,
   bugprone-signed-char-misuse,
+  bugprone-unused-local-non-trivial-variable,
   bugprone-unused-return-value,
   bugprone-use-after-move,
   bugprone-virtual-near-miss,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,7 @@ Checks: >-
   misc-unused-using-decls,
   modernize-deprecated-headers,
   modernize-make-unique,
+  modernize-use-bool-literals,
   modernize-use-nullptr,
   readability-braces-around-statements,
   readability-redundant-smartptr-get,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,7 @@
 Checks: >-
   -*,
   -portability-avoid-pragma-once,
+  boost-use-to-string,
   bugprone-dangling-handle,
   bugprone-infinite-loop,
   bugprone-misplaced-widening-cast,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >-
   bugprone-inc-dec-in-conditions,
   bugprone-infinite-loop,
   bugprone-misplaced-widening-cast,
+  bugprone-move-forwarding-reference,
   bugprone-redundant-expression,
   bugprone-reserved-identifier,
   bugprone-signed-char-misuse,
@@ -52,7 +53,6 @@ Checks: >-
 # readability-else-after-return,
 # readability-non-const-parameter,
 # readability-redundant-member-init,
-# readability-redundant-string-cstr,
 # readability-simplify-boolean-expr,
 
 # Only report diagnostics in src/ but not third-party or system headers.

--- a/.github/workflows/lint-full.yml
+++ b/.github/workflows/lint-full.yml
@@ -1,6 +1,9 @@
 name: Full lint check
 
 on:
+  schedule:
+    # run weekly
+    - cron: '0 18 * * 0'
   workflow_dispatch:
 
 permissions:

--- a/src/storm-counterexamples/api/counterexamples.cpp
+++ b/src/storm-counterexamples/api/counterexamples.cpp
@@ -64,7 +64,7 @@ std::shared_ptr<storm::counterexamples::Counterexample> computeKShortestPathCoun
         cex.addPath(generator.getPathAsList(k), k);
         probability += generator.getDistance(k);
         // Check if accumulated probability mass is already enough
-        if ((probability > threshold) || (strictBound && probability >= threshold && strictBound)) {
+        if ((probability > threshold) || (strictBound && probability >= threshold)) {
             thresholdExceeded = true;
             break;
         }

--- a/src/storm-dft/parser/DFTJsonParser.cpp
+++ b/src/storm-dft/parser/DFTJsonParser.cpp
@@ -36,7 +36,6 @@ storm::dft::storage::DFT<ValueType> DFTJsonParser<ValueType>::parseJson(Json con
     // Initialize DFT builder and value parser
     storm::dft::builder::DFTBuilder<ValueType> builder;
     storm::parser::ValueParser<ValueType> valueParser;
-    std::string toplevelName = "";
     storm::dft::utility::RelevantEvents relevantEvents;
 
     std::string currentLocation;

--- a/src/storm-dft/storage/SylvanBddManager.h
+++ b/src/storm-dft/storage/SylvanBddManager.h
@@ -177,7 +177,7 @@ class SylvanBddManager {
             bdd.PrintDot(filePointer);
             fclose(filePointer);
             std::ofstream filestream;
-            storm::io::openFile(filename.c_str(), filestream, true);
+            storm::io::openFile(filename, filestream, true);
             filestream << "// Mapping from BDD nodes to DFT BEs as follows: \n";
             for (auto const &[index, name] : indexToName) {
                 filestream << "// " << index << " -> " << name << '\n';

--- a/src/storm-gspn/storage/gspn/GSPN.cpp
+++ b/src/storm-gspn/storage/gspn/GSPN.cpp
@@ -2,8 +2,6 @@
 
 #include <unordered_map>
 
-#include <boost/lexical_cast.hpp>
-
 #include "storm-gspn/storage/gspn/GspnJsonExporter.h"
 #include "storm/exceptions/InvalidArgumentException.h"
 #include "storm/utility/macros.h"
@@ -265,7 +263,7 @@ bool GSPN::testPlaces() const {
         }
 
         if (std::find(idsOfPlaces.begin(), idsOfPlaces.end(), place.getID()) != idsOfPlaces.end()) {
-            STORM_LOG_WARN("duplicates states with the id \"" + boost::lexical_cast<std::string>(place.getID()) + "\"\n");
+            STORM_LOG_WARN("duplicates states with the id \"" + std::to_string(place.getID()) + "\"\n");
             result = false;
         }
 

--- a/src/storm-pars/transformer/RobustParameterLifter.cpp
+++ b/src/storm-pars/transformer/RobustParameterLifter.cpp
@@ -13,6 +13,7 @@
 #include "storm-pars/transformer/BigStep.h"
 #include "storm-pars/utility/parametric.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
+#include "storm/exceptions/InvalidArgumentException.h"
 #include "storm/settings/modules/GeneralSettings.h"
 #include "storm/solver/SmtSolver.h"
 #include "storm/solver/Z3SmtSolver.h"
@@ -279,7 +280,6 @@ RobustParameterLifter<ParametricType, ConstantType>::RobustAbstractValuation::cu
             continue;
         }
         CoefficientType coefficient = term.coeff();
-        STORM_LOG_ASSERT(term.tdeg() < 4, "Transitions are only allowed to have a maximum degree of four.");
         switch (term.tdeg()) {
             case 0:
                 d = coefficient;
@@ -292,6 +292,9 @@ RobustParameterLifter<ParametricType, ConstantType>::RobustAbstractValuation::cu
                 break;
             case 3:
                 a = coefficient;
+                break;
+            default:
+                STORM_LOG_THROW(false, storm::exceptions::InvalidArgumentException, "Transitions are only allowed to have have a maximum degree of four.");
                 break;
         }
     }

--- a/src/storm-permissive/analysis/SmtBasedPermissiveSchedulers.h
+++ b/src/storm-permissive/analysis/SmtBasedPermissiveSchedulers.h
@@ -116,7 +116,6 @@ class SmtPermissiveSchedulerComputation : public PermissiveSchedulerComputation<
             solver.add(mProbVariables[initialStateIndex] <= manager.rational(boundary));
         }
         for (uint_fast64_t s : relevantStates) {
-            std::string stateString = std::to_string(s);
             std::vector<storm::expressions::Expression> expressions;
             // (2)
             for (uint_fast64_t a = 0; a < this->mdp.getNumberOfChoices(s); ++a) {
@@ -133,8 +132,6 @@ class SmtPermissiveSchedulerComputation : public PermissiveSchedulerComputation<
 
             // (3) For the relevant states.
             for (uint_fast64_t a = 0; a < this->mdp.getNumberOfChoices(s); ++a) {
-                std::string sastring(stateString + "_" + std::to_string(a));
-
                 for (auto const& entry : this->mdp.getTransitionMatrix().getRow(this->mdp.getNondeterministicChoiceIndices()[s] + a)) {
                     if (entry.getValue() != 0 && relevantStates.get(entry.getColumn())) {
                         expressions.push_back(manager.rational(entry.getValue()) * mProbVariables[entry.getColumn()]);

--- a/src/storm/adapters/RationalNumberForward.h
+++ b/src/storm/adapters/RationalNumberForward.h
@@ -6,7 +6,7 @@
 // The small gmp.h header is always included.
 #include <gmp.h>
 template<typename U, typename V>
-class __gmp_expr;
+class __gmp_expr;  // NOLINT(bugprone-reserved-identifier)
 #endif
 
 #if defined(STORM_HAVE_CLN)
@@ -22,8 +22,11 @@ typedef cln::cl_RA ClnRationalNumber;
 typedef cln::cl_I ClnIntegerNumber;
 #endif
 #if defined(STORM_HAVE_GMP)
+// Silence clang-tidy warnings. We cannot use the typedefs here, because they are only defined in gmpxx.h
+// NOLINTBEGIN(bugprone-reserved-identifier)
 typedef __gmp_expr<mpq_t, mpq_t> GmpRationalNumber;  // corresponds to mpq_class
 typedef __gmp_expr<mpz_t, mpz_t> GmpIntegerNumber;   // corresponds to mpz_class
+// NOLINTEND(bugprone-reserved-identifier)
 #endif
 
 #if defined(STORM_HAVE_CLN) && defined(STORM_USE_CLN_EA)

--- a/src/storm/modelchecker/helper/infinitehorizon/internal/LraViHelper.cpp
+++ b/src/storm/modelchecker/helper/infinitehorizon/internal/LraViHelper.cpp
@@ -29,7 +29,7 @@ LraViHelper<ValueType, ComponentType, TransitionsType>::LraViHelper(ComponentTyp
     : _transitionMatrix(transitionMatrix),
       _timedStates(timedStates),
       _hasInstantStates(TransitionsType == LraViTransitionsType::DetTsNondetIs || TransitionsType == LraViTransitionsType::DetTsDetIs),
-      _Tsx1IsCurrent(false) {
+      _tsx1IsCurrent(false) {
     setComponent(component);
 
     // Run through the component and collect some data:
@@ -85,7 +85,7 @@ LraViHelper<ValueType, ComponentType, TransitionsType>::LraViHelper(ComponentTyp
                                                                               nondetIs() ? numIsSubModelStates : 0);
         isToTsTransitionsBuilder = storm::storage::SparseMatrixBuilder<ValueType>(numIsSubModelChoices, numTsSubModelStates, 0, true, nondetIs(),
                                                                                   nondetIs() ? numIsSubModelStates : 0);
-        _IsChoiceValues.reserve(numIsSubModelChoices);
+        _isChoiceValues.reserve(numIsSubModelChoices);
     }
     ValueType uniformizationFactor = storm::utility::one<ValueType>() / _uniformizationRate;
     uint64_t currTsRow = 0;
@@ -145,11 +145,11 @@ LraViHelper<ValueType, ComponentType, TransitionsType>::LraViHelper(ComponentTyp
             }
         }
     }
-    _TsTransitions = tsTransitionsBuilder.build();
+    _tsTransitions = tsTransitionsBuilder.build();
     if (_hasInstantStates) {
-        _TsToIsTransitions = tsToIsTransitionsBuilder.build();
-        _IsTransitions = isTransitionsBuilder.build();
-        _IsToTsTransitions = isToTsTransitionsBuilder.build();
+        _tsToIsTransitions = tsToIsTransitionsBuilder.build();
+        _isTransitions = isTransitionsBuilder.build();
+        _isToTsTransitions = isToTsTransitionsBuilder.build();
     }
 }
 
@@ -220,11 +220,11 @@ template<typename ValueType, typename ComponentType, LraViTransitionsType Transi
 void LraViHelper<ValueType, ComponentType, TransitionsType>::initializeNewValues(ValueGetter const& stateValueGetter, ValueGetter const& actionValueGetter,
                                                                                  std::vector<ValueType> const* exitRates) {
     // clear potential old values and reserve enough space for new values
-    _TsChoiceValues.clear();
-    _TsChoiceValues.reserve(_TsTransitions.getRowCount());
+    _tsChoiceValues.clear();
+    _tsChoiceValues.reserve(_tsTransitions.getRowCount());
     if (_hasInstantStates) {
-        _IsChoiceValues.clear();
-        _IsChoiceValues.reserve(_IsTransitions.getRowCount());
+        _isChoiceValues.clear();
+        _isChoiceValues.reserve(_isTransitions.getRowCount());
     }
 
     // Set the new choice-based values
@@ -237,55 +237,55 @@ void LraViHelper<ValueType, ComponentType, TransitionsType>::initializeNewValues
             }
             for (auto const& componentChoice : element.second) {
                 // Compute the values obtained for this choice.
-                _TsChoiceValues.push_back(stateValueGetter(componentState) / _uniformizationRate +
+                _tsChoiceValues.push_back(stateValueGetter(componentState) / _uniformizationRate +
                                           actionValueGetter(componentChoice) * actionRewardScalingFactor);
             }
         } else {
             for (auto const& componentChoice : element.second) {
                 // Compute the values obtained for this choice.
                 // State values do not count here since no time passes in instant states.
-                _IsChoiceValues.push_back(actionValueGetter(componentChoice));
+                _isChoiceValues.push_back(actionValueGetter(componentChoice));
             }
         }
     }
 
     // Set-up new iteration vectors for timed states
-    _Tsx1.assign(_TsTransitions.getRowGroupCount(), storm::utility::zero<ValueType>());
-    _Tsx2 = _Tsx1;
+    _tsx1.assign(_tsTransitions.getRowGroupCount(), storm::utility::zero<ValueType>());
+    _tsx2 = _tsx1;
 
     if (_hasInstantStates) {
         // Set-up vectors for storing intermediate results for instant states.
-        _Isx.resize(_IsTransitions.getRowGroupCount(), storm::utility::zero<ValueType>());
-        _Isb = _IsChoiceValues;
+        _isx.resize(_isTransitions.getRowGroupCount(), storm::utility::zero<ValueType>());
+        _isb = _isChoiceValues;
     }
 }
 
 template<typename ValueType, typename ComponentType, LraViTransitionsType TransitionsType>
 void LraViHelper<ValueType, ComponentType, TransitionsType>::prepareSolversAndMultipliers(const Environment& env,
                                                                                           storm::solver::OptimizationDirection const* dir) {
-    _TsMultiplier = storm::solver::MultiplierFactory<ValueType>().create(env, _TsTransitions);
+    _tsMultiplier = storm::solver::MultiplierFactory<ValueType>().create(env, _tsTransitions);
     if (_hasInstantStates) {
-        if (_IsTransitions.getNonzeroEntryCount() > 0) {
+        if (_isTransitions.getNonzeroEntryCount() > 0) {
             // Set-up a solver for transitions within instant states
-            _IsSolverEnv = std::make_unique<storm::Environment>(env);
+            _isSolverEnv = std::make_unique<storm::Environment>(env);
             if (env.solver().isForceSoundness()) {
                 // To get correct results, the inner equation systems are solved exactly.
                 // TODO investigate how an error would propagate
-                _IsSolverEnv->solver().setForceExact(true);
+                _isSolverEnv->solver().setForceExact(true);
             }
-            bool isAcyclic = !storm::utility::graph::hasCycle(_IsTransitions);
+            bool isAcyclic = !storm::utility::graph::hasCycle(_isTransitions);
             if (isAcyclic) {
                 STORM_LOG_INFO("Instant transitions are acyclic.");
-                _IsSolverEnv->solver().minMax().setMethod(storm::solver::MinMaxMethod::Acyclic);
-                _IsSolverEnv->solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Acyclic);
+                _isSolverEnv->solver().minMax().setMethod(storm::solver::MinMaxMethod::Acyclic);
+                _isSolverEnv->solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Acyclic);
             }
             if (nondetIs()) {
                 storm::solver::GeneralMinMaxLinearEquationSolverFactory<ValueType> factory;
-                _NondetIsSolver = factory.create(*_IsSolverEnv, _IsTransitions);
-                _NondetIsSolver->setHasUniqueSolution(true);   // Assume non-zeno MA
-                _NondetIsSolver->setHasNoEndComponents(true);  // assume non-zeno MA
-                _NondetIsSolver->setCachingEnabled(true);
-                auto req = _NondetIsSolver->getRequirements(*_IsSolverEnv, *dir);
+                _nondetIsSolver = factory.create(*_isSolverEnv, _isTransitions);
+                _nondetIsSolver->setHasUniqueSolution(true);   // Assume non-zeno MA
+                _nondetIsSolver->setHasNoEndComponents(true);  // assume non-zeno MA
+                _nondetIsSolver->setCachingEnabled(true);
+                auto req = _nondetIsSolver->getRequirements(*_isSolverEnv, *dir);
                 req.clearUniqueSolution();
                 if (isAcyclic) {
                     req.clearAcyclic();
@@ -294,24 +294,24 @@ void LraViHelper<ValueType, ComponentType, TransitionsType>::prepareSolversAndMu
                 // Which accumulate a lot of reward. Moreover, the right-hand-side of the equation system changes dynamically.
                 STORM_LOG_THROW(!req.hasEnabledCriticalRequirement(), storm::exceptions::UnmetRequirementException,
                                 "The solver requirement " << req.getEnabledRequirementsAsString() << " has not been cleared.");
-                _NondetIsSolver->setRequirementsChecked(true);
+                _nondetIsSolver->setRequirementsChecked(true);
             } else {
                 storm::solver::GeneralLinearEquationSolverFactory<ValueType> factory;
-                if (factory.getEquationProblemFormat(*_IsSolverEnv) != storm::solver::LinearEquationSolverProblemFormat::FixedPointSystem) {
+                if (factory.getEquationProblemFormat(*_isSolverEnv) != storm::solver::LinearEquationSolverProblemFormat::FixedPointSystem) {
                     // We need to convert the transition matrix connecting instant states
                     // TODO: This could have been done already during construction of the matrix.
                     // Insert diagonal entries.
-                    storm::storage::SparseMatrix<ValueType> converted(_IsTransitions, true);
+                    storm::storage::SparseMatrix<ValueType> converted(_isTransitions, true);
                     // Compute A' = 1-A
                     converted.convertToEquationSystem();
                     STORM_LOG_WARN("The selected equation solver requires to create a temporary " << converted.getDimensionsAsString());
                     // Note that the solver has ownership of the converted matrix.
-                    _DetIsSolver = factory.create(*_IsSolverEnv, std::move(converted));
+                    _detIsSolver = factory.create(*_isSolverEnv, std::move(converted));
                 } else {
-                    _DetIsSolver = factory.create(*_IsSolverEnv, _IsTransitions);
+                    _detIsSolver = factory.create(*_isSolverEnv, _isTransitions);
                 }
-                _DetIsSolver->setCachingEnabled(true);
-                auto req = _DetIsSolver->getRequirements(*_IsSolverEnv);
+                _detIsSolver->setCachingEnabled(true);
+                auto req = _detIsSolver->getRequirements(*_isSolverEnv);
                 if (isAcyclic) {
                     req.clearAcyclic();
                 }
@@ -322,8 +322,8 @@ void LraViHelper<ValueType, ComponentType, TransitionsType>::prepareSolversAndMu
         }
 
         // Set up multipliers for transitions connecting timed and instant states
-        _TsToIsMultiplier = storm::solver::MultiplierFactory<ValueType>().create(env, _TsToIsTransitions);
-        _IsToTsMultiplier = storm::solver::MultiplierFactory<ValueType>().create(env, _IsToTsTransitions);
+        _tsToIsMultiplier = storm::solver::MultiplierFactory<ValueType>().create(env, _tsToIsTransitions);
+        _isToTsMultiplier = storm::solver::MultiplierFactory<ValueType>().create(env, _isToTsTransitions);
     }
 }
 
@@ -356,60 +356,60 @@ void LraViHelper<ValueType, ComponentType, TransitionsType>::performIterationSte
                                                                                   std::vector<uint64_t>* choices) {
     STORM_LOG_ASSERT(!((nondetTs() || nondetIs()) && dir == nullptr), "No optimization direction provided for model with nondeterminism.");
     // Initialize value vectors, multiplers, and solver if this has not been done, yet
-    if (!_TsMultiplier) {
+    if (!_tsMultiplier) {
         prepareSolversAndMultipliers(env, dir);
     }
 
     // Compute new x values for the timed states
     // Flip what is new and what is old
-    _Tsx1IsCurrent = !_Tsx1IsCurrent;
+    _tsx1IsCurrent = !_tsx1IsCurrent;
     // At this point, xOld() points to what has been computed in the most recent call of performIterationStep (initially, this is the 0-vector).
     // The result of this ongoing computation will be stored in xNew()
 
     // Compute the values obtained by a single uniformization step between timed states only
     if (nondetTs()) {
         if (choices == nullptr) {
-            _TsMultiplier->multiplyAndReduce(env, *dir, xOld(), &_TsChoiceValues, xNew());
+            _tsMultiplier->multiplyAndReduce(env, *dir, xOld(), &_tsChoiceValues, xNew());
         } else {
             // Also keep track of the choices made.
-            std::vector<uint64_t> tsChoices(_TsTransitions.getRowGroupCount());
-            _TsMultiplier->multiplyAndReduce(env, *dir, xOld(), &_TsChoiceValues, xNew(), UncertaintyResolutionMode::Unset, &tsChoices);
+            std::vector<uint64_t> tsChoices(_tsTransitions.getRowGroupCount());
+            _tsMultiplier->multiplyAndReduce(env, *dir, xOld(), &_tsChoiceValues, xNew(), UncertaintyResolutionMode::Unset, &tsChoices);
             // Note that nondeterminism within the timed states means that there can not be instant states (We either have MDPs or MAs)
             // Hence, in this branch we don't have to care for choices at instant states.
             STORM_LOG_ASSERT(!_hasInstantStates, "Nondeterministic timed states are only supported if there are no instant states.");
             setInputModelChoices(*choices, tsChoices);
         }
     } else {
-        _TsMultiplier->multiply(env, xOld(), &_TsChoiceValues, xNew());
+        _tsMultiplier->multiply(env, xOld(), &_tsChoiceValues, xNew());
     }
     if (_hasInstantStates) {
         // Add the values obtained by taking a single uniformization step that leads to an instant state followed by arbitrarily many instant steps.
         // First compute the total values when taking arbitrarily many instant transitions (in no time)
-        if (_NondetIsSolver) {
+        if (_nondetIsSolver) {
             // We might need to track the optimal choices.
             if (choices == nullptr) {
-                _NondetIsSolver->solveEquations(*_IsSolverEnv, *dir, _Isx, _Isb);
+                _nondetIsSolver->solveEquations(*_isSolverEnv, *dir, _isx, _isb);
             } else {
-                _NondetIsSolver->setTrackScheduler();
-                _NondetIsSolver->solveEquations(*_IsSolverEnv, *dir, _Isx, _Isb);
-                setInputModelChoices(*choices, _NondetIsSolver->getSchedulerChoices(), true);
+                _nondetIsSolver->setTrackScheduler();
+                _nondetIsSolver->solveEquations(*_isSolverEnv, *dir, _isx, _isb);
+                setInputModelChoices(*choices, _nondetIsSolver->getSchedulerChoices(), true);
             }
-        } else if (_DetIsSolver) {
-            _DetIsSolver->solveEquations(*_IsSolverEnv, _Isx, _Isb);
+        } else if (_detIsSolver) {
+            _detIsSolver->solveEquations(*_isSolverEnv, _isx, _isb);
         } else {
-            STORM_LOG_ASSERT(_IsTransitions.getNonzeroEntryCount() == 0, "If no solver was initialized, an empty matrix would have been expected.");
+            STORM_LOG_ASSERT(_isTransitions.getNonzeroEntryCount() == 0, "If no solver was initialized, an empty matrix would have been expected.");
             if (nondetIs()) {
                 if (choices == nullptr) {
-                    storm::utility::vector::reduceVectorMinOrMax(*dir, _Isb, _Isx, _IsTransitions.getRowGroupIndices());
+                    storm::utility::vector::reduceVectorMinOrMax(*dir, _isb, _isx, _isTransitions.getRowGroupIndices());
                 } else {
-                    std::vector<uint64_t> psChoices(_IsTransitions.getRowGroupCount());
-                    storm::utility::vector::reduceVectorMinOrMax(*dir, _Isb, _Isx, _IsTransitions.getRowGroupIndices(), &psChoices);
+                    std::vector<uint64_t> psChoices(_isTransitions.getRowGroupCount());
+                    storm::utility::vector::reduceVectorMinOrMax(*dir, _isb, _isx, _isTransitions.getRowGroupIndices(), &psChoices);
                     setInputModelChoices(*choices, psChoices, true);
                 }
             } else {
                 // For deterministic instant states, there is nothing to reduce, i.e., we could just set _Isx = _Isb.
                 // For efficiency reasons, we do a swap instead:
-                _Isx.swap(_Isb);
+                _isx.swap(_isb);
                 // Note that at this point we have changed the contents of _Isb, but they will be overwritten anyway.
                 if (choices) {
                     // Set choice 0 to all states.
@@ -418,14 +418,14 @@ void LraViHelper<ValueType, ComponentType, TransitionsType>::performIterationSte
             }
         }
         // Now add the (weighted) values of the instant states to the values of the timed states.
-        _TsToIsMultiplier->multiply(env, _Isx, &xNew(), xNew());
+        _tsToIsMultiplier->multiply(env, _isx, &xNew(), xNew());
     }
 }
 
 template<typename ValueType, typename ComponentType, LraViTransitionsType TransitionsType>
 typename LraViHelper<ValueType, ComponentType, TransitionsType>::ConvergenceCheckResult
 LraViHelper<ValueType, ComponentType, TransitionsType>::checkConvergence(bool relative, ValueType precision) const {
-    STORM_LOG_ASSERT(_TsMultiplier, "Tried to check for convergence without doing an iteration first.");
+    STORM_LOG_ASSERT(_tsMultiplier, "Tried to check for convergence without doing an iteration first.");
     // All values are scaled according to the uniformizationRate.
     // We need to 'revert' this scaling when computing the absolute precision.
     // However, for relative precision, the scaling cancels out.
@@ -475,7 +475,7 @@ void LraViHelper<ValueType, ComponentType, TransitionsType>::prepareNextIteratio
     if (_hasInstantStates) {
         // Update the RHS of the equation system for the instant states by taking the new values of timed states into account.
         STORM_LOG_ASSERT(!nondetTs(), "Nondeterministic timed states not expected when there are also instant states.");
-        _IsToTsMultiplier->multiply(env, xNew(), &_IsChoiceValues, _Isb);
+        _isToTsMultiplier->multiply(env, xNew(), &_isChoiceValues, _isb);
     }
 }
 
@@ -489,22 +489,22 @@ bool LraViHelper<ValueType, ComponentType, TransitionsType>::isTimedState(uint64
 
 template<typename ValueType, typename ComponentType, LraViTransitionsType TransitionsType>
 std::vector<ValueType>& LraViHelper<ValueType, ComponentType, TransitionsType>::xNew() {
-    return _Tsx1IsCurrent ? _Tsx1 : _Tsx2;
+    return _tsx1IsCurrent ? _tsx1 : _tsx2;
 }
 
 template<typename ValueType, typename ComponentType, LraViTransitionsType TransitionsType>
 std::vector<ValueType> const& LraViHelper<ValueType, ComponentType, TransitionsType>::xNew() const {
-    return _Tsx1IsCurrent ? _Tsx1 : _Tsx2;
+    return _tsx1IsCurrent ? _tsx1 : _tsx2;
 }
 
 template<typename ValueType, typename ComponentType, LraViTransitionsType TransitionsType>
 std::vector<ValueType>& LraViHelper<ValueType, ComponentType, TransitionsType>::xOld() {
-    return _Tsx1IsCurrent ? _Tsx2 : _Tsx1;
+    return _tsx1IsCurrent ? _tsx2 : _tsx1;
 }
 
 template<typename ValueType, typename ComponentType, LraViTransitionsType TransitionsType>
 std::vector<ValueType> const& LraViHelper<ValueType, ComponentType, TransitionsType>::xOld() const {
-    return _Tsx1IsCurrent ? _Tsx2 : _Tsx1;
+    return _tsx1IsCurrent ? _tsx2 : _tsx1;
 }
 
 template<typename ValueType, typename ComponentType, LraViTransitionsType TransitionsType>

--- a/src/storm/modelchecker/helper/infinitehorizon/internal/LraViHelper.h
+++ b/src/storm/modelchecker/helper/infinitehorizon/internal/LraViHelper.h
@@ -145,14 +145,14 @@ class LraViHelper {
     storm::storage::BitVector const* _timedStates;  // e.g. Markovian states of a Markov automaton.
     bool _hasInstantStates;
     ValueType _uniformizationRate;
-    storm::storage::SparseMatrix<ValueType> _TsTransitions, _TsToIsTransitions, _IsTransitions, _IsToTsTransitions;
-    std::vector<ValueType> _Tsx1, _Tsx2, _TsChoiceValues;
-    bool _Tsx1IsCurrent;
-    std::vector<ValueType> _Isx, _Isb, _IsChoiceValues;
-    std::unique_ptr<storm::solver::Multiplier<ValueType>> _TsMultiplier, _TsToIsMultiplier, _IsToTsMultiplier;
-    std::unique_ptr<storm::solver::MinMaxLinearEquationSolver<ValueType>> _NondetIsSolver;
-    std::unique_ptr<storm::solver::LinearEquationSolver<ValueType>> _DetIsSolver;
-    std::unique_ptr<storm::Environment> _IsSolverEnv;
+    storm::storage::SparseMatrix<ValueType> _tsTransitions, _tsToIsTransitions, _isTransitions, _isToTsTransitions;
+    std::vector<ValueType> _tsx1, _tsx2, _tsChoiceValues;
+    bool _tsx1IsCurrent;
+    std::vector<ValueType> _isx, _isb, _isChoiceValues;
+    std::unique_ptr<storm::solver::Multiplier<ValueType>> _tsMultiplier, _tsToIsMultiplier, _isToTsMultiplier;
+    std::unique_ptr<storm::solver::MinMaxLinearEquationSolver<ValueType>> _nondetIsSolver;
+    std::unique_ptr<storm::solver::LinearEquationSolver<ValueType>> _detIsSolver;
+    std::unique_ptr<storm::Environment> _isSolverEnv;
 };
 }  // namespace internal
 }  // namespace helper

--- a/src/storm/solver/GmmxxLinearEquationSolver.cpp
+++ b/src/storm/solver/GmmxxLinearEquationSolver.cpp
@@ -116,6 +116,7 @@ bool GmmxxLinearEquationSolver<ValueType>::internalSolveEquations(Environment co
             }
         } catch (storm::exceptions::AbortException const&) {
             // Do nothing
+            STORM_LOG_WARN("Gmm++ (externally) aborted.");
         }
 
         if (!this->isCachingEnabled()) {

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -1209,6 +1209,8 @@ inline __attribute__((always_inline)) uint32_t getblock64(uint64_t const* p, int
     return p[i];
 }
 
+// Murmur3 hash functions.
+// based on https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
 template<>
 uint32_t Murmur3BitVectorHash<uint32_t>::operator()(storm::storage::BitVector const& bv) const {
     uint8_t const* data = reinterpret_cast<uint8_t const*>(bv.buckets);
@@ -1352,6 +1354,10 @@ uint64_t Murmur3BitVectorHash<uint64_t>::operator()(storm::storage::BitVector co
             k1 = rotl64(k1, 31);
             k1 *= c2;
             h1 ^= k1;
+            [[fallthrough]];
+        default:
+            // Intentionally left empty
+            break;
     }
 
     //----------

--- a/src/storm/storage/BitVector.cpp
+++ b/src/storm/storage/BitVector.cpp
@@ -4,6 +4,7 @@
 #include <bit>
 #include <bitset>
 #include <boost/functional/hash.hpp>
+#include <cstddef>
 #include <iostream>
 
 #include "storm/storage/BoostTypes.h"
@@ -1226,7 +1227,7 @@ uint32_t Murmur3BitVectorHash<uint32_t>::operator()(storm::storage::BitVector co
     //----------
     // body
 
-    const uint32_t* blocks = reinterpret_cast<uint32_t const*>(data + nblocks * 4);
+    const uint32_t* blocks = reinterpret_cast<uint32_t const*>(data + static_cast<std::ptrdiff_t>(nblocks) * 4);
 
     for (int i = -nblocks; i; i++) {
         uint32_t k1 = getblock32(blocks, i);
@@ -1293,7 +1294,7 @@ uint64_t Murmur3BitVectorHash<uint64_t>::operator()(storm::storage::BitVector co
     //----------
     // tail
 
-    uint8_t const* tail = reinterpret_cast<uint8_t const*>(data + nblocks * 16);
+    uint8_t const* tail = reinterpret_cast<uint8_t const*>(data + static_cast<std::ptrdiff_t>(nblocks) * 16);
 
     uint64_t k1 = 0;
     uint64_t k2 = 0;

--- a/src/storm/storage/FlexibleSparseMatrix.cpp
+++ b/src/storm/storage/FlexibleSparseMatrix.cpp
@@ -242,7 +242,9 @@ storm::storage::SparseMatrix<ValueType> FlexibleSparseMatrix<ValueType>::createS
         auto rowGroupIndexIt = getRowGroupIndices().begin();
         while (rowGroupIndexIt != lastRowGroupIndexIt) {
             // Check whether the rowGroup will be nonempty
-            if (rowConstraint.getNextSetIndex(*rowGroupIndexIt) < *(++rowGroupIndexIt)) {
+            uint64_t nextSet = rowConstraint.getNextSetIndex(*rowGroupIndexIt);
+            ++rowGroupIndexIt;
+            if (nextSet < *rowGroupIndexIt) {
                 ++numRowGroups;
             }
         }

--- a/src/storm/storage/dd/sylvan/InternalSylvanDdManager.cpp
+++ b/src/storm/storage/dd/sylvan/InternalSylvanDdManager.cpp
@@ -58,9 +58,9 @@ uint_fast64_t findLargestPowerOfTwoFitting(uint_fast64_t number) {
 
 InternalDdManager<DdType::Sylvan>::InternalDdManager(storm::SylvanDdManagerEnvironment const& environment) {
     if (numberOfInstances == 0) {
-        size_t const task_deque_size = 1024 * 1024;
+        size_t const task_deque_size = size_t{1024} * 1024;
 
-        lace_set_stacksize(1024 * 1024 * 16);  // 16 MiB
+        lace_set_stacksize(size_t{1024} * 1024 * 16);  // 16 MiB
 
         lace_start(environment.getNumberOfThreads(), task_deque_size);
 

--- a/src/storm/storage/jani/TemplateEdgeContainer.cpp
+++ b/src/storm/storage/jani/TemplateEdgeContainer.cpp
@@ -3,7 +3,8 @@
 
 namespace storm {
 namespace jani {
-TemplateEdgeContainer::TemplateEdgeContainer(TemplateEdgeContainer const& other) : std::unordered_set<std::shared_ptr<TemplateEdge>>() {
+TemplateEdgeContainer::TemplateEdgeContainer(TemplateEdgeContainer const& other) : std::unordered_set<std::shared_ptr<TemplateEdge>>(other) {
+    this->clear();
     for (auto const& te : other) {
         this->insert(std::make_shared<TemplateEdge>(*te));
     }

--- a/src/storm/storage/umb/import/SparseModelFromUmb.cpp
+++ b/src/storm/storage/umb/import/SparseModelFromUmb.cpp
@@ -343,7 +343,7 @@ storm::models::ModelType deriveModelType(storm::umb::ModelIndex const& index) {
     auto const& ts = index.transitionSystem;
 
     STORM_LOG_THROW(ts.branchProbabilityType.has_value(), storm::exceptions::NotSupportedException, "Models without branch values are not supported.");
-    switch (storm::umb::ModelIndex::TransitionSystem::Time(ts.time)) {
+    switch ((storm::umb::ModelIndex::TransitionSystem::Time)ts.time) {
         using enum storm::umb::ModelIndex::TransitionSystem::Time;
         case Discrete:
             switch (ts.numPlayers) {

--- a/src/storm/storage/umb/import/SparseModelFromUmb.cpp
+++ b/src/storm/storage/umb/import/SparseModelFromUmb.cpp
@@ -3,21 +3,20 @@
 #include <ranges>
 #include <utility>
 
-#include "storm/storage/umb/model/UmbModel.h"
-#include "storm/storage/valuations/ValuationsStorage.h"
-
+#include "storm/exceptions/NotSupportedException.h"
+#include "storm/exceptions/UnexpectedException.h"
+#include "storm/exceptions/WrongFormatException.h"
 #include "storm/models/ModelType.h"
 #include "storm/storage/BitVector.h"
 #include "storm/storage/SparseMatrix.h"
 #include "storm/storage/sparse/ModelComponents.h"
+#include "storm/storage/umb/model/ModelIndex.h"
 #include "storm/storage/umb/model/StringEncoding.h"
+#include "storm/storage/umb/model/UmbModel.h"
 #include "storm/storage/umb/model/ValueEncoding.h"
+#include "storm/storage/valuations/ValuationsStorage.h"
 #include "storm/utility/builder.h"
 #include "storm/utility/macros.h"
-
-#include "storm/exceptions/NotSupportedException.h"
-#include "storm/exceptions/UnexpectedException.h"
-#include "storm/exceptions/WrongFormatException.h"
 
 namespace storm::umb {
 
@@ -344,7 +343,7 @@ storm::models::ModelType deriveModelType(storm::umb::ModelIndex const& index) {
     auto const& ts = index.transitionSystem;
 
     STORM_LOG_THROW(ts.branchProbabilityType.has_value(), storm::exceptions::NotSupportedException, "Models without branch values are not supported.");
-    switch (ts.time) {
+    switch (storm::umb::ModelIndex::TransitionSystem::Time(ts.time)) {
         using enum storm::umb::ModelIndex::TransitionSystem::Time;
         case Discrete:
             switch (ts.numPlayers) {

--- a/src/storm/storage/umb/model/Validation.cpp
+++ b/src/storm/storage/umb/model/Validation.cpp
@@ -47,7 +47,7 @@ bool validateTypeDeclaration(storm::umb::SizedType const& type, bool requireStan
     }
     uint64_t const defaultSize = defaultBitSize(type.type);
     bool sizeError = false;
-    switch (type.type) {
+    switch (storm::umb::Type(type.type)) {
         case Double:
         case DoubleInterval:
         case String:
@@ -67,6 +67,7 @@ bool validateTypeDeclaration(storm::umb::SizedType const& type, bool requireStan
         case RationalInterval:
             // types that occasionally must be their default size
             sizeError = requireStandardSize && ((size % defaultSize) != 0);
+            break;
     }
     if (isIntervalType(type.type)) {
         // interval type sizes must be multiples of four or two
@@ -85,7 +86,7 @@ bool vectorMatchesType(storm::umb::GenericVector const& vector, storm::umb::Size
     }
 
     using enum storm::umb::Type;
-    switch (type.type) {
+    switch (storm::umb::Type(type.type)) {
         case Bool:
             return vector.isType<bool>();
         case Int:

--- a/src/storm/storage/umb/model/Validation.cpp
+++ b/src/storm/storage/umb/model/Validation.cpp
@@ -47,7 +47,7 @@ bool validateTypeDeclaration(storm::umb::SizedType const& type, bool requireStan
     }
     uint64_t const defaultSize = defaultBitSize(type.type);
     bool sizeError = false;
-    switch (storm::umb::Type(type.type)) {
+    switch ((storm::umb::Type)type.type) {
         case Double:
         case DoubleInterval:
         case String:
@@ -86,7 +86,7 @@ bool vectorMatchesType(storm::umb::GenericVector const& vector, storm::umb::Size
     }
 
     using enum storm::umb::Type;
-    switch (storm::umb::Type(type.type)) {
+    switch ((storm::umb::Type)type.type) {
         case Bool:
             return vector.isType<bool>();
         case Int:

--- a/src/storm/storage/valuations/Valuations.cpp
+++ b/src/storm/storage/valuations/Valuations.cpp
@@ -136,7 +136,7 @@ std::optional<storm::RationalNumber> Valuations::getOptionalRationalValue(uint64
     umbValuations->readCallback<std::nullopt_t, storm::RationalNumber>(entity, rationalVariable, [&result](auto, auto const&, auto&& value) {
         using T = std::remove_cvref_t<decltype(value)>;
         if constexpr (std::is_same_v<T, storm::RationalNumber>) {
-            result = std::move(value);
+            result = std::forward<decltype(value)>(value);
         }
     });
     return result;
@@ -154,7 +154,7 @@ std::optional<std::string> Valuations::getOptionalStringValue(uint64_t const ent
     umbValuations->readCallback<std::nullopt_t, std::string>(entity, stringVariable, [&result](auto, auto const&, auto&& value) {
         using T = std::remove_cvref_t<decltype(value)>;
         if constexpr (std::is_same_v<T, std::string>) {
-            result = std::move(value);
+            result = std::forward<decltype(value)>(value);
         }
     });
     return result;

--- a/src/storm/storage/valuations/ValuationsStorage.h
+++ b/src/storm/storage/valuations/ValuationsStorage.h
@@ -543,7 +543,7 @@ class ValuationsStorage {
             using ValueType = std::remove_cvref_t<decltype(value)>;
             bool constexpr IsAllowed = (sizeof...(AllowedTypes) == 0) || std::disjunction_v<std::is_same<ValueType, AllowedTypes>...>;
             if constexpr (IsAllowed) {
-                callback(entity, varInfo.expressionVariable, std::move(value));
+                callback(entity, varInfo.expressionVariable, std::forward<decltype(value)>(value));
             }
             return IsAllowed;
         };

--- a/src/storm/utility/OsDetection.h
+++ b/src/storm/utility/OsDetection.h
@@ -4,7 +4,6 @@
 #define LINUX
 #elif defined TARGET_OS_MAC || defined __apple__ || defined __APPLE__
 #define MACOS
-#define _DARWIN_USE_64_BIT_INODE #This relates to stat / stat64.Unsure if still needed.
 #elif defined _WIN32 || defined _WIN64
 #error Windows detected, but not supported.
 #else

--- a/src/storm/utility/vector.h
+++ b/src/storm/utility/vector.h
@@ -44,7 +44,7 @@ template<class T>
 std::size_t findOrInsert(std::vector<T>& vector, T&& element) {
     std::size_t position = std::find(vector.begin(), vector.end(), element) - vector.begin();
     if (position == vector.size()) {
-        vector.emplace_back(std::move(element));
+        vector.emplace_back(std::forward<T>(element));
     }
     return position;
 }

--- a/src/test/storm/parser/FormulaParserTest.cpp
+++ b/src/test/storm/parser/FormulaParserTest.cpp
@@ -487,7 +487,7 @@ TEST(FormulaParserTest, HOAPathFormulaTest) {
     EXPECT_TRUE(nested1.isHOAPathFormula());
     EXPECT_TRUE(nested1.isPathFormula());
 
-    ASSERT_NO_THROW(std::string af = nested1.asHOAPathFormula().getAutomatonFile());
+    ASSERT_NO_THROW(nested1.asHOAPathFormula().getAutomatonFile());
     storm::automata::DeterministicAutomaton::ptr da1;
     ASSERT_NO_THROW(da1 = nested1.asHOAPathFormula().readAutomaton());
     EXPECT_EQ(3ul, da1->getNumberOfStates());
@@ -503,7 +503,7 @@ TEST(FormulaParserTest, HOAPathFormulaTest) {
     EXPECT_TRUE(nested2.isHOAPathFormula());
     EXPECT_TRUE(nested2.isPathFormula());
 
-    ASSERT_NO_THROW(std::string af = nested2.asHOAPathFormula().getAutomatonFile());
+    ASSERT_NO_THROW(nested2.asHOAPathFormula().getAutomatonFile());
     storm::automata::DeterministicAutomaton::ptr da2;
     ASSERT_NO_THROW(da2 = nested2.asHOAPathFormula().readAutomaton());
     EXPECT_EQ(4ul, da2->getNumberOfStates());

--- a/src/test/storm/storage/BitVectorTest.cpp
+++ b/src/test/storm/storage/BitVectorTest.cpp
@@ -186,7 +186,7 @@ TEST(BitVectorTest, Resize) {
         ASSERT_TRUE(vector.get(i));
     }
 
-    vector.resize(16, 0);
+    vector.resize(16, false);
     ASSERT_EQ(16ul, vector.size());
     ASSERT_EQ(16ul, vector.getNumberOfSetBits());
 
@@ -194,7 +194,7 @@ TEST(BitVectorTest, Resize) {
         ASSERT_TRUE(vector.get(i));
     }
 
-    vector.resize(65, 1);
+    vector.resize(65, true);
     ASSERT_EQ(65ul, vector.size());
     ASSERT_TRUE(vector.full());
 }

--- a/src/test/storm/storage/BitVectorTest.cpp
+++ b/src/test/storm/storage/BitVectorTest.cpp
@@ -285,7 +285,7 @@ TEST(BitVectorTest, OperatorXor) {
 
     storm::storage::BitVector vector3 = vector1 ^ vector2;
     storm::storage::BitVector vector4 = ~vector2;
-    storm::storage::BitVector vector5 = vector1 ^ vector1;
+    storm::storage::BitVector vector5 = vector1 ^ vector1;  // NOLINT(misc-redundant-expression)
 
     for (uint64_t i = 0; i < 32; ++i) {
         ASSERT_EQ(vector3.get(i), vector4.get(i));


### PR DESCRIPTION
Follows: https://github.com/stormchecker/storm/pull/1003
Resolves https://github.com/stormchecker/storm/issues/1007

Adds a weekly CI job to lint-check the full codebase.

Fixed all code related to the following clang-tidy warnings:
- boost-use-to-string
- bugprone-copy-constructor-init
- bugprone-empty-catch
- bugprone-implicit-widening-of-multiplication-result
- bugprone-inc-dec-in-conditions
- bugprone-move-forwarding-reference
- bugprone-redundant-expression
- bugprone-reserved-identifier
- bugprone-switch-missing-default-case
- bugprone-unused-local-non-trivial-variable
- modernize-use-bool-literals
- readability-redundant-string-cstr

Deliberately disabled portability-avoid-pragma-once because we want to use `pragma once`.
