### PR TITLE
Add upper and lowerbounds to check results.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ nbproject/
 .idea
 .vscode
 *.out
+.claude/

--- a/src/storm-counterexamples/api/counterexamples.cpp
+++ b/src/storm-counterexamples/api/counterexamples.cpp
@@ -51,7 +51,7 @@ std::shared_ptr<storm::counterexamples::Counterexample> computeKShortestPathCoun
     storm::storage::BitVector phiStates(model->getNumberOfStates(), true);
     auto results = storm::modelchecker::helper::SparseDtmcPrctlHelper<double>::computeUntilProbabilities(
         env, false, model->getTransitionMatrix(), model->getBackwardTransitions(), phiStates, subQualitativeResult.getTruthValuesVector(), true);
-    double reachProb = results.at(initialState);
+    double reachProb = results.values.at(initialState);
     STORM_LOG_THROW((reachProb > threshold) || (strictBound && reachProb >= threshold), storm::exceptions::InvalidArgumentException,
                     "Given probability threshold " << threshold << " cannot be " << (strictBound ? "achieved" : "exceeded")
                                                    << " in model with maximal reachability probability of " << reachProb << ".");

--- a/src/storm-counterexamples/counterexamples/SMTMinimalLabelSetGenerator.h
+++ b/src/storm-counterexamples/counterexamples/SMTMinimalLabelSetGenerator.h
@@ -1668,8 +1668,9 @@ class SMTMinimalLabelSetGenerator {
         if (model.isOfType(storm::models::ModelType::Dtmc)) {
             if (rewardName == boost::none) {
                 results.push_back(storm::utility::zero<T>());
-                allStatesResult = storm::modelchecker::helper::SparseDtmcPrctlHelper<T>::computeUntilProbabilities(
-                    env, false, model.getTransitionMatrix(), model.getBackwardTransitions(), phiStates, psiStates, false);
+                allStatesResult = std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<T>::computeUntilProbabilities(
+                                                env, false, model.getTransitionMatrix(), model.getBackwardTransitions(), phiStates, psiStates, false)
+                                                .values);
                 for (auto state : model.getInitialStates()) {
                     STORM_LOG_TRACE("Found probability " << allStatesResult[state]);
                     results.back() = std::max(results.back(), allStatesResult[state]);

--- a/src/storm-dft/modelchecker/DFTModelChecker.cpp
+++ b/src/storm-dft/modelchecker/DFTModelChecker.cpp
@@ -471,7 +471,7 @@ std::vector<typename DFTModelChecker<ValueType>::ExtendedValueType> DFTModelChec
 
         if (result) {
             result->filter(storm::modelchecker::ExplicitQualitativeCheckResult<ValueType>(model->getInitialStates()));
-            results.push_back(result->asExplicitQuantitativeCheckResult<ValueType>().getValueMap().begin()->second);
+            results.push_back(result->asExplicitQuantitativeCheckResult<ValueType>().getValueVector().front());
         } else {
             STORM_LOG_WARN("The property '" << *property << "' could not be checked with the current settings.");
             results.push_back(-storm::utility::one<ExtendedValueType>());

--- a/src/storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.cpp
+++ b/src/storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.cpp
@@ -1286,8 +1286,10 @@ void postProcessStrategies(uint64_t iteration, storm::OptimizationDirection cons
             }
         }
         auto dtmcMatrix = dtmcMatrixBuilder.build();
-        std::vector<ValueType> sanityValues = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
-            Environment(), storm::solver::SolveGoal<ValueType>(), dtmcMatrix, dtmcMatrix.transpose(), constraintStates, targetStates, false);
+        std::vector<ValueType> sanityValues =
+            std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
+                          Environment(), storm::solver::SolveGoal<ValueType>(), dtmcMatrix, dtmcMatrix.transpose(), constraintStates, targetStates, false)
+                          .values);
 
         ValueType maxDiff = storm::utility::zero<ValueType>();
         uint64_t maxState = 0;
@@ -1324,8 +1326,10 @@ void postProcessStrategies(uint64_t iteration, storm::OptimizationDirection cons
             }
         }
         dtmcMatrix = dtmcMatrixBuilder.build();
-        sanityValues = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
-            Environment(), storm::solver::SolveGoal<ValueType>(), dtmcMatrix, dtmcMatrix.transpose(), constraintStates, targetStates, false);
+        sanityValues =
+            std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
+                          Environment(), storm::solver::SolveGoal<ValueType>(), dtmcMatrix, dtmcMatrix.transpose(), constraintStates, targetStates, false)
+                          .values);
 
         maxDiff = storm::utility::zero<ValueType>();
         maxState = 0;

--- a/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
+++ b/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
@@ -94,9 +94,11 @@ std::unique_ptr<CheckResult> SparseCtmcCslModelChecker<SparseCtmcModelType>::com
     std::unique_ptr<CheckResult> subResultPointer = this->check(env, pathFormula.getSubformula());
     ExplicitQualitativeCheckResult<ValueType> const& subResult = subResultPointer->template asExplicitQualitativeCheckResult<ValueType>();
     auto probabilisticTransitions = this->getModel().computeProbabilityMatrix();
-    std::vector<ValueType> numericResult = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeGloballyProbabilities(
-        env, storm::solver::SolveGoal<ValueType>(this->getModel(), checkTask), probabilisticTransitions, probabilisticTransitions.transpose(),
-        subResult.getTruthValuesVector(), checkTask.isQualitativeSet());
+    // CTMC results do not carry bounds yet.
+    std::vector<ValueType> numericResult = std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeGloballyProbabilities(
+                                                         env, storm::solver::SolveGoal<ValueType>(this->getModel(), checkTask), probabilisticTransitions,
+                                                         probabilisticTransitions.transpose(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet())
+                                                         .values);
     return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<ValueType>(std::move(numericResult)));
 }
 

--- a/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
+++ b/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
@@ -94,7 +94,6 @@ std::unique_ptr<CheckResult> SparseCtmcCslModelChecker<SparseCtmcModelType>::com
     std::unique_ptr<CheckResult> subResultPointer = this->check(env, pathFormula.getSubformula());
     ExplicitQualitativeCheckResult<ValueType> const& subResult = subResultPointer->template asExplicitQualitativeCheckResult<ValueType>();
     auto probabilisticTransitions = this->getModel().computeProbabilityMatrix();
-    // CTMC results do not carry bounds yet.
     std::vector<ValueType> numericResult = std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeGloballyProbabilities(
                                                          env, storm::solver::SolveGoal<ValueType>(this->getModel(), checkTask), probabilisticTransitions,
                                                          probabilisticTransitions.transpose(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet())

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
@@ -258,7 +258,6 @@ std::vector<ValueType> SparseCtmcCslHelper::computeUntilProbabilities(Environmen
                                                                       storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                       std::vector<ValueType> const& exitRateVector, storm::storage::BitVector const& phiStates,
                                                                       storm::storage::BitVector const& psiStates, bool qualitative) {
-    // The CTMC helper does not expose bounds to its callers yet.
     return std::move(SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(env, std::move(goal), computeProbabilityMatrix(rateMatrix, exitRateVector),
                                                                                  backwardTransitions, phiStates, psiStates, qualitative)
                          .values);

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
@@ -258,8 +258,10 @@ std::vector<ValueType> SparseCtmcCslHelper::computeUntilProbabilities(Environmen
                                                                       storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                       std::vector<ValueType> const& exitRateVector, storm::storage::BitVector const& phiStates,
                                                                       storm::storage::BitVector const& psiStates, bool qualitative) {
-    return SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(env, std::move(goal), computeProbabilityMatrix(rateMatrix, exitRateVector),
-                                                                       backwardTransitions, phiStates, psiStates, qualitative);
+    // The CTMC helper does not expose bounds to its callers yet.
+    return std::move(SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(env, std::move(goal), computeProbabilityMatrix(rateMatrix, exitRateVector),
+                                                                                 backwardTransitions, phiStates, psiStates, qualitative)
+                         .values);
 }
 
 template<typename ValueType>

--- a/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
+++ b/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
@@ -314,9 +314,11 @@ std::vector<ValueType> SparseLTLHelper<ValueType, Nondeterministic>::computeDAPr
         }
 
     } else {
-        prodNumericResult = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
-            env, std::move(solveGoalProduct), product->getProductModel().getTransitionMatrix(), product->getProductModel().getBackwardTransitions(), bvTrue,
-            acceptingStates, this->isQualitativeSet());
+        // Any bounds would have to be projected back to the original model alongside the values, which is not done yet.
+        prodNumericResult = std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
+                                          env, std::move(solveGoalProduct), product->getProductModel().getTransitionMatrix(),
+                                          product->getProductModel().getBackwardTransitions(), bvTrue, acceptingStates, this->isQualitativeSet())
+                                          .values);
     }
 
     std::vector<ValueType> numericResult = product->projectToOriginalModel(this->_transitionMatrix.getRowGroupCount(), prodNumericResult);

--- a/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
+++ b/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
@@ -314,7 +314,6 @@ std::vector<ValueType> SparseLTLHelper<ValueType, Nondeterministic>::computeDAPr
         }
 
     } else {
-        // Any bounds would have to be projected back to the original model alongside the values, which is not done yet.
         prodNumericResult = std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
                                           env, std::move(solveGoalProduct), product->getProductModel().getTransitionMatrix(),
                                           product->getProductModel().getBackwardTransitions(), bvTrue, acceptingStates, this->isQualitativeSet())

--- a/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
@@ -151,12 +151,17 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
     std::unique_ptr<CheckResult> rightResultPointer = this->check(env, pathFormula.getRightSubformula());
     ExplicitQualitativeCheckResult<SolutionType> const& leftResult = leftResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
     ExplicitQualitativeCheckResult<SolutionType> const& rightResult = rightResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
+    storm::solver::SolutionBounds<SolutionType> solutionBounds;
     std::vector<SolutionType> numericResult =
         storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
             env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
             this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
-            checkTask.getHint());
-    return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+            checkTask.getHint(), &solutionBounds);
+    auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(numericResult));
+    if (solutionBounds) {
+        result->setBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+    }
+    return result;
 }
 
 template<typename SparseDtmcModelType>
@@ -168,11 +173,16 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
         storm::logic::GloballyFormula const& pathFormula = checkTask.getFormula();
         std::unique_ptr<CheckResult> subResultPointer = this->check(env, pathFormula.getSubformula());
         ExplicitQualitativeCheckResult<SolutionType> const& subResult = subResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
+        storm::solver::SolutionBounds<SolutionType> solutionBounds;
         std::vector<SolutionType> numericResult =
             storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
                 env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
-                this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet());
-        return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+                this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), &solutionBounds);
+        auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(numericResult));
+        if (solutionBounds) {
+            result->setBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+        }
+        return result;
     }
 }
 

--- a/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
@@ -98,7 +98,7 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
         auto formula = std::make_shared<storm::logic::ProbabilityOperatorFormula>(checkTask.getFormula().asSharedPointer(), opInfo);
         auto numericResult = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeRewardBoundedValues(
             env, this->getModel(), formula);
-        return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+        return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(this->getModel().getInitialStates(), std::move(numericResult)));
     } else {
         STORM_LOG_THROW(pathFormula.hasUpperBound(), storm::exceptions::InvalidPropertyException, "Formula needs to have (a single) upper step bound.");
         STORM_LOG_THROW(pathFormula.hasIntegerLowerBound(), storm::exceptions::InvalidPropertyException, "Formula lower step bound must be discrete/integral.");
@@ -156,7 +156,7 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
         this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
         checkTask.getHint());
     auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(ret.values));
-    setBounds(*result, ret.solutionBounds);
+    result->setBounds(std::move(ret.solutionBounds));
     return result;
 }
 
@@ -173,7 +173,7 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
             env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
             this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet());
         auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(ret.values));
-        setBounds(*result, ret.solutionBounds);
+        result->setBounds(std::move(ret.solutionBounds));
         return result;
     }
 }
@@ -238,7 +238,7 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
             auto formula = std::make_shared<storm::logic::RewardOperatorFormula>(checkTask.getFormula().asSharedPointer(), checkTask.getRewardModel(), opInfo);
             auto numericResult = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeRewardBoundedValues(
                 env, this->getModel(), formula);
-            return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<ValueType>(std::move(numericResult)));
+            return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<ValueType>(this->getModel().getInitialStates(), std::move(numericResult)));
         } else {
             STORM_LOG_THROW(rewardPathFormula.hasIntegerBound(), storm::exceptions::InvalidPropertyException, "Formula needs to have a discrete time bound.");
             auto rewardModel = storm::utility::createFilteredRewardModel(this->getModel(), checkTask);

--- a/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
@@ -151,16 +151,12 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
     std::unique_ptr<CheckResult> rightResultPointer = this->check(env, pathFormula.getRightSubformula());
     ExplicitQualitativeCheckResult<SolutionType> const& leftResult = leftResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
     ExplicitQualitativeCheckResult<SolutionType> const& rightResult = rightResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
-    storm::solver::SolutionBounds<SolutionType> solutionBounds;
-    std::vector<SolutionType> numericResult =
-        storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
-            env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
-            this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
-            checkTask.getHint(), &solutionBounds);
-    auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(numericResult));
-    if (solutionBounds) {
-        result->setBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
-    }
+    auto ret = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
+        env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
+        this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
+        checkTask.getHint());
+    auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(ret.values));
+    setBounds(*result, ret.solutionBounds);
     return result;
 }
 
@@ -173,15 +169,11 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
         storm::logic::GloballyFormula const& pathFormula = checkTask.getFormula();
         std::unique_ptr<CheckResult> subResultPointer = this->check(env, pathFormula.getSubformula());
         ExplicitQualitativeCheckResult<SolutionType> const& subResult = subResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
-        storm::solver::SolutionBounds<SolutionType> solutionBounds;
-        std::vector<SolutionType> numericResult =
-            storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
-                env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
-                this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), &solutionBounds);
-        auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(numericResult));
-        if (solutionBounds) {
-            result->setBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
-        }
+        auto ret = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
+            env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
+            this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet());
+        auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(ret.values));
+        setBounds(*result, ret.solutionBounds);
         return result;
     }
 }

--- a/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
@@ -182,6 +182,9 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
         checkTask.isProduceSchedulersSet(), checkTask.getHint());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
+    if (ret.solutionBounds) {
+        result->asExplicitQuantitativeCheckResult<SolutionType>().setBounds(std::move(ret.solutionBounds->first), std::move(ret.solutionBounds->second));
+    }
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }

--- a/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
@@ -182,9 +182,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
         checkTask.isProduceSchedulersSet(), checkTask.getHint());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
-    if (ret.solutionBounds) {
-        result->asExplicitQuantitativeCheckResult<SolutionType>().setBounds(std::move(ret.solutionBounds->first), std::move(ret.solutionBounds->second));
-    }
+    setBounds(result->asExplicitQuantitativeCheckResult<SolutionType>(), ret.solutionBounds);
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }
@@ -203,6 +201,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
         this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), checkTask.isProduceSchedulersSet());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
+    setBounds(result->asExplicitQuantitativeCheckResult<SolutionType>(), ret.solutionBounds);
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }

--- a/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
@@ -134,7 +134,8 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
             helper::rewardbounded::MultiDimensionalRewardUnfolding<ValueType, true> rewardUnfolding(this->getModel(), formula);
             auto numericResult = storm::modelchecker::helper::SparseMdpPrctlHelper<ValueType, SolutionType>::computeRewardBoundedValues(
                 env, checkTask.getOptimizationDirection(), rewardUnfolding, this->getModel().getInitialStates());
-            return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+            return std::unique_ptr<CheckResult>(
+                new ExplicitQuantitativeCheckResult<SolutionType>(this->getModel().getInitialStates(), std::move(numericResult)));
         }
     } else {
         STORM_LOG_THROW(pathFormula.hasUpperBound(), storm::exceptions::InvalidPropertyException, "Formula needs to have (a single) upper step bound.");
@@ -182,7 +183,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
         checkTask.isProduceSchedulersSet(), checkTask.getHint());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
-    setBounds(result->asExplicitQuantitativeCheckResult<SolutionType>(), ret.solutionBounds);
+    result->asExplicitQuantitativeCheckResult<SolutionType>().setBounds(std::move(ret.solutionBounds));
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }
@@ -201,7 +202,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
         this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), checkTask.isProduceSchedulersSet());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
-    setBounds(result->asExplicitQuantitativeCheckResult<SolutionType>(), ret.solutionBounds);
+    result->asExplicitQuantitativeCheckResult<SolutionType>().setBounds(std::move(ret.solutionBounds));
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }
@@ -316,7 +317,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         helper::rewardbounded::MultiDimensionalRewardUnfolding<ValueType, true> rewardUnfolding(this->getModel(), formula);
         auto numericResult = storm::modelchecker::helper::SparseMdpPrctlHelper<ValueType, SolutionType>::computeRewardBoundedValues(
             env, checkTask.getOptimizationDirection(), rewardUnfolding, this->getModel().getInitialStates());
-        return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+        return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(this->getModel().getInitialStates(), std::move(numericResult)));
     } else {
         STORM_LOG_THROW(rewardPathFormula.hasIntegerBound(), storm::exceptions::InvalidPropertyException, "Formula needs to have a discrete time bound.");
         auto rewardModel = storm::utility::createFilteredRewardModel(this->getModel(), checkTask);

--- a/src/storm/modelchecker/prctl/helper/DTMCModelCheckingHelperReturnType.h
+++ b/src/storm/modelchecker/prctl/helper/DTMCModelCheckingHelperReturnType.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "storm/solver/SolutionBounds.h"
+
+namespace storm {
+namespace modelchecker {
+namespace helper {
+
+/*!
+ * The outcome of a quantitative model checking query on a sparse DTMC. Unlike its MDP counterpart it carries no
+ * scheduler, as a DTMC has no nondeterminism to resolve.
+ */
+template<typename ValueType>
+struct DTMCSparseModelCheckingHelperReturnType {
+    DTMCSparseModelCheckingHelperReturnType(DTMCSparseModelCheckingHelperReturnType const&) = delete;
+    DTMCSparseModelCheckingHelperReturnType(DTMCSparseModelCheckingHelperReturnType&&) = default;
+    DTMCSparseModelCheckingHelperReturnType& operator=(DTMCSparseModelCheckingHelperReturnType&&) = default;
+
+    explicit DTMCSparseModelCheckingHelperReturnType(std::vector<ValueType>&& values) : values(std::move(values)) {
+        // Intentionally left empty.
+    }
+
+    virtual ~DTMCSparseModelCheckingHelperReturnType() {
+        // Intentionally left empty.
+    }
+
+    // The values computed for the states.
+    std::vector<ValueType> values;
+
+    // Sound bounds on the values, if the algorithm that computed them provided any.
+    storm::solver::SolutionBounds<ValueType> solutionBounds;
+};
+
+}  // namespace helper
+}  // namespace modelchecker
+}  // namespace storm

--- a/src/storm/modelchecker/prctl/helper/DTMCModelCheckingHelperReturnType.h
+++ b/src/storm/modelchecker/prctl/helper/DTMCModelCheckingHelperReturnType.h
@@ -30,7 +30,6 @@ struct DTMCSparseModelCheckingHelperReturnType {
     // The values computed for the states.
     std::vector<ValueType> values;
 
-    // Sound bounds on the values, if the algorithm that computed them provided any.
     storm::solver::SolutionBounds<ValueType> solutionBounds;
 };
 

--- a/src/storm/modelchecker/prctl/helper/MDPModelCheckingHelperReturnType.h
+++ b/src/storm/modelchecker/prctl/helper/MDPModelCheckingHelperReturnType.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+#include "storm/solver/SolutionBounds.h"
 #include "storm/storage/Scheduler.h"
 
 namespace storm {
@@ -30,6 +31,11 @@ struct MDPSparseModelCheckingHelperReturnType {
 
     // A scheduler, if it was computed.
     std::unique_ptr<storm::storage::Scheduler<ValueType>> scheduler;
+
+    // Sound bounds on the values, if the algorithm that computed them provided any. These are bounds on the
+    // values, so they are expressed in the same type as those: a bound on a reward that may be infinite has to
+    // be able to say so.
+    storm::solver::SolutionBounds<ValuesType> solutionBounds;
 };
 }  // namespace helper
 

--- a/src/storm/modelchecker/prctl/helper/MDPModelCheckingHelperReturnType.h
+++ b/src/storm/modelchecker/prctl/helper/MDPModelCheckingHelperReturnType.h
@@ -32,9 +32,6 @@ struct MDPSparseModelCheckingHelperReturnType {
     // A scheduler, if it was computed.
     std::unique_ptr<storm::storage::Scheduler<ValueType>> scheduler;
 
-    // Sound bounds on the values, if the algorithm that computed them provided any. These are bounds on the
-    // values, so they are expressed in the same type as those: a bound on a reward that may be infinite has to
-    // be able to say so.
     storm::solver::SolutionBounds<ValuesType> solutionBounds;
 };
 }  // namespace helper

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -276,9 +276,7 @@ DTMCSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<Valu
                 solver->setBounds(storm::utility::zero<ValueType>(), storm::utility::one<ValueType>());
                 solver->solveEquations(env, x, b);
 
-                // Outside of the maybe states the probability is exactly zero or one, so the entries that
-                // result already holds bound those states from both sides. Note that the solver may well know
-                // only one of the two bounds, e.g. optimistic value iteration that did not converge.
+                // The copy of result supplies the exact values outside the maybe states.
                 auto embedBound = [&result, &maybeStates](std::vector<SolutionType> const& boundForMaybeStates) {
                     std::vector<SolutionType> bound(result);
                     storm::utility::vector::setVectorValues<SolutionType>(bound, maybeStates, boundForMaybeStates);
@@ -382,8 +380,7 @@ DTMCSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<Valu
         for (auto& entry : returnValue.values) {
             entry = storm::utility::one<SolutionType>() - entry;
         }
-        // One minus is antitone, so the complement of the lower bound bounds the result from above and vice
-        // versa. In particular, knowing only one side before means knowing only the other side afterwards.
+        // Inverse the bounds, lb = 1 - ub and ub = 1 - lb.
         auto& bounds = returnValue.solutionBounds;
         for (auto* bound : {&bounds.lower, &bounds.upper}) {
             if (*bound) {

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -166,10 +166,11 @@ std::vector<SolutionType> computeRobustValuesForMaybeStates(Environment const& e
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
+DTMCSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-    bool qualitative, ModelCheckerHint const& hint, storm::solver::SolutionBounds<SolutionType>* solutionBounds) {
+    bool qualitative, ModelCheckerHint const& hint) {
+    storm::solver::SolutionBounds<SolutionType> solutionBounds;
     std::vector<SolutionType> result(transitionMatrix.getRowCount(), storm::utility::zero<SolutionType>());
 
     // We need to identify the maybe states (states which have a probability for satisfying the until formula
@@ -274,13 +275,19 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
                 solver->setBounds(storm::utility::zero<ValueType>(), storm::utility::one<ValueType>());
                 solver->solveEquations(env, x, b);
 
-                if (solutionBounds != nullptr && solver->hasSolutionBounds()) {
-                    // Outside of the maybe states the probability is exactly zero or one, so the entries that
-                    // result already holds bound those states from both sides.
-                    std::vector<SolutionType> lower(result), upper(result);
-                    storm::utility::vector::setVectorValues<SolutionType>(lower, maybeStates, solver->getSolutionLowerBounds());
-                    storm::utility::vector::setVectorValues<SolutionType>(upper, maybeStates, solver->getSolutionUpperBounds());
-                    *solutionBounds = std::make_pair(std::move(lower), std::move(upper));
+                // Outside of the maybe states the probability is exactly zero or one, so the entries that
+                // result already holds bound those states from both sides. Note that the solver may well know
+                // only one of the two bounds, e.g. optimistic value iteration that did not converge.
+                auto embedBound = [&result, &maybeStates](std::vector<SolutionType> const& boundForMaybeStates) {
+                    std::vector<SolutionType> bound(result);
+                    storm::utility::vector::setVectorValues<SolutionType>(bound, maybeStates, boundForMaybeStates);
+                    return bound;
+                };
+                if (solver->hasSolutionLowerBounds()) {
+                    solutionBounds.lower = embedBound(solver->getSolutionLowerBounds());
+                }
+                if (solver->hasSolutionUpperBounds()) {
+                    solutionBounds.upper = embedBound(solver->getSolutionUpperBounds());
                 }
 
                 // Set values of resulting vector according to result.
@@ -288,7 +295,9 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
             }
         }
     }
-    return result;
+    DTMCSparseModelCheckingHelperReturnType<SolutionType> returnValue(std::move(result));
+    returnValue.solutionBounds = std::move(solutionBounds);
+    return returnValue;
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
@@ -359,32 +368,31 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
+DTMCSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& psiStates, bool qualitative,
-    storm::solver::SolutionBounds<SolutionType>* solutionBounds) {
+    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& psiStates, bool qualitative) {
     if constexpr (storm::IsIntervalType<ValueType>) {
         STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "We do not support computing globally probabilities with interval models.");
     } else {
         goal.oneMinus();
-        std::vector<SolutionType> result = computeUntilProbabilities(env, std::move(goal), transitionMatrix, backwardTransitions,
-                                                                     storm::storage::BitVector(transitionMatrix.getRowCount(), true), ~psiStates, qualitative,
-                                                                     ModelCheckerHint(), solutionBounds);
-        for (auto& entry : result) {
+        DTMCSparseModelCheckingHelperReturnType<SolutionType> returnValue =
+            computeUntilProbabilities(env, std::move(goal), transitionMatrix, backwardTransitions,
+                                      storm::storage::BitVector(transitionMatrix.getRowCount(), true), ~psiStates, qualitative);
+        for (auto& entry : returnValue.values) {
             entry = storm::utility::one<SolutionType>() - entry;
         }
-        if (solutionBounds != nullptr && *solutionBounds) {
-            // One minus is antitone, so the complement of the lower bound bounds the result from above.
-            auto& bounds = **solutionBounds;
-            for (auto& entry : bounds.first) {
-                entry = storm::utility::one<SolutionType>() - entry;
+        // One minus is antitone, so the complement of the lower bound bounds the result from above and vice
+        // versa. In particular, knowing only one side before means knowing only the other side afterwards.
+        auto& bounds = returnValue.solutionBounds;
+        for (auto* bound : {&bounds.lower, &bounds.upper}) {
+            if (*bound) {
+                for (auto& entry : **bound) {
+                    entry = storm::utility::one<SolutionType>() - entry;
+                }
             }
-            for (auto& entry : bounds.second) {
-                entry = storm::utility::one<SolutionType>() - entry;
-            }
-            std::swap(bounds.first, bounds.second);
         }
-        return result;
+        std::swap(bounds.lower, bounds.upper);
+        return returnValue;
     }
 }
 
@@ -738,8 +746,9 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeBaierTra
 
         // Start by computing all 'before' states, i.e. the states for which the conditional probability is defined.
         std::vector<ValueType> probabilitiesToReachConditionStates =
-            computeUntilProbabilities(env, storm::solver::SolveGoal<ValueType>(), transitionMatrix, backwardTransitions,
-                                      storm::storage::BitVector(transitionMatrix.getRowCount(), true), conditionStates, false);
+            std::move(computeUntilProbabilities(env, storm::solver::SolveGoal<ValueType>(), transitionMatrix, backwardTransitions,
+                                                storm::storage::BitVector(transitionMatrix.getRowCount(), true), conditionStates, false)
+                          .values);
 
         result.beforeStates = storm::storage::BitVector(targetStates.size(), true);
         uint_fast64_t state = 0;
@@ -909,9 +918,11 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeConditio
                     newRelevantValues = transformedModel.getNewRelevantStates();
                 }
                 goal.setRelevantValues(std::move(newRelevantValues));
-                std::vector<ValueType> conditionalProbabilities = computeUntilProbabilities(
-                    env, std::move(goal), newTransitionMatrix, newTransitionMatrix.transpose(),
-                    storm::storage::BitVector(newTransitionMatrix.getRowCount(), true), transformedModel.targetStates.get(), qualitative);
+                std::vector<ValueType> conditionalProbabilities =
+                    std::move(computeUntilProbabilities(env, std::move(goal), newTransitionMatrix, newTransitionMatrix.transpose(),
+                                                        storm::storage::BitVector(newTransitionMatrix.getRowCount(), true), transformedModel.targetStates.get(),
+                                                        qualitative)
+                                  .values);
 
                 storm::utility::vector::setVectorValues(result, transformedModel.beforeStates, conditionalProbabilities);
             }

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -169,7 +169,7 @@ template<typename ValueType, typename RewardModelType, typename SolutionType>
 std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-    bool qualitative, ModelCheckerHint const& hint) {
+    bool qualitative, ModelCheckerHint const& hint, storm::solver::SolutionBounds<SolutionType>* solutionBounds) {
     std::vector<SolutionType> result(transitionMatrix.getRowCount(), storm::utility::zero<SolutionType>());
 
     // We need to identify the maybe states (states which have a probability for satisfying the until formula
@@ -274,6 +274,15 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
                 solver->setBounds(storm::utility::zero<ValueType>(), storm::utility::one<ValueType>());
                 solver->solveEquations(env, x, b);
 
+                if (solutionBounds != nullptr && solver->hasSolutionBounds()) {
+                    // Outside of the maybe states the probability is exactly zero or one, so the entries that
+                    // result already holds bound those states from both sides.
+                    std::vector<SolutionType> lower(result), upper(result);
+                    storm::utility::vector::setVectorValues<SolutionType>(lower, maybeStates, solver->getSolutionLowerBounds());
+                    storm::utility::vector::setVectorValues<SolutionType>(upper, maybeStates, solver->getSolutionUpperBounds());
+                    *solutionBounds = std::make_pair(std::move(lower), std::move(upper));
+                }
+
                 // Set values of resulting vector according to result.
                 storm::utility::vector::setVectorValues(result, maybeStates, x);
             }
@@ -352,15 +361,28 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
 template<typename ValueType, typename RewardModelType, typename SolutionType>
 std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& psiStates, bool qualitative) {
+    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& psiStates, bool qualitative,
+    storm::solver::SolutionBounds<SolutionType>* solutionBounds) {
     if constexpr (storm::IsIntervalType<ValueType>) {
         STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "We do not support computing globally probabilities with interval models.");
     } else {
         goal.oneMinus();
         std::vector<SolutionType> result = computeUntilProbabilities(env, std::move(goal), transitionMatrix, backwardTransitions,
-                                                                     storm::storage::BitVector(transitionMatrix.getRowCount(), true), ~psiStates, qualitative);
+                                                                     storm::storage::BitVector(transitionMatrix.getRowCount(), true), ~psiStates, qualitative,
+                                                                     ModelCheckerHint(), solutionBounds);
         for (auto& entry : result) {
             entry = storm::utility::one<SolutionType>() - entry;
+        }
+        if (solutionBounds != nullptr && *solutionBounds) {
+            // One minus is antitone, so the complement of the lower bound bounds the result from above.
+            auto& bounds = **solutionBounds;
+            for (auto& entry : bounds.first) {
+                entry = storm::utility::one<SolutionType>() - entry;
+            }
+            for (auto& entry : bounds.second) {
+                entry = storm::utility::one<SolutionType>() - entry;
+            }
+            std::swap(bounds.first, bounds.second);
         }
         return result;
     }

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -31,15 +31,15 @@ namespace modelchecker {
 namespace helper {
 
 template<>
-std::map<storm::storage::sparse::state_type, storm::RationalFunction> SparseDtmcPrctlHelper<storm::RationalFunction>::computeRewardBoundedValues(
+std::vector<storm::RationalFunction> SparseDtmcPrctlHelper<storm::RationalFunction>::computeRewardBoundedValues(
     Environment const& /*env*/, storm::models::sparse::Dtmc<storm::RationalFunction> const& /*model*/,
     std::shared_ptr<storm::logic::OperatorFormula const> /*rewardBoundedFormula*/) {
     STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "The specified property is not supported by this value type.");
-    return std::map<storm::storage::sparse::state_type, storm::RationalFunction>();
+    return std::vector<storm::RationalFunction>();
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-std::map<storm::storage::sparse::state_type, SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeRewardBoundedValues(
+std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeRewardBoundedValues(
     Environment const& env, storm::models::sparse::Dtmc<ValueType> const& model, std::shared_ptr<storm::logic::OperatorFormula const> rewardBoundedFormula) {
     if constexpr (storm::IsIntervalType<ValueType>) {
         STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "We do not support computing reward bounded values with interval models.");
@@ -100,9 +100,10 @@ std::map<storm::storage::sparse::state_type, SolutionType> SparseDtmcPrctlHelper
             }
         }
 
-        std::map<storm::storage::sparse::state_type, ValueType> result;
+        std::vector<ValueType> result;
+        result.reserve(model.getInitialStates().getNumberOfSetBits());
         for (auto initState : model.getInitialStates()) {
-            result[initState] = rewardUnfolding.getInitialStateResult(initEpoch, initState);
+            result.push_back(rewardUnfolding.getInitialStateResult(initEpoch, initState));
         }
 
         swAll.stop();

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
@@ -30,8 +30,11 @@ class SparseDtmcPrctlHelper {
    public:
     using ExtendedSolutionType = storm::utility::ExtendedValueType<SolutionType>;
 
-    static std::map<storm::storage::sparse::state_type, SolutionType> computeRewardBoundedValues(
-        Environment const& env, storm::models::sparse::Dtmc<ValueType> const& model, std::shared_ptr<storm::logic::OperatorFormula const> rewardBoundedFormula);
+    /*!
+     * @return One value per initial state of the given model, in the order of those states.
+     */
+    static std::vector<SolutionType> computeRewardBoundedValues(Environment const& env, storm::models::sparse::Dtmc<ValueType> const& model,
+                                                                std::shared_ptr<storm::logic::OperatorFormula const> rewardBoundedFormula);
 
     static std::vector<SolutionType> computeNextProbabilities(Environment const& env, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                               storm::storage::BitVector const& nextStates);

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
@@ -5,6 +5,7 @@
 #include <boost/optional.hpp>
 
 #include "storm/modelchecker/hints/ModelCheckerHint.h"
+#include "storm/modelchecker/prctl/helper/DTMCModelCheckingHelperReturnType.h"
 #include "storm/models/sparse/Dtmc.h"
 #include "storm/models/sparse/StandardRewardModel.h"
 
@@ -36,26 +37,24 @@ class SparseDtmcPrctlHelper {
                                                               storm::storage::BitVector const& nextStates);
 
     /*!
-     * @param solutionBounds If given, receives sound bounds on the computed probabilities, provided that the
-     * equation solver produced any.
+     * @return The probabilities, together with sound bounds on them if the equation solver provided any.
      */
-    static std::vector<SolutionType> computeUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
-                                                               storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                               storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                               storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-                                                               bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint(),
-                                                               storm::solver::SolutionBounds<SolutionType>* solutionBounds = nullptr);
+    static DTMCSparseModelCheckingHelperReturnType<SolutionType> computeUntilProbabilities(
+        Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+        storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& phiStates,
+        storm::storage::BitVector const& psiStates, bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint());
 
     static std::vector<SolutionType> computeAllUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                   storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                   storm::storage::BitVector const& initialStates, storm::storage::BitVector const& phiStates,
                                                                   storm::storage::BitVector const& psiStates);
 
-    static std::vector<SolutionType> computeGloballyProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
-                                                                  storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                                  storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                  storm::storage::BitVector const& psiStates, bool qualitative,
-                                                                  storm::solver::SolutionBounds<SolutionType>* solutionBounds = nullptr);
+    /*!
+     * @return The probabilities, together with sound bounds on them if the equation solver provided any.
+     */
+    static DTMCSparseModelCheckingHelperReturnType<SolutionType> computeGloballyProbabilities(
+        Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+        storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& psiStates, bool qualitative);
 
     static std::vector<SolutionType> computeCumulativeRewards(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                               storm::storage::SparseMatrix<ValueType> const& transitionMatrix,

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
@@ -35,11 +35,16 @@ class SparseDtmcPrctlHelper {
     static std::vector<SolutionType> computeNextProbabilities(Environment const& env, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                               storm::storage::BitVector const& nextStates);
 
+    /*!
+     * @param solutionBounds If given, receives sound bounds on the computed probabilities, provided that the
+     * equation solver produced any.
+     */
     static std::vector<SolutionType> computeUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-                                                               bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint());
+                                                               bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint(),
+                                                               storm::solver::SolutionBounds<SolutionType>* solutionBounds = nullptr);
 
     static std::vector<SolutionType> computeAllUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                   storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
@@ -49,7 +54,8 @@ class SparseDtmcPrctlHelper {
     static std::vector<SolutionType> computeGloballyProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                   storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                   storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                  storm::storage::BitVector const& psiStates, bool qualitative);
+                                                                  storm::storage::BitVector const& psiStates, bool qualitative,
+                                                                  storm::solver::SolutionBounds<SolutionType>* solutionBounds = nullptr);
 
     static std::vector<SolutionType> computeCumulativeRewards(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                               storm::storage::SparseMatrix<ValueType> const& transitionMatrix,

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -425,7 +425,6 @@ struct MaybeStateResult {
     std::vector<ValueType> values;
     boost::optional<std::vector<uint64_t>> scheduler;
 
-    // Sound bounds on the values, if the solver provided any.
     storm::solver::SolutionBounds<ValueType> solutionBounds;
 };
 
@@ -488,8 +487,6 @@ MaybeStateResult<SolutionType> computeValuesForMaybeStates(Environment const& en
 
     // Create result.
     MaybeStateResult<SolutionType> result(std::move(x));
-    // Note that the solver may well know only one of the two bounds, e.g. optimistic value iteration that did
-    // not converge.
     if (solver->hasSolutionLowerBounds()) {
         result.solutionBounds.lower = solver->getSolutionLowerBounds();
     }
@@ -702,7 +699,6 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
     // Prepare resulting vector.
     std::vector<SolutionType> result(transitionMatrix.getRowGroupCount(), storm::utility::zero<SolutionType>());
 
-    // Sound bounds on the result, if the solver provides any.
     storm::solver::SolutionBounds<SolutionType> resultBounds;
 
     // We need to identify the maybe states (states which have a probability for satisfying the until formula
@@ -780,8 +776,7 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
                 // Set values of resulting vector according to result.
                 if constexpr (!storm::IsIntervalType<ValueType>) {
                     // For non-interval models, we only operated on the maybe states, and we must recover the qualitative values for the other state.
-                    // Outside of the maybe states the probability is exactly zero or one, so the entries that
-                    // result already holds bound those states from both sides.
+                    // The copy of result supplies the exact values outside the maybe states.
                     auto embedBound = [&result, &qualitativeStateSets](std::vector<SolutionType> const& boundForMaybeStates) {
                         std::vector<SolutionType> bound(result);
                         storm::utility::vector::setVectorValues<SolutionType>(bound, qualitativeStateSets.maybeStates, boundForMaybeStates);
@@ -849,8 +844,7 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
         for (auto& element : result.values) {
             element = storm::utility::one<SolutionType>() - element;
         }
-        // One minus is antitone, so the complement of the lower bound bounds the result from above and vice
-        // versa. In particular, knowing only one side before means knowing only the other side afterwards.
+        // Inverse the bounds, lb = 1 - ub and ub = 1 - lb.
         auto& bounds = result.solutionBounds;
         for (auto* bound : {&bounds.lower, &bounds.upper}) {
             if (*bound) {

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -423,6 +423,9 @@ struct MaybeStateResult {
 
     std::vector<ValueType> values;
     boost::optional<std::vector<uint64_t>> scheduler;
+
+    // Sound bounds on the values, if the solver provided any.
+    storm::solver::SolutionBounds<ValueType> solutionBounds;
 };
 
 template<typename ValueType, typename SolutionType>
@@ -484,6 +487,9 @@ MaybeStateResult<SolutionType> computeValuesForMaybeStates(Environment const& en
 
     // Create result.
     MaybeStateResult<SolutionType> result(std::move(x));
+    if (solver->hasSolutionBounds()) {
+        result.solutionBounds = std::make_pair(solver->getSolutionLowerBounds(), solver->getSolutionUpperBounds());
+    }
 
     // If requested, return the requested scheduler.
     if (produceScheduler) {
@@ -690,6 +696,9 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
     // Prepare resulting vector.
     std::vector<SolutionType> result(transitionMatrix.getRowGroupCount(), storm::utility::zero<SolutionType>());
 
+    // Sound bounds on the result, if the solver provides any.
+    storm::solver::SolutionBounds<SolutionType> resultBounds;
+
     // We need to identify the maybe states (states which have a probability for satisfying the until formula
     // that is strictly between 0 and 1) and the states that satisfy the formula with probablity 1 and 0, respectively.
     QualitativeStateSetsUntilProbabilities qualitativeStateSets =
@@ -765,7 +774,17 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
                 // Set values of resulting vector according to result.
                 if constexpr (!storm::IsIntervalType<ValueType>) {
                     // For non-interval models, we only operated on the maybe states, and we must recover the qualitative values for the other state.
-                    storm::utility::vector::setVectorValues(result, qualitativeStateSets.maybeStates, resultForMaybeStates.getValues());
+                    if (resultForMaybeStates.solutionBounds) {
+                        // Outside of the maybe states the probability is exactly zero or one, so the entries
+                        // that result already holds bound those states from both sides.
+                        std::vector<SolutionType> lower(result), upper(result);
+                        storm::utility::vector::setVectorValues<SolutionType>(lower, qualitativeStateSets.maybeStates,
+                                                                              resultForMaybeStates.solutionBounds->first);
+                        storm::utility::vector::setVectorValues<SolutionType>(upper, qualitativeStateSets.maybeStates,
+                                                                              resultForMaybeStates.solutionBounds->second);
+                        resultBounds = std::make_pair(std::move(lower), std::move(upper));
+                    }
+                    storm::utility::vector::setVectorValues<SolutionType>(result, qualitativeStateSets.maybeStates, resultForMaybeStates.getValues());
                 } else {
                     // For interval models, the result for maybe states indeed also holds values for all qualitative states.
                     STORM_LOG_ASSERT(resultForMaybeStates.getValues().size() == transitionMatrix.getColumnCount(), "Dimensions do not match.");
@@ -791,7 +810,9 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
     STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isMemorylessScheduler(), "Expected a memoryless scheduler.");
 
     // Return result.
-    return MDPSparseModelCheckingHelperReturnType<SolutionType>(std::move(result), std::move(scheduler));
+    MDPSparseModelCheckingHelperReturnType<SolutionType> returnValue(std::move(result), std::move(scheduler));
+    returnValue.solutionBounds = std::move(resultBounds);
+    return returnValue;
 }
 
 template<typename ValueType, typename SolutionType>

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -487,8 +487,13 @@ MaybeStateResult<SolutionType> computeValuesForMaybeStates(Environment const& en
 
     // Create result.
     MaybeStateResult<SolutionType> result(std::move(x));
-    if (solver->hasSolutionBounds()) {
-        result.solutionBounds = std::make_pair(solver->getSolutionLowerBounds(), solver->getSolutionUpperBounds());
+    // Note that the solver may well know only one of the two bounds, e.g. optimistic value iteration that did
+    // not converge.
+    if (solver->hasSolutionLowerBounds()) {
+        result.solutionBounds.lower = solver->getSolutionLowerBounds();
+    }
+    if (solver->hasSolutionUpperBounds()) {
+        result.solutionBounds.upper = solver->getSolutionUpperBounds();
     }
 
     // If requested, return the requested scheduler.
@@ -774,15 +779,18 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
                 // Set values of resulting vector according to result.
                 if constexpr (!storm::IsIntervalType<ValueType>) {
                     // For non-interval models, we only operated on the maybe states, and we must recover the qualitative values for the other state.
-                    if (resultForMaybeStates.solutionBounds) {
-                        // Outside of the maybe states the probability is exactly zero or one, so the entries
-                        // that result already holds bound those states from both sides.
-                        std::vector<SolutionType> lower(result), upper(result);
-                        storm::utility::vector::setVectorValues<SolutionType>(lower, qualitativeStateSets.maybeStates,
-                                                                              resultForMaybeStates.solutionBounds->first);
-                        storm::utility::vector::setVectorValues<SolutionType>(upper, qualitativeStateSets.maybeStates,
-                                                                              resultForMaybeStates.solutionBounds->second);
-                        resultBounds = std::make_pair(std::move(lower), std::move(upper));
+                    // Outside of the maybe states the probability is exactly zero or one, so the entries that
+                    // result already holds bound those states from both sides.
+                    auto embedBound = [&result, &qualitativeStateSets](std::vector<SolutionType> const& boundForMaybeStates) {
+                        std::vector<SolutionType> bound(result);
+                        storm::utility::vector::setVectorValues<SolutionType>(bound, qualitativeStateSets.maybeStates, boundForMaybeStates);
+                        return bound;
+                    };
+                    if (resultForMaybeStates.solutionBounds.hasLower()) {
+                        resultBounds.lower = embedBound(*resultForMaybeStates.solutionBounds.lower);
+                    }
+                    if (resultForMaybeStates.solutionBounds.hasUpper()) {
+                        resultBounds.upper = embedBound(*resultForMaybeStates.solutionBounds.upper);
                     }
                     storm::utility::vector::setVectorValues<SolutionType>(result, qualitativeStateSets.maybeStates, resultForMaybeStates.getValues());
                 } else {
@@ -840,6 +848,17 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
         for (auto& element : result.values) {
             element = storm::utility::one<SolutionType>() - element;
         }
+        // One minus is antitone, so the complement of the lower bound bounds the result from above and vice
+        // versa. In particular, knowing only one side before means knowing only the other side afterwards.
+        auto& bounds = result.solutionBounds;
+        for (auto* bound : {&bounds.lower, &bounds.upper}) {
+            if (*bound) {
+                for (auto& entry : **bound) {
+                    entry = storm::utility::one<SolutionType>() - entry;
+                }
+            }
+        }
+        std::swap(bounds.lower, bounds.upper);
         return result;
     }
 }

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -37,7 +37,7 @@ namespace modelchecker {
 namespace helper {
 
 template<typename ValueType, typename SolutionType>
-std::map<storm::storage::sparse::state_type, SolutionType> SparseMdpPrctlHelper<ValueType, SolutionType>::computeRewardBoundedValues(
+std::vector<SolutionType> SparseMdpPrctlHelper<ValueType, SolutionType>::computeRewardBoundedValues(
     Environment const& env, OptimizationDirection dir, rewardbounded::MultiDimensionalRewardUnfolding<ValueType, true>& rewardUnfolding,
     storm::storage::BitVector const& initialStates) {
     if constexpr (storm::IsIntervalType<ValueType>) {
@@ -93,9 +93,10 @@ std::map<storm::storage::sparse::state_type, SolutionType> SparseMdpPrctlHelper<
             }
         }
 
-        std::map<storm::storage::sparse::state_type, ValueType> result;
+        std::vector<ValueType> result;
+        result.reserve(initialStates.getNumberOfSetBits());
         for (uint64_t initState : initialStates) {
-            result[initState] = rewardUnfolding.getInitialStateResult(initEpoch, initState);
+            result.push_back(rewardUnfolding.getInitialStateResult(initEpoch, initState));
         }
 
         swAll.stop();

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.h
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.h
@@ -38,9 +38,12 @@ class SparseMdpPrctlHelper {
     using ExtendedSolutionType = storm::utility::ExtendedValueType<SolutionType>;
     using ExtendedReturnType = MDPSparseModelCheckingHelperReturnType<SolutionType, ExtendedSolutionType>;
 
-    static std::map<storm::storage::sparse::state_type, SolutionType> computeRewardBoundedValues(
-        Environment const& env, OptimizationDirection dir, rewardbounded::MultiDimensionalRewardUnfolding<ValueType, true>& rewardUnfolding,
-        storm::storage::BitVector const& initialStates);
+    /*!
+     * @return One value per given initial state, in the order of those states.
+     */
+    static std::vector<SolutionType> computeRewardBoundedValues(Environment const& env, OptimizationDirection dir,
+                                                                rewardbounded::MultiDimensionalRewardUnfolding<ValueType, true>& rewardUnfolding,
+                                                                storm::storage::BitVector const& initialStates);
 
     static std::vector<SolutionType> computeNextProbabilities(Environment const& env, OptimizationDirection dir,
                                                               UncertaintyResolutionMode uncertaintyResolutionMode,

--- a/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
+++ b/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
@@ -512,11 +512,9 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
     if (computeForInitialStatesOnly) {
         // If we computed the results for the initial (and prob 0 and prob1) states only, we need to filter the
         // result to only communicate these results.
-        std::unique_ptr<ExplicitQuantitativeCheckResult<ValueType>> checkResult = std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>();
-        for (uint64_t state : ~maybeStates | initialStates) {
-            (*checkResult)[state] = result[state];
-        }
-        return std::move(checkResult);  // move() required by, e.g., clang 3.8
+        storm::storage::BitVector relevantStates = ~maybeStates | initialStates;
+        std::vector<ValueType> relevantValues = storm::utility::vector::filterVector(result, relevantStates);
+        return std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(std::move(relevantStates), std::move(relevantValues));
     }
     return std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(result);
 }
@@ -621,11 +619,9 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
     if (computeForInitialStatesOnly) {
         // If we computed the results for the initial (and inf) states only, we need to filter the result to
         // only communicate these results.
-        std::unique_ptr<ExplicitQuantitativeCheckResult<ValueType>> checkResult = std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>();
-        for (uint64_t state : ~maybeStates | initialStates) {
-            (*checkResult)[state] = result[state];
-        }
-        return std::move(checkResult);  // move() required by, e.g., clang 3.8
+        storm::storage::BitVector relevantStates = ~maybeStates | initialStates;
+        auto relevantValues = storm::utility::vector::filterVector(result, relevantStates);
+        return std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(std::move(relevantStates), std::move(relevantValues));
     }
     return std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(result);
 }

--- a/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
@@ -4,6 +4,8 @@
 
 #include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
 
+#include <algorithm>
+
 #include "storm/adapters/JsonAdapter.h"
 #include "storm/exceptions/InvalidOperationException.h"
 #include "storm/utility/macros.h"
@@ -12,52 +14,35 @@ namespace storm {
 namespace modelchecker {
 
 template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult() : truthValues(map_type()) {
-    // Intentionally left empty.
+ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(storm::storage::sparse::state_type state, bool value)
+    : states(storm::storage::BitVector(state + 1)), truthValues(1, value) {
+    states->set(state);
 }
 
 template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(map_type const& map) : truthValues(map) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(map_type&& map) : truthValues(map) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(storm::storage::sparse::state_type state, bool value) : truthValues(map_type()) {
-    boost::get<map_type>(truthValues)[state] = value;
-}
-
-template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(storm::storage::BitVector const& truthValues) : truthValues(truthValues) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(storm::storage::BitVector&& truthValues) : truthValues(std::move(truthValues)) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(boost::variant<vector_type, map_type> const& truthValues,
+ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(vector_type const& truthValues,
                                                                           std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
     : truthValues(truthValues), scheduler(scheduler) {
     // Intentionally left empty.
 }
 
 template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(boost::variant<vector_type, map_type>&& truthValues,
+ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(vector_type&& truthValues,
                                                                           std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
     : truthValues(std::move(truthValues)), scheduler(scheduler) {
     // Intentionally left empty.
 }
 
 template<typename ValueType>
+ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(storm::storage::BitVector states, vector_type&& truthValues,
+                                                                          std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
+    : states(std::move(states)), truthValues(std::move(truthValues)), scheduler(scheduler) {
+    STORM_LOG_ASSERT(this->states->getNumberOfSetBits() == this->truthValues.size(), "Expected one truth value per selected state.");
+}
+
+template<typename ValueType>
 std::unique_ptr<CheckResult> ExplicitQualitativeCheckResult<ValueType>::clone() const {
-    return std::make_unique<ExplicitQualitativeCheckResult<ValueType>>(this->truthValues);
+    return std::make_unique<ExplicitQualitativeCheckResult<ValueType>>(*this);
 }
 
 template<typename ValueType>
@@ -65,34 +50,13 @@ void ExplicitQualitativeCheckResult<ValueType>::performLogicalOperation(Explicit
                                                                         bool logicalAnd) {
     STORM_LOG_THROW(second.isExplicitQualitativeCheckResult(), storm::exceptions::InvalidOperationException,
                     "Cannot perform logical 'and' on check results of incompatible type.");
-    STORM_LOG_THROW(first.isResultForAllStates() == second.isResultForAllStates(), storm::exceptions::InvalidOperationException,
-                    "Cannot perform logical 'and' on check results of incompatible type.");
     ExplicitQualitativeCheckResult<ValueType> const& secondCheckResult = static_cast<ExplicitQualitativeCheckResult<ValueType> const&>(second);
-    if (first.isResultForAllStates()) {
-        if (logicalAnd) {
-            boost::get<vector_type>(first.truthValues) &= boost::get<vector_type>(secondCheckResult.truthValues);
-        } else {
-            boost::get<vector_type>(first.truthValues) |= boost::get<vector_type>(secondCheckResult.truthValues);
-        }
+    STORM_LOG_THROW(first.states == secondCheckResult.states && first.truthValues.size() == secondCheckResult.truthValues.size(),
+                    storm::exceptions::InvalidOperationException, "Cannot perform logical 'and' on check results of incompatible type.");
+    if (logicalAnd) {
+        first.truthValues &= secondCheckResult.truthValues;
     } else {
-        std::function<bool(bool, bool)> function = logicalAnd ? std::function<bool(bool, bool)>([](bool a, bool b) { return a && b; })
-                                                              : std::function<bool(bool, bool)>([](bool a, bool b) { return a || b; });
-
-        map_type& map1 = boost::get<map_type>(first.truthValues);
-        map_type const& map2 = boost::get<map_type>(secondCheckResult.truthValues);
-        for (auto& element1 : map1) {
-            auto const& keyValuePair = map2.find(element1.first);
-            STORM_LOG_THROW(keyValuePair != map2.end(), storm::exceptions::InvalidOperationException,
-                            "Cannot perform logical 'and' on check results of incompatible type.");
-            element1.second = function(element1.second, keyValuePair->second);
-        }
-
-        // Double-check that there are no entries in map2 that the current result does not have.
-        for (auto const& element2 : map2) {
-            auto const& keyValuePair = map1.find(element2.first);
-            STORM_LOG_THROW(keyValuePair != map1.end(), storm::exceptions::InvalidOperationException,
-                            "Cannot perform logical 'and' on check results of incompatible type.");
-        }
+        first.truthValues |= secondCheckResult.truthValues;
     }
 }
 
@@ -110,78 +74,53 @@ QualitativeCheckResult& ExplicitQualitativeCheckResult<ValueType>::operator|=(Qu
 
 template<typename ValueType>
 bool ExplicitQualitativeCheckResult<ValueType>::existsTrue() const {
-    if (this->isResultForAllStates()) {
-        return !boost::get<vector_type>(truthValues).empty();
-    } else {
-        for (auto& element : boost::get<map_type>(truthValues)) {
-            if (element.second) {
-                return true;
-            }
-        }
-        return false;
-    }
+    return !truthValues.empty();
 }
 
 template<typename ValueType>
 bool ExplicitQualitativeCheckResult<ValueType>::forallTrue() const {
-    if (this->isResultForAllStates()) {
-        return boost::get<vector_type>(truthValues).full();
-    } else {
-        for (auto& element : boost::get<map_type>(truthValues)) {
-            if (!element.second) {
-                return false;
-            }
-        }
-        return true;
-    }
+    return truthValues.full();
 }
 
 template<typename ValueType>
 uint64_t ExplicitQualitativeCheckResult<ValueType>::count() const {
-    if (this->isResultForAllStates()) {
-        return boost::get<vector_type>(truthValues).getNumberOfSetBits();
-    } else {
-        uint64_t result = 0;
-        for (auto& element : boost::get<map_type>(truthValues)) {
-            if (element.second) {
-                ++result;
-            }
-        }
-        return result;
+    return truthValues.getNumberOfSetBits();
+}
+
+template<typename ValueType>
+bool ExplicitQualitativeCheckResult<ValueType>::hasValueForState(storm::storage::sparse::state_type state) const {
+    if (states) {
+        return state < states->size() && states->get(state);
     }
+    return state < truthValues.size();
+}
+
+template<typename ValueType>
+uint64_t ExplicitQualitativeCheckResult<ValueType>::getOffset(storm::storage::sparse::state_type state) const {
+    STORM_LOG_THROW(this->hasValueForState(state), storm::exceptions::InvalidOperationException, "Unknown key '" << state << "'.");
+    return states ? states->getNumberOfSetBitsBeforeIndex(state) : state;
 }
 
 template<typename ValueType>
 bool ExplicitQualitativeCheckResult<ValueType>::operator[](storm::storage::sparse::state_type state) const {
-    if (this->isResultForAllStates()) {
-        return boost::get<vector_type>(truthValues).get(state);
-    } else {
-        map_type const& map = boost::get<map_type>(truthValues);
-        auto const& keyValuePair = map.find(state);
-        STORM_LOG_THROW(keyValuePair != map.end(), storm::exceptions::InvalidOperationException, "Unknown key '" << state << "'.");
-        return keyValuePair->second;
-    }
+    return truthValues.get(this->getOffset(state));
+}
+
+template<typename ValueType>
+storm::storage::BitVector const& ExplicitQualitativeCheckResult<ValueType>::getStates() const {
+    STORM_LOG_THROW(!this->isResultForAllStates(), storm::exceptions::InvalidOperationException,
+                    "Unable to retrieve the states of a result that is for all states.");
+    return *states;
 }
 
 template<typename ValueType>
 typename ExplicitQualitativeCheckResult<ValueType>::vector_type const& ExplicitQualitativeCheckResult<ValueType>::getTruthValuesVector() const {
-    return boost::get<vector_type>(truthValues);
-}
-
-template<typename ValueType>
-typename ExplicitQualitativeCheckResult<ValueType>::map_type const& ExplicitQualitativeCheckResult<ValueType>::getTruthValuesMap() const {
-    return boost::get<map_type>(truthValues);
+    return truthValues;
 }
 
 template<typename ValueType>
 void ExplicitQualitativeCheckResult<ValueType>::complement() {
-    if (this->isResultForAllStates()) {
-        boost::get<vector_type>(truthValues).complement();
-    } else {
-        for (auto& element : boost::get<map_type>(truthValues)) {
-            element.second = !element.second;
-        }
-    }
+    truthValues.complement();
 }
 
 template<typename ValueType>
@@ -191,7 +130,7 @@ bool ExplicitQualitativeCheckResult<ValueType>::isExplicit() const {
 
 template<typename ValueType>
 bool ExplicitQualitativeCheckResult<ValueType>::isResultForAllStates() const {
-    return truthValues.which() == 0;
+    return !states.has_value();
 }
 
 template<typename ValueType>
@@ -201,44 +140,16 @@ bool ExplicitQualitativeCheckResult<ValueType>::isExplicitQualitativeCheckResult
 
 template<typename ValueType>
 std::ostream& ExplicitQualitativeCheckResult<ValueType>::writeToStream(std::ostream& out) const {
-    if (this->isResultForAllStates()) {
-        vector_type const& vector = boost::get<vector_type>(truthValues);
-        bool allTrue = vector.full();
-        bool allFalse = !allTrue && vector.empty();
-        if (allTrue) {
-            out << "{true}";
-        } else if (allFalse) {
-            out << "{false}";
-        } else {
-            out << "{true, false}";
-        }
+    if (!this->isResultForAllStates() && truthValues.size() == 1) {
+        std::ios::fmtflags oldflags(out.flags());
+        out << std::boolalpha << truthValues.get(0);
+        out.flags(oldflags);
+    } else if (truthValues.full()) {
+        out << "{true}";
+    } else if (truthValues.empty()) {
+        out << "{false}";
     } else {
-        std::ios::fmtflags oldflags(std::cout.flags());
-        out << std::boolalpha;
-
-        map_type const& map = boost::get<map_type>(truthValues);
-        if (map.size() == 1) {
-            out << map.begin()->second;
-        } else {
-            bool allTrue = true;
-            bool allFalse = true;
-            for (auto const& entry : map) {
-                if (entry.second) {
-                    allFalse = false;
-                } else {
-                    allTrue = false;
-                }
-            }
-            if (allTrue) {
-                out << "{true}";
-            } else if (allFalse) {
-                out << "{false}";
-            } else {
-                out << "{true, false}";
-            }
-        }
-
-        std::cout.flags(oldflags);
+        out << "{true, false}";
     }
     return out;
 }
@@ -251,27 +162,20 @@ void ExplicitQualitativeCheckResult<ValueType>::filter(QualitativeCheckResult co
     ExplicitQualitativeCheckResult<ValueType> const& explicitFilter = filter.template asExplicitQualitativeCheckResult<ValueType>();
     vector_type const& filterTruthValues = explicitFilter.getTruthValuesVector();
 
-    if (this->isResultForAllStates()) {
-        map_type newMap;
-        for (auto element : filterTruthValues) {
-            newMap.emplace(element, this->getTruthValuesVector().get(element));
-        }
-        this->truthValues = newMap;
-    } else {
-        map_type const& map = boost::get<map_type>(truthValues);
+    // Line the filter up with the states this result has truth values for. The two need not span the same range
+    // of states, e.g. if this result holds a truth value for a single state only.
+    uint64_t const numStates = std::max(filterTruthValues.size(), states ? states->size() : truthValues.size());
+    storm::storage::BitVector available = states ? *states : storm::storage::BitVector(truthValues.size(), true);
+    available.resize(numStates);
+    storm::storage::BitVector selected(filterTruthValues);
+    selected.resize(numStates);
+    STORM_LOG_THROW(selected.isSubsetOf(available), storm::exceptions::InvalidOperationException,
+                    "The check result fails to contain some results referred to by the filter.");
 
-        map_type newMap;
-        for (auto const& element : map) {
-            if (filterTruthValues.get(element.first)) {
-                newMap.insert(element);
-            }
-        }
-
-        STORM_LOG_THROW(newMap.size() == filterTruthValues.getNumberOfSetBits(), storm::exceptions::InvalidOperationException,
-                        "The check result fails to contain some results referred to by the filter.");
-
-        this->truthValues = newMap;
-    }
+    // Keep the truth values of the selected states. Note that the result is a result for the selected states
+    // even if those happen to be all of them.
+    truthValues = truthValues % (selected % available);
+    states = filterTruthValues;
 }
 
 template<typename ValueType>
@@ -319,17 +223,9 @@ template<typename JsonRationalType>
 storm::json<JsonRationalType> ExplicitQualitativeCheckResult<ValueType>::toJson(std::optional<storm::storage::sparse::Valuations> const& stateValuations,
                                                                                 std::optional<storm::models::sparse::StateLabeling> const& stateLabels) const {
     storm::json<JsonRationalType> result;
-    if (this->isResultForAllStates()) {
-        vector_type const& valuesAsVector = boost::get<vector_type>(truthValues);
-        for (uint64_t state = 0; state < valuesAsVector.size(); ++state) {
-            insertJsonEntry(result, state, valuesAsVector.get(state), stateValuations, stateLabels);
-        }
-    } else {
-        map_type const& valuesAsMap = boost::get<map_type>(truthValues);
-        for (auto const& stateValue : valuesAsMap) {
-            insertJsonEntry(result, stateValue.first, stateValue.second, stateValuations, stateLabels);
-        }
-    }
+    this->forEachState([&](storm::storage::sparse::state_type state, uint64_t offset) {
+        insertJsonEntry(result, state, truthValues.get(offset), stateValuations, stateLabels);
+    });
     return result;
 }
 

--- a/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
@@ -172,8 +172,6 @@ void ExplicitQualitativeCheckResult<ValueType>::filter(QualitativeCheckResult co
     STORM_LOG_THROW(selected.isSubsetOf(available), storm::exceptions::InvalidOperationException,
                     "The check result fails to contain some results referred to by the filter.");
 
-    // Keep the truth values of the selected states. Note that the result is a result for the selected states
-    // even if those happen to be all of them.
     truthValues = truthValues % (selected % available);
     states = filterTruthValues;
 }

--- a/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <boost/variant.hpp>
-#include <map>
 #include <optional>
 
 #include "storm/adapters/JsonForward.h"
@@ -16,24 +14,38 @@ namespace storm {
 
 namespace modelchecker {
 
+/*!
+ * A qualitative check result over the states of a sparse model.
+ *
+ * The result either covers every state of the model or just a subset of them, e.g. after filtering it to the
+ * initial states. In the latter case the states in question are recorded in a bit vector and the truth values are
+ * stored compressed, i.e. the i-th truth value belongs to the i-th state selected by that bit vector.
+ */
 template<typename ValueType>
 class ExplicitQualitativeCheckResult : public QualitativeCheckResult {
    public:
     typedef storm::storage::BitVector vector_type;
-    typedef std::map<storm::storage::sparse::state_type, bool> map_type;
 
-    ExplicitQualitativeCheckResult();
-    virtual ~ExplicitQualitativeCheckResult() = default;
-    ExplicitQualitativeCheckResult(map_type const& map);
-    ExplicitQualitativeCheckResult(map_type&& map);
+    /*!
+     * Creates a result that holds the given truth value for the given state only.
+     */
     ExplicitQualitativeCheckResult(storm::storage::sparse::state_type state, bool value);
-    ExplicitQualitativeCheckResult(vector_type const& truthValues);
-    ExplicitQualitativeCheckResult(vector_type&& truthValues);
-    ExplicitQualitativeCheckResult(boost::variant<vector_type, map_type> const& truthValues,
-                                   std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
-    ExplicitQualitativeCheckResult(boost::variant<vector_type, map_type>&& truthValues,
+
+    /*!
+     * Creates a result for all states of a model with as many states as the given bit vector has bits.
+     */
+    ExplicitQualitativeCheckResult(vector_type const& truthValues, std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
+    ExplicitQualitativeCheckResult(vector_type&& truthValues, std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
+
+    /*!
+     * Creates a result for the given states only.
+     * @param states The states the result is for.
+     * @param truthValues One truth value per state selected by @p states, in the order of the selected states.
+     */
+    ExplicitQualitativeCheckResult(storm::storage::BitVector states, vector_type&& truthValues,
                                    std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
 
+    virtual ~ExplicitQualitativeCheckResult() = default;
     ExplicitQualitativeCheckResult(ExplicitQualitativeCheckResult const& other) = default;
     ExplicitQualitativeCheckResult& operator=(ExplicitQualitativeCheckResult const& other) = default;
     ExplicitQualitativeCheckResult(ExplicitQualitativeCheckResult&& other) = default;
@@ -41,7 +53,11 @@ class ExplicitQualitativeCheckResult : public QualitativeCheckResult {
 
     virtual std::unique_ptr<CheckResult> clone() const override;
 
-    bool operator[](storm::storage::sparse::state_type index) const;
+    /*!
+     * Retrieves the truth value of the given state.
+     * @pre The result holds a truth value for that state.
+     */
+    bool operator[](storm::storage::sparse::state_type state) const;
 
     virtual bool isExplicit() const override;
     virtual bool isResultForAllStates() const override;
@@ -52,8 +68,22 @@ class ExplicitQualitativeCheckResult : public QualitativeCheckResult {
     virtual QualitativeCheckResult& operator|=(QualitativeCheckResult const& other) override;
     virtual void complement() override;
 
+    /*!
+     * Retrieves whether the result holds a truth value for the given state.
+     */
+    bool hasValueForState(storm::storage::sparse::state_type state) const;
+
+    /*!
+     * Retrieves the states this result holds truth values for.
+     * @pre This is not a result for all states.
+     */
+    storm::storage::BitVector const& getStates() const;
+
+    /*!
+     * Retrieves the truth values, one per state this result is for. If this is not a result for all states, the
+     * i-th truth value belongs to the i-th state selected by getStates().
+     */
     vector_type const& getTruthValuesVector() const;
-    map_type const& getTruthValuesMap() const;
 
     virtual bool existsTrue() const override;
     virtual bool forallTrue() const override;
@@ -79,8 +109,36 @@ class ExplicitQualitativeCheckResult : public QualitativeCheckResult {
 
     static void performLogicalOperation(ExplicitQualitativeCheckResult& first, QualitativeCheckResult const& second, bool logicalAnd);
 
-    // The values of the quantitative check result.
-    boost::variant<vector_type, map_type> truthValues;
+    /*!
+     * Retrieves the index at which the truth value of the given state is stored.
+     * @pre The result holds a truth value for that state.
+     */
+    uint64_t getOffset(storm::storage::sparse::state_type state) const;
+
+    /*!
+     * Invokes the given function with the state and the offset of its truth value, for every state this result is
+     * for.
+     */
+    template<typename Function>
+    void forEachState(Function const& f) const {
+        if (states) {
+            uint64_t offset = 0;
+            for (auto const& state : *states) {
+                f(state, offset);
+                ++offset;
+            }
+        } else {
+            for (uint64_t state = 0; state < truthValues.size(); ++state) {
+                f(state, state);
+            }
+        }
+    }
+
+    // The states this result holds truth values for, or nothing at all if it is a result for all states.
+    std::optional<storm::storage::BitVector> states;
+
+    // The truth values of the qualitative check result, one per state this result is for.
+    vector_type truthValues;
 
     // An optional scheduler that accompanies the values.
     std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler;

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -2,13 +2,13 @@
 
 #include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
 
+#include <algorithm>
+
 #include "storm/adapters/JsonAdapter.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
-#include "storm/exceptions/InvalidAccessException.h"
 #include "storm/exceptions/InvalidOperationException.h"
 #include "storm/exceptions/NotSupportedException.h"
 #include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
-#include "storm/storage/BitVector.h"
 #include "storm/utility/constants.h"
 #include "storm/utility/macros.h"
 #include "storm/utility/vector.h"
@@ -16,93 +16,38 @@
 namespace storm {
 namespace modelchecker {
 
-namespace detail {
-/*!
- * Restricts the given values to the states selected by the filter. Note that the result is always a map, even
- * if the given values are a vector.
- */
-template<typename ValueType>
-boost::variant<std::vector<ValueType>, std::map<storm::storage::sparse::state_type, ValueType>> filterValues(
-    boost::variant<std::vector<ValueType>, std::map<storm::storage::sparse::state_type, ValueType>> const& values,
-    storm::storage::BitVector const& filterTruthValues) {
-    typedef std::vector<ValueType> vector_type;
-    typedef std::map<storm::storage::sparse::state_type, ValueType> map_type;
-
-    map_type newMap;
-    if (values.which() == 0) {
-        vector_type const& valuesAsVector = boost::get<vector_type>(values);
-        for (auto element : filterTruthValues) {
-            STORM_LOG_THROW(element < valuesAsVector.size(), storm::exceptions::InvalidAccessException, "Invalid index in results.");
-            newMap.emplace(element, valuesAsVector[element]);
-        }
-    } else {
-        for (auto const& element : boost::get<map_type>(values)) {
-            if (filterTruthValues.get(element.first)) {
-                newMap.insert(element);
-            }
-        }
-        STORM_LOG_THROW(newMap.size() == filterTruthValues.getNumberOfSetBits(), storm::exceptions::InvalidOperationException,
-                        "The check result fails to contain some results referred to by the filter.");
-    }
-    return newMap;
-}
-
-/*!
- * Replaces every value by one minus that value.
- */
-template<typename ValueType>
-void complementValues(boost::variant<std::vector<ValueType>, std::map<storm::storage::sparse::state_type, ValueType>>& values) {
-    typedef std::vector<ValueType> vector_type;
-    typedef std::map<storm::storage::sparse::state_type, ValueType> map_type;
-
-    if (values.which() == 0) {
-        for (auto& element : boost::get<vector_type>(values)) {
-            element = storm::utility::one<ValueType>() - element;
-        }
-    } else {
-        for (auto& element : boost::get<map_type>(values)) {
-            element.second = storm::utility::one<ValueType>() - element.second;
-        }
-    }
-}
-}  // namespace detail
-
-template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult() : values(map_type()) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(map_type const& values) : values(values) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(map_type&& values) : values(std::move(values)) {
-    // Intentionally left empty.
-}
-
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(storm::storage::sparse::state_type const& state, ExtendedValueType const& value)
-    : values(map_type()) {
-    boost::get<map_type>(values).emplace(state, value);
+    : states(storm::storage::BitVector(state + 1)), values({value}) {
+    states->set(state);
 }
 
 template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(vector_type const& values) : values(values) {
+ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(vector_type const& values,
+                                                                            std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
+    : values(values), scheduler(scheduler) {
     // Intentionally left empty.
 }
 
 template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(vector_type&& values) : values(std::move(values)) {
+ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(vector_type&& values,
+                                                                            std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
+    : values(std::move(values)), scheduler(scheduler) {
     // Intentionally left empty.
+}
+
+template<typename ValueType>
+ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(storm::storage::BitVector states, vector_type&& values,
+                                                                            std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
+    : states(std::move(states)), values(std::move(values)), scheduler(scheduler) {
+    STORM_LOG_ASSERT(this->states->getNumberOfSetBits() == this->values.size(), "Expected one value per selected state.");
 }
 
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(std::vector<ValueType> const& values)
     requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
-    : values(map_type()) {
-    this->values = storm::utility::fromSentinel(std::vector<ValueType>(values));
+    : values(storm::utility::fromSentinel(std::vector<ValueType>(values))) {
+    // Intentionally left empty.
 }
 
 template<typename ValueType>
@@ -113,148 +58,153 @@ ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(std:
 }
 
 template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(std::map<storm::storage::sparse::state_type, ValueType> const& values)
+ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(storm::storage::BitVector states, std::vector<ValueType>&& values)
     requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
-    : values(map_type()) {
-    map_type& widened = boost::get<map_type>(this->values);
-    for (auto const& stateValue : values) {
-        widened.emplace(stateValue.first, storm::utility::fromSentinel(stateValue.second));
-    }
-}
-
-template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(boost::variant<vector_type, map_type> const& values,
-                                                                            std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
-    : values(values), scheduler(scheduler) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(boost::variant<vector_type, map_type>&& values,
-                                                                            std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
-    : values(std::move(values)), scheduler(scheduler) {
-    // Intentionally left empty.
+    : states(std::move(states)), values(storm::utility::fromSentinel(std::move(values))) {
+    STORM_LOG_ASSERT(this->states->getNumberOfSetBits() == this->values.size(), "Expected one value per selected state.");
 }
 
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(ExplicitQualitativeCheckResult<ValueType> const& other) {
-    if (other.isResultForAllStates()) {
-        storm::storage::BitVector const& bvValues = other.getTruthValuesVector();
+    auto const toValue = [](bool truthValue) { return truthValue ? storm::utility::one<ExtendedValueType>() : storm::utility::zero<ExtendedValueType>(); };
 
-        vector_type newVector;
-        newVector.reserve(bvValues.size());
-        for (std::size_t i = 0, n = bvValues.size(); i < n; i++) {
-            newVector.push_back(bvValues.get(i) ? storm::utility::one<ValueType>() : storm::utility::zero<ValueType>());
-        }
-
-        values = newVector;
-    } else {
-        typename ExplicitQualitativeCheckResult<ValueType>::map_type const& bitMap = other.getTruthValuesMap();
-
-        map_type newMap;
-        for (auto const& e : bitMap) {
-            newMap[e.first] = e.second ? storm::utility::one<ValueType>() : storm::utility::zero<ValueType>();
-        }
-
-        values = newMap;
+    storm::storage::BitVector const& truthValues = other.getTruthValuesVector();
+    values.reserve(truthValues.size());
+    for (std::size_t i = 0, n = truthValues.size(); i < n; i++) {
+        values.push_back(toValue(truthValues.get(i)));
+    }
+    if (!other.isResultForAllStates()) {
+        states = other.getStates();
     }
 }
 
 template<typename ValueType>
 std::unique_ptr<CheckResult> ExplicitQuantitativeCheckResult<ValueType>::clone() const {
-    auto result = std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(this->values, this->scheduler);
-    result->lowerBounds = this->lowerBounds;
-    result->upperBounds = this->upperBounds;
-    return result;
+    return std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(*this);
+}
+
+template<typename ValueType>
+bool ExplicitQuantitativeCheckResult<ValueType>::hasValueForState(storm::storage::sparse::state_type state) const {
+    if (states) {
+        return state < states->size() && states->get(state);
+    }
+    return state < values.size();
+}
+
+template<typename ValueType>
+uint64_t ExplicitQuantitativeCheckResult<ValueType>::getOffset(storm::storage::sparse::state_type state) const {
+    STORM_LOG_THROW(this->hasValueForState(state), storm::exceptions::InvalidOperationException, "Unknown key '" << state << "'.");
+    return states ? states->getNumberOfSetBitsBeforeIndex(state) : state;
+}
+
+template<typename ValueType>
+storm::storage::BitVector const& ExplicitQuantitativeCheckResult<ValueType>::getStates() const {
+    STORM_LOG_THROW(!this->isResultForAllStates(), storm::exceptions::InvalidOperationException,
+                    "Unable to retrieve the states of a result that is for all states.");
+    return *states;
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::vector_type const& ExplicitQuantitativeCheckResult<ValueType>::getValueVector() const {
-    return boost::get<vector_type>(values);
+    return values;
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::vector_type& ExplicitQuantitativeCheckResult<ValueType>::getValueVector() {
-    return boost::get<vector_type>(values);
-}
-
-template<typename ValueType>
-typename ExplicitQuantitativeCheckResult<ValueType>::map_type const& ExplicitQuantitativeCheckResult<ValueType>::getValueMap() const {
-    return boost::get<map_type>(values);
+    return values;
 }
 
 template<typename ValueType>
 std::vector<ValueType> ExplicitQuantitativeCheckResult<ValueType>::getFiniteValueVector() const {
-    return storm::utility::narrowFinite<ValueType>(boost::get<vector_type>(values));
+    return storm::utility::narrowFinite<ValueType>(values);
+}
+
+template<typename ValueType>
+std::vector<ValueType> ExplicitQuantitativeCheckResult<ValueType>::getSentinelValueVector() const {
+    if constexpr (!std::is_same_v<ExtendedValueType, ValueType>) {
+        std::vector<ValueType> result;
+        result.reserve(values.size());
+        for (auto const& value : values) {
+            result.push_back(storm::utility::toSentinel<ValueType>(value));
+        }
+        return result;
+    } else {
+        return values;
+    }
 }
 
 template<typename ValueType>
 bool ExplicitQuantitativeCheckResult<ValueType>::hasLowerBounds() const {
-    return lowerBounds.has_value();
+    return bounds.hasLower();
 }
 
 template<typename ValueType>
 bool ExplicitQuantitativeCheckResult<ValueType>::hasUpperBounds() const {
-    return upperBounds.has_value();
+    return bounds.hasUpper();
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::vector_type const& ExplicitQuantitativeCheckResult<ValueType>::getLowerBoundVector() const {
     STORM_LOG_THROW(this->hasLowerBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown lower bounds.");
-    return boost::get<vector_type>(*lowerBounds);
+    return *bounds.lower;
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::vector_type const& ExplicitQuantitativeCheckResult<ValueType>::getUpperBoundVector() const {
     STORM_LOG_THROW(this->hasUpperBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown upper bounds.");
-    return boost::get<vector_type>(*upperBounds);
+    return *bounds.upper;
 }
 
 template<typename ValueType>
-typename ExplicitQuantitativeCheckResult<ValueType>::map_type const& ExplicitQuantitativeCheckResult<ValueType>::getLowerBoundMap() const {
-    STORM_LOG_THROW(this->hasLowerBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown lower bounds.");
-    return boost::get<map_type>(*lowerBounds);
+storm::solver::SolutionBounds<typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType> const&
+ExplicitQuantitativeCheckResult<ValueType>::getSolutionBounds() const {
+    return bounds;
 }
 
 template<typename ValueType>
-typename ExplicitQuantitativeCheckResult<ValueType>::map_type const& ExplicitQuantitativeCheckResult<ValueType>::getUpperBoundMap() const {
-    STORM_LOG_THROW(this->hasUpperBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown upper bounds.");
-    return boost::get<map_type>(*upperBounds);
+void ExplicitQuantitativeCheckResult<ValueType>::assertBoundsShape([[maybe_unused]] vector_type const& bounds) const {
+    STORM_LOG_ASSERT(bounds.size() == values.size(), "Bounds must have the same size as the values.");
 }
 
 template<typename ValueType>
-void ExplicitQuantitativeCheckResult<ValueType>::assertBoundsShape([[maybe_unused]] boost::variant<vector_type, map_type> const& bounds) const {
-    STORM_LOG_ASSERT(bounds.which() == values.which(), "Bounds must have the same shape as the values.");
-    if (this->isResultForAllStates()) {
-        STORM_LOG_ASSERT(boost::get<vector_type>(bounds).size() == boost::get<vector_type>(values).size(), "Bounds must have the same size as the values.");
-    } else {
-        STORM_LOG_ASSERT(boost::get<map_type>(bounds).size() == boost::get<map_type>(values).size(), "Bounds must have the same size as the values.");
+void ExplicitQuantitativeCheckResult<ValueType>::setLowerBounds(vector_type lowerBounds) {
+    this->assertBoundsShape(lowerBounds);
+    this->bounds.lower = std::move(lowerBounds);
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::setUpperBounds(vector_type upperBounds) {
+    this->assertBoundsShape(upperBounds);
+    this->bounds.upper = std::move(upperBounds);
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::setBounds(storm::solver::SolutionBounds<ExtendedValueType> bounds) {
+    // Each of the two sides is transferred only if the algorithm in question established it; the other side is
+    // left as it is.
+    if (bounds.hasLower()) {
+        this->setLowerBounds(std::move(*bounds.lower));
+    }
+    if (bounds.hasUpper()) {
+        this->setUpperBounds(std::move(*bounds.upper));
     }
 }
 
 template<typename ValueType>
-void ExplicitQuantitativeCheckResult<ValueType>::setLowerBounds(boost::variant<vector_type, map_type> lowerBounds) {
-    this->assertBoundsShape(lowerBounds);
-    this->lowerBounds = std::move(lowerBounds);
-}
-
-template<typename ValueType>
-void ExplicitQuantitativeCheckResult<ValueType>::setUpperBounds(boost::variant<vector_type, map_type> upperBounds) {
-    this->assertBoundsShape(upperBounds);
-    this->upperBounds = std::move(upperBounds);
-}
-
-template<typename ValueType>
-void ExplicitQuantitativeCheckResult<ValueType>::setBounds(boost::variant<vector_type, map_type> lowerBounds,
-                                                           boost::variant<vector_type, map_type> upperBounds) {
-    this->setLowerBounds(std::move(lowerBounds));
-    this->setUpperBounds(std::move(upperBounds));
+void ExplicitQuantitativeCheckResult<ValueType>::setBounds(storm::solver::SolutionBounds<ValueType> bounds)
+    requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
+{
+    if (bounds.hasLower()) {
+        this->setLowerBounds(storm::utility::fromSentinel(std::move(*bounds.lower)));
+    }
+    if (bounds.hasUpper()) {
+        this->setUpperBounds(storm::utility::fromSentinel(std::move(*bounds.upper)));
+    }
 }
 
 template<typename ValueType>
 void ExplicitQuantitativeCheckResult<ValueType>::clearBounds() {
-    lowerBounds = std::nullopt;
-    upperBounds = std::nullopt;
+    bounds.clear();
 }
 
 template<typename ValueType>
@@ -266,62 +216,47 @@ void ExplicitQuantitativeCheckResult<ValueType>::filter(QualitativeCheckResult c
     ExplicitQualitativeCheckResult<ValueType> const& explicitFilter = filter.template asExplicitQualitativeCheckResult<ValueType>();
     typename ExplicitQualitativeCheckResult<ValueType>::vector_type const& filterTruthValues = explicitFilter.getTruthValuesVector();
 
+    // Line the filter up with the states this result has values for. The two need not span the same range of
+    // states, e.g. if this result holds a value for a single state only.
+    uint64_t const numStates = std::max(filterTruthValues.size(), states ? states->size() : values.size());
+    storm::storage::BitVector available = states ? *states : storm::storage::BitVector(values.size(), true);
+    available.resize(numStates);
+    storm::storage::BitVector selected(filterTruthValues);
+    selected.resize(numStates);
+    STORM_LOG_THROW(selected.isSubsetOf(available), storm::exceptions::InvalidOperationException,
+                    "The check result fails to contain some results referred to by the filter.");
+
+    // The entries that survive, in the index space the values are stored in. Note that the result is a result
+    // for the selected states even if those happen to be all of them.
+    storm::storage::BitVector const keep = selected % available;
+
     if (this->hasLowerBounds()) {
-        this->lowerBounds = detail::filterValues<ExtendedValueType>(*this->lowerBounds, filterTruthValues);
+        bounds.lower = storm::utility::vector::filterVector(*bounds.lower, keep);
     }
     if (this->hasUpperBounds()) {
-        this->upperBounds = detail::filterValues<ExtendedValueType>(*this->upperBounds, filterTruthValues);
+        bounds.upper = storm::utility::vector::filterVector(*bounds.upper, keep);
     }
-    this->values = detail::filterValues<ExtendedValueType>(this->values, filterTruthValues);
-}
-
-template<typename ValueType>
-std::vector<ValueType> ExplicitQuantitativeCheckResult<ValueType>::getSentinelValueVector() const {
-    vector_type const& valuesAsVector = boost::get<vector_type>(values);
-    if constexpr (!std::is_same_v<ExtendedValueType, ValueType>) {
-        std::vector<ValueType> result;
-        result.reserve(valuesAsVector.size());
-        for (auto const& value : valuesAsVector) {
-            result.push_back(storm::utility::toSentinel<ValueType>(value));
-        }
-        return result;
-    } else {
-        return valuesAsVector;
-    }
+    values = storm::utility::vector::filterVector(values, keep);
+    states = filterTruthValues;
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQuantitativeCheckResult<ValueType>::getMin() const {
     STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Minimum of empty set is not defined.");
-
-    if (this->isResultForAllStates()) {
-        return storm::utility::minimum(boost::get<vector_type>(values));
-    } else {
-        return storm::utility::minimum(boost::get<map_type>(values));
-    }
+    return storm::utility::minimum(values);
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQuantitativeCheckResult<ValueType>::getMax() const {
-    STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Minimum of empty set is not defined.");
-
-    if (this->isResultForAllStates()) {
-        return storm::utility::maximum(boost::get<vector_type>(values));
-    } else {
-        return storm::utility::maximum(boost::get<map_type>(values));
-    }
+    STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Maximum of empty set is not defined.");
+    return storm::utility::maximum(values);
 }
 
 template<typename ValueType>
 std::pair<typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType, typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType>
 ExplicitQuantitativeCheckResult<ValueType>::getMinMax() const {
     STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Minimum/maximum of empty set is not defined.");
-
-    if (this->isResultForAllStates()) {
-        return storm::utility::minmax(boost::get<vector_type>(values));
-    } else {
-        return storm::utility::minmax(boost::get<map_type>(values));
-    }
+    return storm::utility::minmax(values);
 }
 
 template<typename ValueType>
@@ -329,18 +264,10 @@ typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQ
     STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Sum of empty set is not defined.");
 
     ExtendedValueType sum = storm::utility::zero<ExtendedValueType>();
-    if (this->isResultForAllStates()) {
-        for (auto const& element : boost::get<vector_type>(values)) {
-            STORM_LOG_THROW(!storm::utility::isInfinity(element), storm::exceptions::InvalidOperationException,
-                            "Cannot compute the sum of values containing infinity.");
-            sum += element;
-        }
-    } else {
-        for (auto const& element : boost::get<map_type>(values)) {
-            STORM_LOG_THROW(!storm::utility::isInfinity(element.second), storm::exceptions::InvalidOperationException,
-                            "Cannot compute the sum of values containing infinity.");
-            sum += element.second;
-        }
+    for (auto const& element : values) {
+        STORM_LOG_THROW(!storm::utility::isInfinity(element), storm::exceptions::InvalidOperationException,
+                        "Cannot compute the sum of values containing infinity.");
+        sum += element;
     }
     return sum;
 }
@@ -350,23 +277,12 @@ typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQ
     STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Average of empty set is not defined.");
 
     ExtendedValueType sum = storm::utility::zero<ExtendedValueType>();
-    uint64_t count = 0;
-    if (this->isResultForAllStates()) {
-        for (auto const& element : boost::get<vector_type>(values)) {
-            STORM_LOG_THROW(!storm::utility::isInfinity(element), storm::exceptions::InvalidOperationException,
-                            "Cannot compute the average of values containing infinity.");
-            sum += element;
-        }
-        count = boost::get<vector_type>(values).size();
-    } else {
-        for (auto const& element : boost::get<map_type>(values)) {
-            STORM_LOG_THROW(!storm::utility::isInfinity(element.second), storm::exceptions::InvalidOperationException,
-                            "Cannot compute the average of values containing infinity.");
-            sum += element.second;
-        }
-        count = boost::get<map_type>(values).size();
+    for (auto const& element : values) {
+        STORM_LOG_THROW(!storm::utility::isInfinity(element), storm::exceptions::InvalidOperationException,
+                        "Cannot compute the average of values containing infinity.");
+        sum += element;
     }
-    return sum / storm::utility::convertNumber<ExtendedValueType, uint64_t>(count);
+    return sum / storm::utility::convertNumber<ExtendedValueType, uint64_t>(values.size());
 }
 
 template<typename ValueType>
@@ -429,8 +345,8 @@ void printRange(std::ostream& out, ValueType const& min, ValueType const& max) {
 }
 
 template<typename ValueType>
-void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, storm::storage::sparse::state_type state) const {
-    print(out, (*this)[state]);
+void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, uint64_t offset) const {
+    print(out, values[offset]);
     if (!this->hasLowerBounds() && !this->hasUpperBounds()) {
         return;
     }
@@ -438,13 +354,13 @@ void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, s
     // that is printed for large results below.
     out << " [";
     if (this->hasLowerBounds()) {
-        print(out, this->isResultForAllStates() ? this->getLowerBoundVector()[state] : this->getLowerBoundMap().at(state));
+        print(out, this->getLowerBoundVector()[offset]);
     } else {
         out << "-inf";
     }
     out << ", ";
     if (this->hasUpperBounds()) {
-        print(out, this->isResultForAllStates() ? this->getUpperBoundVector()[state] : this->getUpperBoundMap().at(state));
+        print(out, this->getUpperBoundVector()[offset]);
     } else {
         out << "inf";
     }
@@ -454,51 +370,21 @@ void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, s
 template<typename ValueType>
 std::ostream& ExplicitQuantitativeCheckResult<ValueType>::writeToStream(std::ostream& out) const {
     bool minMaxSupported = std::is_same<ValueType, double>::value || std::is_same<ValueType, storm::RationalNumber>::value;
-    bool printAsRange = false;
 
-    if (this->isResultForAllStates()) {
-        vector_type const& valuesAsVector = boost::get<vector_type>(values);
-        if (valuesAsVector.size() >= 10 && minMaxSupported) {
-            printAsRange = true;
-        } else {
-            out << "{";
-            bool first = true;
-            for (uint64_t state = 0; state < valuesAsVector.size(); ++state) {
-                if (!first) {
-                    out << ", ";
-                } else {
-                    first = false;
-                }
-                this->printValue(out, state);
-            }
-            out << "}";
-        }
-    } else {
-        map_type const& valuesAsMap = boost::get<map_type>(values);
-        if (valuesAsMap.size() >= 10 && minMaxSupported) {
-            printAsRange = true;
-        } else {
-            if (valuesAsMap.size() == 1) {
-                this->printValue(out, valuesAsMap.begin()->first);
-            } else {
-                out << "{";
-                bool first = true;
-                for (auto const& element : valuesAsMap) {
-                    if (!first) {
-                        out << ", ";
-                    } else {
-                        first = false;
-                    }
-                    this->printValue(out, element.first);
-                }
-                out << "}";
-            }
-        }
-    }
-
-    if (printAsRange) {
+    if (values.size() >= 10 && minMaxSupported) {
         std::pair<ExtendedValueType, ExtendedValueType> minmax = this->getMinMax();
         printRange(out, minmax.first, minmax.second);
+    } else if (!this->isResultForAllStates() && values.size() == 1) {
+        this->printValue(out, 0);
+    } else {
+        out << "{";
+        for (uint64_t offset = 0; offset < values.size(); ++offset) {
+            if (offset > 0) {
+                out << ", ";
+            }
+            this->printValue(out, offset);
+        }
+        out << "}";
     }
 
     return out;
@@ -507,66 +393,39 @@ std::ostream& ExplicitQuantitativeCheckResult<ValueType>::writeToStream(std::ost
 template<typename ValueType>
 std::unique_ptr<CheckResult> ExplicitQuantitativeCheckResult<ValueType>::compareAgainstBound(storm::logic::ComparisonType comparisonType,
                                                                                              ValueType const& bound) const {
+    auto const compare = [&comparisonType, &bound](ExtendedValueType const& value) {
+        switch (comparisonType) {
+            case logic::ComparisonType::Less:
+                return value < bound;
+            case logic::ComparisonType::LessEqual:
+                return value <= bound;
+            case logic::ComparisonType::Greater:
+                return value > bound;
+            case logic::ComparisonType::GreaterEqual:
+                return value >= bound;
+        }
+        return false;
+    };
+
+    // A comparison is only sound if the bound fall outside the lower and upperbound of te result.
+    if (this->hasLowerBounds() && this->hasUpperBounds()) {
+        for (uint64_t offset = 0; offset < values.size(); ++offset) {
+            STORM_LOG_ASSERT(!((*bounds.lower)[offset] < bound && bound < (*bounds.upper)[offset]),
+                             "The bound " << bound << " lies between the lower bound " << (*bounds.lower)[offset] << " and the upper bound "
+                                          << (*bounds.upper)[offset] << ", so the comparison against it is not decided at state " << offset << ".");
+        }
+    }
+
+    storm::storage::BitVector result(values.size());
+    for (uint64_t offset = 0; offset < values.size(); ++offset) {
+        if (compare(values[offset])) {
+            result.set(offset);
+        }
+    }
     if (this->isResultForAllStates()) {
-        vector_type const& valuesAsVector = boost::get<vector_type>(values);
-        storm::storage::BitVector result(valuesAsVector.size());
-        switch (comparisonType) {
-            case logic::ComparisonType::Less:
-                for (uint_fast64_t index = 0; index < valuesAsVector.size(); ++index) {
-                    if (valuesAsVector[index] < bound) {
-                        result.set(index);
-                    }
-                }
-                break;
-            case logic::ComparisonType::LessEqual:
-                for (uint_fast64_t index = 0; index < valuesAsVector.size(); ++index) {
-                    if (valuesAsVector[index] <= bound) {
-                        result.set(index);
-                    }
-                }
-                break;
-            case logic::ComparisonType::Greater:
-                for (uint_fast64_t index = 0; index < valuesAsVector.size(); ++index) {
-                    if (valuesAsVector[index] > bound) {
-                        result.set(index);
-                    }
-                }
-                break;
-            case logic::ComparisonType::GreaterEqual:
-                for (uint_fast64_t index = 0; index < valuesAsVector.size(); ++index) {
-                    if (valuesAsVector[index] >= bound) {
-                        result.set(index);
-                    }
-                }
-                break;
-        }
-        return std::unique_ptr<CheckResult>(new ExplicitQualitativeCheckResult<ValueType>(std::move(result), std::move(scheduler)));
+        return std::unique_ptr<CheckResult>(new ExplicitQualitativeCheckResult<ValueType>(std::move(result), scheduler));
     } else {
-        map_type const& valuesAsMap = boost::get<map_type>(values);
-        std::map<storm::storage::sparse::state_type, bool> result;
-        switch (comparisonType) {
-            case logic::ComparisonType::Less:
-                for (auto const& element : valuesAsMap) {
-                    result[element.first] = element.second < bound;
-                }
-                break;
-            case logic::ComparisonType::LessEqual:
-                for (auto const& element : valuesAsMap) {
-                    result[element.first] = element.second <= bound;
-                }
-                break;
-            case logic::ComparisonType::Greater:
-                for (auto const& element : valuesAsMap) {
-                    result[element.first] = element.second > bound;
-                }
-                break;
-            case logic::ComparisonType::GreaterEqual:
-                for (auto const& element : valuesAsMap) {
-                    result[element.first] = element.second >= bound;
-                }
-                break;
-        }
-        return std::unique_ptr<CheckResult>(new ExplicitQualitativeCheckResult<ValueType>(std::move(result), std::move(scheduler)));
+        return std::unique_ptr<CheckResult>(new ExplicitQualitativeCheckResult<ValueType>(*states, std::move(result), scheduler));
     }
 }
 
@@ -580,24 +439,13 @@ std::unique_ptr<CheckResult> ExplicitQuantitativeCheckResult<storm::RationalFunc
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType& ExplicitQuantitativeCheckResult<ValueType>::operator[](
     storm::storage::sparse::state_type state) {
-    if (this->isResultForAllStates()) {
-        return boost::get<vector_type>(values)[state];
-    } else {
-        return boost::get<map_type>(values)[state];
-    }
+    return values[this->getOffset(state)];
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType const& ExplicitQuantitativeCheckResult<ValueType>::operator[](
     storm::storage::sparse::state_type state) const {
-    if (this->isResultForAllStates()) {
-        return boost::get<vector_type>(values)[state];
-    } else {
-        map_type const& valuesAsMap = boost::get<map_type>(values);
-        auto const& keyValuePair = valuesAsMap.find(state);
-        STORM_LOG_THROW(keyValuePair != valuesAsMap.end(), storm::exceptions::InvalidOperationException, "Unknown key '" << state << "'.");
-        return keyValuePair->second;
-    }
+    return values[this->getOffset(state)];
 }
 
 template<typename ValueType>
@@ -607,7 +455,7 @@ bool ExplicitQuantitativeCheckResult<ValueType>::isExplicit() const {
 
 template<typename ValueType>
 bool ExplicitQuantitativeCheckResult<ValueType>::isResultForAllStates() const {
-    return values.which() == 0;
+    return !states.has_value();
 }
 
 template<typename ValueType>
@@ -617,15 +465,15 @@ bool ExplicitQuantitativeCheckResult<ValueType>::isExplicitQuantitativeCheckResu
 
 template<typename ValueType>
 void ExplicitQuantitativeCheckResult<ValueType>::oneMinus() {
-    detail::complementValues<ExtendedValueType>(values);
+    storm::utility::vector::subtractFromConstantOneVector(values);
     if (this->hasLowerBounds()) {
-        detail::complementValues<ExtendedValueType>(*lowerBounds);
+        storm::utility::vector::subtractFromConstantOneVector(*bounds.lower);
     }
     if (this->hasUpperBounds()) {
-        detail::complementValues<ExtendedValueType>(*upperBounds);
+        storm::utility::vector::subtractFromConstantOneVector(*bounds.upper);
     }
     // One minus is antitone, so what used to bound the values from below now bounds them from above.
-    std::swap(lowerBounds, upperBounds);
+    std::swap(bounds.lower, bounds.upper);
 }
 
 /*!
@@ -674,21 +522,11 @@ template<typename ValueType>
 storm::json<ValueType> ExplicitQuantitativeCheckResult<ValueType>::toJson(std::optional<storm::storage::sparse::Valuations> const& stateValuations,
                                                                           std::optional<storm::models::sparse::StateLabeling> const& stateLabels) const {
     storm::json<ValueType> result;
-    if (this->isResultForAllStates()) {
-        vector_type const& valuesAsVector = boost::get<vector_type>(values);
-        for (uint64_t state = 0; state < valuesAsVector.size(); ++state) {
-            insertJsonEntry(result, state, valuesAsVector[state], stateValuations, stateLabels,
-                            this->hasLowerBounds() ? std::make_optional(this->getLowerBoundVector()[state]) : std::nullopt,
-                            this->hasUpperBounds() ? std::make_optional(this->getUpperBoundVector()[state]) : std::nullopt);
-        }
-    } else {
-        map_type const& valuesAsMap = boost::get<map_type>(values);
-        for (auto const& stateValue : valuesAsMap) {
-            insertJsonEntry(result, stateValue.first, stateValue.second, stateValuations, stateLabels,
-                            this->hasLowerBounds() ? std::make_optional(this->getLowerBoundMap().at(stateValue.first)) : std::nullopt,
-                            this->hasUpperBounds() ? std::make_optional(this->getUpperBoundMap().at(stateValue.first)) : std::nullopt);
-        }
-    }
+    this->forEachState([&](storm::storage::sparse::state_type state, uint64_t offset) {
+        insertJsonEntry(result, state, values[offset], stateValuations, stateLabels,
+                        this->hasLowerBounds() ? std::make_optional(this->getLowerBoundVector()[offset]) : std::nullopt,
+                        this->hasUpperBounds() ? std::make_optional(this->getUpperBoundVector()[offset]) : std::nullopt);
+    });
     return result;
 }
 

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -46,21 +46,21 @@ ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(stor
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(std::vector<ValueType> const& values)
     requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
-    : values(storm::utility::fromSentinel(std::vector<ValueType>(values))) {
+    : values(storm::utility::widen(std::vector<ValueType>(values))) {
     // Intentionally left empty.
 }
 
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(std::vector<ValueType>&& values)
     requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
-    : values(storm::utility::fromSentinel(std::move(values))) {
+    : values(storm::utility::widen(std::move(values))) {
     // Intentionally left empty.
 }
 
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(storm::storage::BitVector states, std::vector<ValueType>&& values)
     requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
-    : states(std::move(states)), values(storm::utility::fromSentinel(std::move(values))) {
+    : states(std::move(states)), values(storm::utility::widen(std::move(values))) {
     STORM_LOG_ASSERT(this->states->getNumberOfSetBits() == this->values.size(), "Expected one value per selected state.");
 }
 

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -180,8 +180,6 @@ void ExplicitQuantitativeCheckResult<ValueType>::setUpperBounds(vector_type uppe
 
 template<typename ValueType>
 void ExplicitQuantitativeCheckResult<ValueType>::setBounds(storm::solver::SolutionBounds<ExtendedValueType> bounds) {
-    // Each of the two sides is transferred only if the algorithm in question established it; the other side is
-    // left as it is.
     if (bounds.hasLower()) {
         this->setLowerBounds(std::move(*bounds.lower));
     }
@@ -226,8 +224,6 @@ void ExplicitQuantitativeCheckResult<ValueType>::filter(QualitativeCheckResult c
     STORM_LOG_THROW(selected.isSubsetOf(available), storm::exceptions::InvalidOperationException,
                     "The check result fails to contain some results referred to by the filter.");
 
-    // The entries that survive, in the index space the values are stored in. Note that the result is a result
-    // for the selected states even if those happen to be all of them.
     storm::storage::BitVector const keep = selected % available;
 
     if (this->hasLowerBounds()) {
@@ -350,11 +346,8 @@ void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, u
     if (!this->hasLowerBounds() && !this->hasUpperBounds()) {
         return;
     }
-    // The enclosure is printed next to the estimate. Note that this is unrelated to the range over all states
-    // that is printed for large results below.
     out << " [";
-    // A side that is not known is written as a dash rather than as the infinity that would bound anything, so
-    // that "nothing was proven here" cannot be read as "the value may be arbitrarily large".
+    // A side that is not known is written as a dash, so that it cannot be read as an infinite bound.
     if (this->hasLowerBounds()) {
         print(out, this->getLowerBoundVector()[offset]);
     } else {
@@ -409,7 +402,7 @@ std::unique_ptr<CheckResult> ExplicitQuantitativeCheckResult<ValueType>::compare
         return false;
     };
 
-    // A comparison is only sound if the bound fall outside the lower and upperbound of te result.
+    // A comparison is only sound if the bound falls outside the lower and upper bound of the result.
     if (this->hasLowerBounds() && this->hasUpperBounds()) {
         for (uint64_t offset = 0; offset < values.size(); ++offset) {
             STORM_LOG_WARN_COND(!((*bounds.lower)[offset] < bound && bound < (*bounds.upper)[offset]),
@@ -474,7 +467,7 @@ void ExplicitQuantitativeCheckResult<ValueType>::oneMinus() {
     if (this->hasUpperBounds()) {
         storm::utility::vector::subtractFromConstantOneVector(*bounds.upper);
     }
-    // One minus is antitone, so what used to bound the values from below now bounds them from above.
+    // Inverse the bounds, lb = 1 - ub and ub = 1 - lb.
     std::swap(bounds.lower, bounds.upper);
 }
 

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -15,6 +15,58 @@
 
 namespace storm {
 namespace modelchecker {
+
+namespace detail {
+/*!
+ * Restricts the given values to the states selected by the filter. Note that the result is always a map, even
+ * if the given values are a vector.
+ */
+template<typename ValueType>
+boost::variant<std::vector<ValueType>, std::map<storm::storage::sparse::state_type, ValueType>> filterValues(
+    boost::variant<std::vector<ValueType>, std::map<storm::storage::sparse::state_type, ValueType>> const& values,
+    storm::storage::BitVector const& filterTruthValues) {
+    typedef std::vector<ValueType> vector_type;
+    typedef std::map<storm::storage::sparse::state_type, ValueType> map_type;
+
+    map_type newMap;
+    if (values.which() == 0) {
+        vector_type const& valuesAsVector = boost::get<vector_type>(values);
+        for (auto element : filterTruthValues) {
+            STORM_LOG_THROW(element < valuesAsVector.size(), storm::exceptions::InvalidAccessException, "Invalid index in results.");
+            newMap.emplace(element, valuesAsVector[element]);
+        }
+    } else {
+        for (auto const& element : boost::get<map_type>(values)) {
+            if (filterTruthValues.get(element.first)) {
+                newMap.insert(element);
+            }
+        }
+        STORM_LOG_THROW(newMap.size() == filterTruthValues.getNumberOfSetBits(), storm::exceptions::InvalidOperationException,
+                        "The check result fails to contain some results referred to by the filter.");
+    }
+    return newMap;
+}
+
+/*!
+ * Replaces every value by one minus that value.
+ */
+template<typename ValueType>
+void complementValues(boost::variant<std::vector<ValueType>, std::map<storm::storage::sparse::state_type, ValueType>>& values) {
+    typedef std::vector<ValueType> vector_type;
+    typedef std::map<storm::storage::sparse::state_type, ValueType> map_type;
+
+    if (values.which() == 0) {
+        for (auto& element : boost::get<vector_type>(values)) {
+            element = storm::utility::one<ValueType>() - element;
+        }
+    } else {
+        for (auto& element : boost::get<map_type>(values)) {
+            element.second = storm::utility::one<ValueType>() - element.second;
+        }
+    }
+}
+}  // namespace detail
+
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult() : values(map_type()) {
     // Intentionally left empty.
@@ -110,7 +162,10 @@ ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(Expl
 
 template<typename ValueType>
 std::unique_ptr<CheckResult> ExplicitQuantitativeCheckResult<ValueType>::clone() const {
-    return std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(this->values, this->scheduler);
+    auto result = std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(this->values, this->scheduler);
+    result->lowerBounds = this->lowerBounds;
+    result->upperBounds = this->upperBounds;
+    return result;
 }
 
 template<typename ValueType>
@@ -134,6 +189,75 @@ std::vector<ValueType> ExplicitQuantitativeCheckResult<ValueType>::getFiniteValu
 }
 
 template<typename ValueType>
+bool ExplicitQuantitativeCheckResult<ValueType>::hasLowerBounds() const {
+    return lowerBounds.has_value();
+}
+
+template<typename ValueType>
+bool ExplicitQuantitativeCheckResult<ValueType>::hasUpperBounds() const {
+    return upperBounds.has_value();
+}
+
+template<typename ValueType>
+typename ExplicitQuantitativeCheckResult<ValueType>::vector_type const& ExplicitQuantitativeCheckResult<ValueType>::getLowerBoundVector() const {
+    STORM_LOG_THROW(this->hasLowerBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown lower bounds.");
+    return boost::get<vector_type>(*lowerBounds);
+}
+
+template<typename ValueType>
+typename ExplicitQuantitativeCheckResult<ValueType>::vector_type const& ExplicitQuantitativeCheckResult<ValueType>::getUpperBoundVector() const {
+    STORM_LOG_THROW(this->hasUpperBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown upper bounds.");
+    return boost::get<vector_type>(*upperBounds);
+}
+
+template<typename ValueType>
+typename ExplicitQuantitativeCheckResult<ValueType>::map_type const& ExplicitQuantitativeCheckResult<ValueType>::getLowerBoundMap() const {
+    STORM_LOG_THROW(this->hasLowerBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown lower bounds.");
+    return boost::get<map_type>(*lowerBounds);
+}
+
+template<typename ValueType>
+typename ExplicitQuantitativeCheckResult<ValueType>::map_type const& ExplicitQuantitativeCheckResult<ValueType>::getUpperBoundMap() const {
+    STORM_LOG_THROW(this->hasUpperBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown upper bounds.");
+    return boost::get<map_type>(*upperBounds);
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::assertBoundsShape([[maybe_unused]] boost::variant<vector_type, map_type> const& bounds) const {
+    STORM_LOG_ASSERT(bounds.which() == values.which(), "Bounds must have the same shape as the values.");
+    if (this->isResultForAllStates()) {
+        STORM_LOG_ASSERT(boost::get<vector_type>(bounds).size() == boost::get<vector_type>(values).size(), "Bounds must have the same size as the values.");
+    } else {
+        STORM_LOG_ASSERT(boost::get<map_type>(bounds).size() == boost::get<map_type>(values).size(), "Bounds must have the same size as the values.");
+    }
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::setLowerBounds(boost::variant<vector_type, map_type> lowerBounds) {
+    this->assertBoundsShape(lowerBounds);
+    this->lowerBounds = std::move(lowerBounds);
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::setUpperBounds(boost::variant<vector_type, map_type> upperBounds) {
+    this->assertBoundsShape(upperBounds);
+    this->upperBounds = std::move(upperBounds);
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::setBounds(boost::variant<vector_type, map_type> lowerBounds,
+                                                           boost::variant<vector_type, map_type> upperBounds) {
+    this->setLowerBounds(std::move(lowerBounds));
+    this->setUpperBounds(std::move(upperBounds));
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::clearBounds() {
+    lowerBounds = std::nullopt;
+    upperBounds = std::nullopt;
+}
+
+template<typename ValueType>
 void ExplicitQuantitativeCheckResult<ValueType>::filter(QualitativeCheckResult const& filter) {
     STORM_LOG_THROW(filter.isExplicitQualitativeCheckResult(), storm::exceptions::InvalidOperationException,
                     "Cannot filter explicit check result with non-explicit filter.");
@@ -142,29 +266,13 @@ void ExplicitQuantitativeCheckResult<ValueType>::filter(QualitativeCheckResult c
     ExplicitQualitativeCheckResult<ValueType> const& explicitFilter = filter.template asExplicitQualitativeCheckResult<ValueType>();
     typename ExplicitQualitativeCheckResult<ValueType>::vector_type const& filterTruthValues = explicitFilter.getTruthValuesVector();
 
-    if (this->isResultForAllStates()) {
-        map_type newMap;
-
-        for (auto element : filterTruthValues) {
-            STORM_LOG_THROW(element < this->getValueVector().size(), storm::exceptions::InvalidAccessException, "Invalid index in results.");
-            newMap.emplace(element, this->getValueVector()[element]);
-        }
-        this->values = newMap;
-    } else {
-        map_type const& map = boost::get<map_type>(values);
-
-        map_type newMap;
-        for (auto const& element : map) {
-            if (filterTruthValues.get(element.first)) {
-                newMap.insert(element);
-            }
-        }
-
-        STORM_LOG_THROW(newMap.size() == filterTruthValues.getNumberOfSetBits(), storm::exceptions::InvalidOperationException,
-                        "The check result fails to contain some results referred to by the filter.");
-
-        this->values = newMap;
+    if (this->hasLowerBounds()) {
+        this->lowerBounds = detail::filterValues<ExtendedValueType>(*this->lowerBounds, filterTruthValues);
     }
+    if (this->hasUpperBounds()) {
+        this->upperBounds = detail::filterValues<ExtendedValueType>(*this->upperBounds, filterTruthValues);
+    }
+    this->values = detail::filterValues<ExtendedValueType>(this->values, filterTruthValues);
 }
 
 template<typename ValueType>
@@ -321,6 +429,29 @@ void printRange(std::ostream& out, ValueType const& min, ValueType const& max) {
 }
 
 template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, storm::storage::sparse::state_type state) const {
+    print(out, (*this)[state]);
+    if (!this->hasLowerBounds() && !this->hasUpperBounds()) {
+        return;
+    }
+    // The enclosure is printed next to the estimate. Note that this is unrelated to the range over all states
+    // that is printed for large results below.
+    out << " [";
+    if (this->hasLowerBounds()) {
+        print(out, this->isResultForAllStates() ? this->getLowerBoundVector()[state] : this->getLowerBoundMap().at(state));
+    } else {
+        out << "-inf";
+    }
+    out << ", ";
+    if (this->hasUpperBounds()) {
+        print(out, this->isResultForAllStates() ? this->getUpperBoundVector()[state] : this->getUpperBoundMap().at(state));
+    } else {
+        out << "inf";
+    }
+    out << "]";
+}
+
+template<typename ValueType>
 std::ostream& ExplicitQuantitativeCheckResult<ValueType>::writeToStream(std::ostream& out) const {
     bool minMaxSupported = std::is_same<ValueType, double>::value || std::is_same<ValueType, storm::RationalNumber>::value;
     bool printAsRange = false;
@@ -332,13 +463,13 @@ std::ostream& ExplicitQuantitativeCheckResult<ValueType>::writeToStream(std::ost
         } else {
             out << "{";
             bool first = true;
-            for (auto const& element : valuesAsVector) {
+            for (uint64_t state = 0; state < valuesAsVector.size(); ++state) {
                 if (!first) {
                     out << ", ";
                 } else {
                     first = false;
                 }
-                print(out, element);
+                this->printValue(out, state);
             }
             out << "}";
         }
@@ -348,7 +479,7 @@ std::ostream& ExplicitQuantitativeCheckResult<ValueType>::writeToStream(std::ost
             printAsRange = true;
         } else {
             if (valuesAsMap.size() == 1) {
-                print(out, valuesAsMap.begin()->second);
+                this->printValue(out, valuesAsMap.begin()->first);
             } else {
                 out << "{";
                 bool first = true;
@@ -358,7 +489,7 @@ std::ostream& ExplicitQuantitativeCheckResult<ValueType>::writeToStream(std::ost
                     } else {
                         first = false;
                     }
-                    print(out, element.second);
+                    this->printValue(out, element.first);
                 }
                 out << "}";
             }
@@ -486,35 +617,51 @@ bool ExplicitQuantitativeCheckResult<ValueType>::isExplicitQuantitativeCheckResu
 
 template<typename ValueType>
 void ExplicitQuantitativeCheckResult<ValueType>::oneMinus() {
-    if (this->isResultForAllStates()) {
-        for (auto& element : boost::get<vector_type>(values)) {
-            element = storm::utility::one<ExtendedValueType>() - element;
-        }
+    detail::complementValues<ExtendedValueType>(values);
+    if (this->hasLowerBounds()) {
+        detail::complementValues<ExtendedValueType>(*lowerBounds);
+    }
+    if (this->hasUpperBounds()) {
+        detail::complementValues<ExtendedValueType>(*upperBounds);
+    }
+    // One minus is antitone, so what used to bound the values from below now bounds them from above.
+    std::swap(lowerBounds, upperBounds);
+}
+
+/*!
+ * Writes the given value under the given key, spelling out an infinity that the plain value type cannot represent.
+ */
+template<typename ValueType>
+void insertJsonValue(storm::json<ValueType>& entry, std::string const& key, storm::utility::ExtendedValueType<ValueType> const& value) {
+    if (storm::utility::isInfinity(value)) {
+        entry[key] = "inf";
+    } else if (storm::utility::isNegativeInfinity(value)) {
+        entry[key] = "-inf";
+    } else if constexpr (std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>) {
+        entry[key] = value;
     } else {
-        for (auto& element : boost::get<map_type>(values)) {
-            element.second = storm::utility::one<ExtendedValueType>() - element.second;
-        }
+        entry[key] = value.getFinite();
     }
 }
 
 template<typename ValueType>
 void insertJsonEntry(storm::json<ValueType>& json, uint64_t const& id, storm::utility::ExtendedValueType<ValueType> const& value,
                      std::optional<storm::storage::sparse::Valuations> const& stateValuations = std::nullopt,
-                     std::optional<storm::models::sparse::StateLabeling> const& stateLabels = std::nullopt) {
+                     std::optional<storm::models::sparse::StateLabeling> const& stateLabels = std::nullopt,
+                     std::optional<storm::utility::ExtendedValueType<ValueType>> const& lowerBound = std::nullopt,
+                     std::optional<storm::utility::ExtendedValueType<ValueType>> const& upperBound = std::nullopt) {
     typename storm::json<ValueType> entry;
     if (stateValuations) {
         entry["s"] = stateValuations->template toJson<ValueType>(id);
     } else {
         entry["s"] = id;
     }
-    if (storm::utility::isInfinity(value)) {
-        entry["v"] = "inf";
-    } else if (storm::utility::isNegativeInfinity(value)) {
-        entry["v"] = "-inf";
-    } else if constexpr (std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>) {
-        entry["v"] = value;
-    } else {
-        entry["v"] = value.getFinite();
+    insertJsonValue(entry, "v", value);
+    if (lowerBound) {
+        insertJsonValue(entry, "lb", *lowerBound);
+    }
+    if (upperBound) {
+        insertJsonValue(entry, "ub", *upperBound);
     }
     if (stateLabels) {
         auto labs = stateLabels->getLabelsOfState(id);
@@ -530,12 +677,16 @@ storm::json<ValueType> ExplicitQuantitativeCheckResult<ValueType>::toJson(std::o
     if (this->isResultForAllStates()) {
         vector_type const& valuesAsVector = boost::get<vector_type>(values);
         for (uint64_t state = 0; state < valuesAsVector.size(); ++state) {
-            insertJsonEntry(result, state, valuesAsVector[state], stateValuations, stateLabels);
+            insertJsonEntry(result, state, valuesAsVector[state], stateValuations, stateLabels,
+                            this->hasLowerBounds() ? std::make_optional(this->getLowerBoundVector()[state]) : std::nullopt,
+                            this->hasUpperBounds() ? std::make_optional(this->getUpperBoundVector()[state]) : std::nullopt);
         }
     } else {
         map_type const& valuesAsMap = boost::get<map_type>(values);
         for (auto const& stateValue : valuesAsMap) {
-            insertJsonEntry(result, stateValue.first, stateValue.second, stateValuations, stateLabels);
+            insertJsonEntry(result, stateValue.first, stateValue.second, stateValuations, stateLabels,
+                            this->hasLowerBounds() ? std::make_optional(this->getLowerBoundMap().at(stateValue.first)) : std::nullopt,
+                            this->hasUpperBounds() ? std::make_optional(this->getUpperBoundMap().at(stateValue.first)) : std::nullopt);
         }
     }
     return result;

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -410,9 +410,9 @@ std::unique_ptr<CheckResult> ExplicitQuantitativeCheckResult<ValueType>::compare
     // A comparison is only sound if the bound fall outside the lower and upperbound of te result.
     if (this->hasLowerBounds() && this->hasUpperBounds()) {
         for (uint64_t offset = 0; offset < values.size(); ++offset) {
-            STORM_LOG_ASSERT(!((*bounds.lower)[offset] < bound && bound < (*bounds.upper)[offset]),
-                             "The bound " << bound << " lies between the lower bound " << (*bounds.lower)[offset] << " and the upper bound "
-                                          << (*bounds.upper)[offset] << ", so the comparison against it is not decided at state " << offset << ".");
+            STORM_LOG_WARN_COND(!((*bounds.lower)[offset] < bound && bound < (*bounds.upper)[offset]),
+                                "The bound " << bound << " lies between the lower bound " << (*bounds.lower)[offset] << " and the upper bound "
+                                             << (*bounds.upper)[offset] << ", so the comparison against it is not decided at state " << offset << ".");
         }
     }
 

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -353,16 +353,18 @@ void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, u
     // The enclosure is printed next to the estimate. Note that this is unrelated to the range over all states
     // that is printed for large results below.
     out << " [";
+    // A side that is not known is written as a dash rather than as the infinity that would bound anything, so
+    // that "nothing was proven here" cannot be read as "the value may be arbitrarily large".
     if (this->hasLowerBounds()) {
         print(out, this->getLowerBoundVector()[offset]);
     } else {
-        out << "-inf";
+        out << "-";
     }
     out << ", ";
     if (this->hasUpperBounds()) {
         print(out, this->getUpperBoundVector()[offset]);
     } else {
-        out << "inf";
+        out << "-";
     }
     out << "]";
 }

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -195,10 +195,10 @@ void ExplicitQuantitativeCheckResult<ValueType>::setBounds(storm::solver::Soluti
     requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
 {
     if (bounds.hasLower()) {
-        this->setLowerBounds(storm::utility::fromSentinel(std::move(*bounds.lower)));
+        this->setLowerBounds(storm::utility::widen(std::move(*bounds.lower)));
     }
     if (bounds.hasUpper()) {
-        this->setUpperBounds(storm::utility::fromSentinel(std::move(*bounds.upper)));
+        this->setUpperBounds(storm::utility::widen(std::move(*bounds.upper)));
     }
 }
 

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -85,6 +85,36 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
      */
     std::vector<ValueType> getSentinelValueVector() const;
 
+    /*!
+     * Retrieves whether sound lower resp. upper bounds on the actual values are known.
+     * A bound that is not known is not stored at all, so that "no information" cannot be confused with an
+     * infinite bound: an individual entry of a known bound may well be (minus) infinity.
+     */
+    bool hasLowerBounds() const;
+    bool hasUpperBounds() const;
+
+    /*!
+     * Retrieves the sound lower resp. upper bounds on the actual values.
+     * @pre The respective bounds are known.
+     */
+    vector_type const& getLowerBoundVector() const;
+    vector_type const& getUpperBoundVector() const;
+    map_type const& getLowerBoundMap() const;
+    map_type const& getUpperBoundMap() const;
+
+    /*!
+     * Sets sound bounds on the actual values. The bounds must have the same shape as the values, i.e. a vector
+     * of the same size resp. a map with the same keys.
+     */
+    void setLowerBounds(boost::variant<vector_type, map_type> lowerBounds);
+    void setUpperBounds(boost::variant<vector_type, map_type> upperBounds);
+    void setBounds(boost::variant<vector_type, map_type> lowerBounds, boost::variant<vector_type, map_type> upperBounds);
+
+    /*!
+     * Drops all bounds, e.g. after an operation that cannot maintain them.
+     */
+    void clearBounds();
+
     virtual std::ostream& writeToStream(std::ostream& out) const override;
 
     virtual void filter(QualitativeCheckResult const& filter) override;
@@ -110,8 +140,25 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
         return t == typeid(ValueType);
     }
 
-    // The values of the quantitative check result.
+    /*!
+     * Asserts that the given bounds have the same shape as the values.
+     */
+    void assertBoundsShape(boost::variant<vector_type, map_type> const& bounds) const;
+
+    /*!
+     * Writes the value of the given state, followed by its bounds if any are known.
+     */
+    void printValue(std::ostream& out, storm::storage::sparse::state_type state) const;
+
+    // The values of the quantitative check result. These are estimates of the actual values, which lie within
+    // the bounds below but carry no further guarantee.
     boost::variant<vector_type, map_type> values;
+
+    // Sound lower bounds on the actual values, if an algorithm provided them.
+    std::optional<boost::variant<vector_type, map_type>> lowerBounds;
+
+    // Sound upper bounds on the actual values, if an algorithm provided them.
+    std::optional<boost::variant<vector_type, map_type>> upperBounds;
 
     // An optional scheduler that accompanies the values.
     std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler;

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -52,8 +52,10 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
                                     std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
 
     /*!
-     * Takes over values that are still expressed in the plain value type, reading an entry equal to the value that
-     * storm::utility::infinity yields as an infinity.
+     * Takes over values that are still expressed in the plain value type. Those are taken to be finite throughout:
+     * no sentinel is read out of them, mirroring how bounds arriving in the plain type are treated. A computation
+     * that can produce an infinite value says so by handing over the extended type instead, which every such path
+     * in the sparse engine does.
      */
     ExplicitQuantitativeCheckResult(std::vector<ValueType> const& values)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -1,7 +1,4 @@
 #pragma once
-#include <boost/optional.hpp>
-#include <boost/variant.hpp>
-#include <map>
 #include <optional>
 #include <vector>
 
@@ -9,6 +6,7 @@
 #include "storm/modelchecker/results/QuantitativeCheckResult.h"
 #include "storm/models/sparse/StateLabeling.h"
 #include "storm/solver/SolutionBounds.h"
+#include "storm/storage/BitVector.h"
 #include "storm/storage/Scheduler.h"
 #include "storm/storage/sparse/StateType.h"
 #include "storm/storage/valuations/Valuations.h"
@@ -21,34 +19,48 @@ namespace modelchecker {
 template<typename ValueType>
 class ExplicitQualitativeCheckResult;
 
+/*!
+ * A quantitative check result over the states of a sparse model.
+ *
+ * The result either covers every state of the model or just a subset of them, e.g. after filtering it to the
+ * initial states. In the latter case the states in question are recorded in a bit vector and the values are
+ * stored compressed, i.e. the i-th value belongs to the i-th state selected by that bit vector.
+ */
 template<typename ValueType>
 class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType> {
    public:
     typedef typename QuantitativeCheckResult<ValueType>::ExtendedValueType ExtendedValueType;
     typedef std::vector<ExtendedValueType> vector_type;
-    typedef std::map<storm::storage::sparse::state_type, ExtendedValueType> map_type;
-
-    ExplicitQuantitativeCheckResult();
-    ExplicitQuantitativeCheckResult(map_type const& values);
-    ExplicitQuantitativeCheckResult(map_type&& values);
-    ExplicitQuantitativeCheckResult(storm::storage::sparse::state_type const& state, ExtendedValueType const& value);
-    ExplicitQuantitativeCheckResult(vector_type const& values);
-    ExplicitQuantitativeCheckResult(vector_type&& values);
 
     /*!
-     * Takes over a result that is still expressed in the plain value type, reading an entry equal to the value that
+     * Creates a result that holds the given value for the given state only.
+     */
+    ExplicitQuantitativeCheckResult(storm::storage::sparse::state_type const& state, ExtendedValueType const& value);
+
+    /*!
+     * Creates a result for all states of a model with the given number of states.
+     */
+    ExplicitQuantitativeCheckResult(vector_type const& values, std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
+    ExplicitQuantitativeCheckResult(vector_type&& values, std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
+
+    /*!
+     * Creates a result for the given states only.
+     * @param states The states the result is for.
+     * @param values One value per state selected by @p states, in the order of the selected states.
+     */
+    ExplicitQuantitativeCheckResult(storm::storage::BitVector states, vector_type&& values,
+                                    std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
+
+    /*!
+     * Takes over values that are still expressed in the plain value type, reading an entry equal to the value that
      * storm::utility::infinity yields as an infinity.
      */
     ExplicitQuantitativeCheckResult(std::vector<ValueType> const& values)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);
     ExplicitQuantitativeCheckResult(std::vector<ValueType>&& values)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);
-    ExplicitQuantitativeCheckResult(std::map<storm::storage::sparse::state_type, ValueType> const& values)
+    ExplicitQuantitativeCheckResult(storm::storage::BitVector states, std::vector<ValueType>&& values)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);
-    ExplicitQuantitativeCheckResult(boost::variant<vector_type, map_type> const& values,
-                                    std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
-    ExplicitQuantitativeCheckResult(boost::variant<vector_type, map_type>&& values,
-                                    std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
 
     ExplicitQuantitativeCheckResult(ExplicitQuantitativeCheckResult const& other) = default;
     ExplicitQuantitativeCheckResult& operator=(ExplicitQuantitativeCheckResult const& other) = default;
@@ -60,6 +72,10 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
 
     virtual std::unique_ptr<CheckResult> clone() const override;
 
+    /*!
+     * Retrieves the value of the given state.
+     * @pre The result holds a value for that state.
+     */
     ExtendedValueType& operator[](storm::storage::sparse::state_type state);
     ExtendedValueType const& operator[](storm::storage::sparse::state_type state) const;
 
@@ -70,9 +86,23 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
 
     virtual bool isExplicitQuantitativeCheckResult() const override;
 
+    /*!
+     * Retrieves whether the result holds a value for the given state.
+     */
+    bool hasValueForState(storm::storage::sparse::state_type state) const;
+
+    /*!
+     * Retrieves the states this result holds values for.
+     * @pre This is not a result for all states.
+     */
+    storm::storage::BitVector const& getStates() const;
+
+    /*!
+     * Retrieves the values, one per state this result is for. If this is not a result for all states, the i-th
+     * value belongs to the i-th state selected by getStates().
+     */
     vector_type const& getValueVector() const;
     vector_type& getValueVector();
-    map_type const& getValueMap() const;
 
     /*!
      * @pre no value is infinite
@@ -95,21 +125,32 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     bool hasUpperBounds() const;
 
     /*!
-     * Retrieves the sound lower resp. upper bounds on the actual values.
+     * Retrieves the sound lower resp. upper bounds on the actual values. These have the same shape as the
+     * values, i.e. they are indexed in the same way.
      * @pre The respective bounds are known.
      */
     vector_type const& getLowerBoundVector() const;
     vector_type const& getUpperBoundVector() const;
-    map_type const& getLowerBoundMap() const;
-    map_type const& getUpperBoundMap() const;
 
     /*!
-     * Sets sound bounds on the actual values. The bounds must have the same shape as the values, i.e. a vector
-     * of the same size resp. a map with the same keys.
+     * Retrieves both bounds at once, either of which may be unset.
      */
-    void setLowerBounds(boost::variant<vector_type, map_type> lowerBounds);
-    void setUpperBounds(boost::variant<vector_type, map_type> upperBounds);
-    void setBounds(boost::variant<vector_type, map_type> lowerBounds, boost::variant<vector_type, map_type> upperBounds);
+    storm::solver::SolutionBounds<ExtendedValueType> const& getSolutionBounds() const;
+
+    /*!
+     * Sets sound bounds on the actual values. Each bound must have the same shape as the values, i.e. hold one
+     * entry per state this result is for.
+     */
+    void setLowerBounds(vector_type lowerBounds);
+    void setUpperBounds(vector_type upperBounds);
+    void setBounds(storm::solver::SolutionBounds<ExtendedValueType> bounds);
+
+    /*!
+     * Sets bounds that are still expressed in the plain value type, reading an entry equal to the value that
+     * storm::utility::infinity yields as an infinity.
+     */
+    void setBounds(storm::solver::SolutionBounds<ValueType> bounds)
+        requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);
 
     /*!
      * Drops all bounds, e.g. after an operation that cannot maintain them.
@@ -142,41 +183,51 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     }
 
     /*!
-     * Asserts that the given bounds have the same shape as the values.
+     * Retrieves the index at which the value of the given state is stored.
+     * @pre The result holds a value for that state.
      */
-    void assertBoundsShape(boost::variant<vector_type, map_type> const& bounds) const;
+    uint64_t getOffset(storm::storage::sparse::state_type state) const;
 
     /*!
-     * Writes the value of the given state, followed by its bounds if any are known.
+     * Invokes the given function with the state and the offset of its value, for every state this result is for.
      */
-    void printValue(std::ostream& out, storm::storage::sparse::state_type state) const;
+    template<typename Function>
+    void forEachState(Function const& f) const {
+        if (states) {
+            uint64_t offset = 0;
+            for (auto const& state : *states) {
+                f(state, offset);
+                ++offset;
+            }
+        } else {
+            for (uint64_t state = 0; state < values.size(); ++state) {
+                f(state, state);
+            }
+        }
+    }
 
-    // The values of the quantitative check result. These are estimates of the actual values, which lie within
-    // the bounds below but carry no further guarantee.
-    boost::variant<vector_type, map_type> values;
+    /*!
+     * Asserts that the given bounds have the same shape as the values.
+     */
+    void assertBoundsShape(vector_type const& bounds) const;
 
-    // Sound lower bounds on the actual values, if an algorithm provided them.
-    std::optional<boost::variant<vector_type, map_type>> lowerBounds;
+    /*!
+     * Writes the value stored at the given offset, followed by its bounds if any are known.
+     */
+    void printValue(std::ostream& out, uint64_t offset) const;
 
-    // Sound upper bounds on the actual values, if an algorithm provided them.
-    std::optional<boost::variant<vector_type, map_type>> upperBounds;
+    // The states this result holds values for, or nothing at all if it is a result for all states.
+    std::optional<storm::storage::BitVector> states;
+
+    // The values of the quantitative check result, one per state this result is for. These are estimates of the
+    // actual values, which lie within the bounds below but carry no further guarantee.
+    vector_type values;
+
+    // Sound bounds on the actual values, if an algorithm provided them.
+    storm::solver::SolutionBounds<ExtendedValueType> bounds;
 
     // An optional scheduler that accompanies the values.
     std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler;
 };
-
-/*!
- * Transfers the sound bounds that an algorithm computed to the given check result. Each of the two sides is
- * transferred only if the algorithm established it; the other side is left alone.
- */
-template<typename ValueType>
-void setBounds(ExplicitQuantitativeCheckResult<ValueType>& result, storm::solver::SolutionBounds<ValueType>& bounds) {
-    if (bounds.hasLower()) {
-        result.setLowerBounds(std::move(*bounds.lower));
-    }
-    if (bounds.hasUpper()) {
-        result.setUpperBounds(std::move(*bounds.upper));
-    }
-}
 }  // namespace modelchecker
 }  // namespace storm

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -8,6 +8,7 @@
 #include "storm/adapters/JsonForward.h"
 #include "storm/modelchecker/results/QuantitativeCheckResult.h"
 #include "storm/models/sparse/StateLabeling.h"
+#include "storm/solver/SolutionBounds.h"
 #include "storm/storage/Scheduler.h"
 #include "storm/storage/sparse/StateType.h"
 #include "storm/storage/valuations/Valuations.h"
@@ -163,5 +164,19 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     // An optional scheduler that accompanies the values.
     std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler;
 };
+
+/*!
+ * Transfers the sound bounds that an algorithm computed to the given check result. Each of the two sides is
+ * transferred only if the algorithm established it; the other side is left alone.
+ */
+template<typename ValueType>
+void setBounds(ExplicitQuantitativeCheckResult<ValueType>& result, storm::solver::SolutionBounds<ValueType>& bounds) {
+    if (bounds.hasLower()) {
+        result.setLowerBounds(std::move(*bounds.lower));
+    }
+    if (bounds.hasUpper()) {
+        result.setUpperBounds(std::move(*bounds.upper));
+    }
+}
 }  // namespace modelchecker
 }  // namespace storm

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -52,10 +52,8 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
                                     std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
 
     /*!
-     * Takes over values that are still expressed in the plain value type. Those are taken to be finite throughout:
-     * no sentinel is read out of them, mirroring how bounds arriving in the plain type are treated. A computation
-     * that can produce an infinite value says so by handing over the extended type instead, which every such path
-     * in the sparse engine does.
+     * Takes over values that are still expressed in the plain value type, which are taken to be finite. A
+     * computation that can produce an infinite value hands over the extended type instead.
      */
     ExplicitQuantitativeCheckResult(std::vector<ValueType> const& values)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);
@@ -120,8 +118,6 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
 
     /*!
      * Retrieves whether sound lower resp. upper bounds on the actual values are known.
-     * A bound that is not known is not stored at all, so that "no information" cannot be confused with an
-     * infinite bound: an individual entry of a known bound may well be (minus) infinity.
      */
     bool hasLowerBounds() const;
     bool hasUpperBounds() const;
@@ -148,9 +144,8 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     void setBounds(storm::solver::SolutionBounds<ExtendedValueType> bounds);
 
     /*!
-     * Sets bounds that are still expressed in the plain value type. Bounds that arrive in that type are taken to
-     * be finite throughout: no sentinel is read out of them, since nothing hands bounds around by sentinel.
-     * An algorithm that can bound a value by infinity states so by handing over the extended type instead.
+     * Sets bounds that are still expressed in the plain value type, which are taken to be finite. An algorithm
+     * that can bound a value by infinity hands over the extended type instead.
      */
     void setBounds(storm::solver::SolutionBounds<ValueType> bounds)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);
@@ -222,8 +217,8 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     // The states this result holds values for, or nothing at all if it is a result for all states.
     std::optional<storm::storage::BitVector> states;
 
-    // The values of the quantitative check result, one per state this result is for. These are estimates of the
-    // actual values, which lie within the bounds below but carry no further guarantee.
+    // The values of the quantitative check result, one per state this result is for. These are estimates that
+    // lie within the bounds below but carry no further guarantee.
     vector_type values;
 
     // Sound bounds on the actual values, if an algorithm provided them.

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -146,8 +146,9 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     void setBounds(storm::solver::SolutionBounds<ExtendedValueType> bounds);
 
     /*!
-     * Sets bounds that are still expressed in the plain value type, reading an entry equal to the value that
-     * storm::utility::infinity yields as an infinity.
+     * Sets bounds that are still expressed in the plain value type. Bounds that arrive in that type are taken to
+     * be finite throughout: no sentinel is read out of them, since nothing hands bounds around by sentinel.
+     * An algorithm that can bound a value by infinity states so by handing over the extended type instead.
      */
     void setBounds(storm::solver::SolutionBounds<ValueType> bounds)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);

--- a/src/storm/solver/AbstractEquationSolver.cpp
+++ b/src/storm/solver/AbstractEquationSolver.cpp
@@ -241,6 +241,34 @@ void AbstractEquationSolver<ValueType>::setBoundsFromOtherSolver(AbstractEquatio
 }
 
 template<typename ValueType>
+bool AbstractEquationSolver<ValueType>::hasSolutionBounds() const {
+    return solutionBounds.has_value();
+}
+
+template<typename ValueType>
+std::vector<ValueType> const& AbstractEquationSolver<ValueType>::getSolutionLowerBounds() const {
+    STORM_LOG_ASSERT(this->hasSolutionBounds(), "No bounds on the solution were computed.");
+    return solutionBounds->first;
+}
+
+template<typename ValueType>
+std::vector<ValueType> const& AbstractEquationSolver<ValueType>::getSolutionUpperBounds() const {
+    STORM_LOG_ASSERT(this->hasSolutionBounds(), "No bounds on the solution were computed.");
+    return solutionBounds->second;
+}
+
+template<typename ValueType>
+void AbstractEquationSolver<ValueType>::setSolutionBounds(std::vector<ValueType> lower, std::vector<ValueType> upper) const {
+    STORM_LOG_ASSERT(lower.size() == upper.size(), "Bounds on the solution must have the same size.");
+    solutionBounds = std::make_pair(std::move(lower), std::move(upper));
+}
+
+template<typename ValueType>
+void AbstractEquationSolver<ValueType>::clearSolutionBounds() const {
+    solutionBounds = std::nullopt;
+}
+
+template<typename ValueType>
 void AbstractEquationSolver<ValueType>::clearBounds() {
     lowerBound = boost::none;
     upperBound = boost::none;

--- a/src/storm/solver/AbstractEquationSolver.cpp
+++ b/src/storm/solver/AbstractEquationSolver.cpp
@@ -241,31 +241,37 @@ void AbstractEquationSolver<ValueType>::setBoundsFromOtherSolver(AbstractEquatio
 }
 
 template<typename ValueType>
-bool AbstractEquationSolver<ValueType>::hasSolutionBounds() const {
-    return solutionBounds.has_value();
+bool AbstractEquationSolver<ValueType>::hasSolutionLowerBounds() const {
+    return solutionBounds.hasLower();
+}
+
+template<typename ValueType>
+bool AbstractEquationSolver<ValueType>::hasSolutionUpperBounds() const {
+    return solutionBounds.hasUpper();
 }
 
 template<typename ValueType>
 std::vector<ValueType> const& AbstractEquationSolver<ValueType>::getSolutionLowerBounds() const {
-    STORM_LOG_ASSERT(this->hasSolutionBounds(), "No bounds on the solution were computed.");
-    return solutionBounds->first;
+    STORM_LOG_ASSERT(this->hasSolutionLowerBounds(), "No lower bound on the solution was computed.");
+    return *solutionBounds.lower;
 }
 
 template<typename ValueType>
 std::vector<ValueType> const& AbstractEquationSolver<ValueType>::getSolutionUpperBounds() const {
-    STORM_LOG_ASSERT(this->hasSolutionBounds(), "No bounds on the solution were computed.");
-    return solutionBounds->second;
+    STORM_LOG_ASSERT(this->hasSolutionUpperBounds(), "No upper bound on the solution was computed.");
+    return *solutionBounds.upper;
 }
 
 template<typename ValueType>
-void AbstractEquationSolver<ValueType>::setSolutionBounds(std::vector<ValueType> lower, std::vector<ValueType> upper) const {
-    STORM_LOG_ASSERT(lower.size() == upper.size(), "Bounds on the solution must have the same size.");
-    solutionBounds = std::make_pair(std::move(lower), std::move(upper));
+void AbstractEquationSolver<ValueType>::setSolutionBounds(SolutionBounds<ValueType> bounds) const {
+    STORM_LOG_ASSERT(!bounds.hasLower() || !bounds.hasUpper() || bounds.lower->size() == bounds.upper->size(),
+                     "Bounds on the solution must have the same size.");
+    solutionBounds = std::move(bounds);
 }
 
 template<typename ValueType>
 void AbstractEquationSolver<ValueType>::clearSolutionBounds() const {
-    solutionBounds = std::nullopt;
+    solutionBounds.clear();
 }
 
 template<typename ValueType>

--- a/src/storm/solver/AbstractEquationSolver.h
+++ b/src/storm/solver/AbstractEquationSolver.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <memory>
 
+#include "storm/solver/SolutionBounds.h"
 #include "storm/solver/SolverStatus.h"
 #include "storm/solver/TerminationCondition.h"
 #include "storm/utility/ProgressMeasurement.h"
@@ -183,6 +184,20 @@ class AbstractEquationSolver {
     void clearBounds();
 
     /*!
+     * Retrieves whether the last call to this solver computed sound bounds on the solution.
+     * Only some algorithms, most notably interval iteration and optimistic value iteration, provide these, and
+     * even those only when they converged.
+     */
+    bool hasSolutionBounds() const;
+
+    /*!
+     * Retrieves sound bounds on the solution that the last call to this solver computed.
+     * @pre Such bounds were computed, see hasSolutionBounds().
+     */
+    std::vector<ValueType> const& getSolutionLowerBounds() const;
+    std::vector<ValueType> const& getSolutionUpperBounds() const;
+
+    /*!
      * Retrieves whether progress is to be shown.
      */
     bool isShowProgressSet() const;
@@ -210,6 +225,18 @@ class AbstractEquationSolver {
      */
     TerminationCondition<ValueType> const& getTerminationCondition() const;
     std::unique_ptr<TerminationCondition<ValueType>> const& getTerminationConditionPointer() const;
+
+    /*!
+     * Stores sound bounds on the solution that were obtained while solving. Note that solving is const, so
+     * that this is as well.
+     */
+    void setSolutionBounds(std::vector<ValueType> lower, std::vector<ValueType> upper) const;
+
+    /*!
+     * Discards any bounds on the solution obtained by a previous call. This must happen whenever solving
+     * starts, so that a solver that is reused does not report stale bounds.
+     */
+    void clearSolutionBounds() const;
 
     void createUpperBoundsVector(std::vector<ValueType>& upperBoundsVector) const;
     void createUpperBoundsVector(std::unique_ptr<std::vector<ValueType>>& upperBoundsVector, uint64_t length) const;
@@ -263,6 +290,9 @@ class AbstractEquationSolver {
     boost::optional<std::vector<ValueType>> upperBounds;
 
    private:
+    // Sound bounds on the solution, if the last call to this solver produced any.
+    mutable SolutionBounds<ValueType> solutionBounds;
+
     // Indicates the progress of this solver.
     mutable boost::optional<storm::utility::ProgressMeasurement> progressMeasurement;
 };

--- a/src/storm/solver/AbstractEquationSolver.h
+++ b/src/storm/solver/AbstractEquationSolver.h
@@ -185,9 +185,7 @@ class AbstractEquationSolver {
 
     /*!
      * Retrieves whether the last call to this solver computed a sound lower resp. upper bound on the solution.
-     * Only some algorithms, most notably interval iteration and optimistic value iteration, provide these, and
-     * they need not provide both: optimistic value iteration, for instance, only verifies its upper bound once
-     * it converges, while its lower bound is available in any case.
+     * Only some algorithms provide these, and they need not provide both.
      */
     bool hasSolutionLowerBounds() const;
     bool hasSolutionUpperBounds() const;

--- a/src/storm/solver/AbstractEquationSolver.h
+++ b/src/storm/solver/AbstractEquationSolver.h
@@ -184,15 +184,17 @@ class AbstractEquationSolver {
     void clearBounds();
 
     /*!
-     * Retrieves whether the last call to this solver computed sound bounds on the solution.
+     * Retrieves whether the last call to this solver computed a sound lower resp. upper bound on the solution.
      * Only some algorithms, most notably interval iteration and optimistic value iteration, provide these, and
-     * even those only when they converged.
+     * they need not provide both: optimistic value iteration, for instance, only verifies its upper bound once
+     * it converges, while its lower bound is available in any case.
      */
-    bool hasSolutionBounds() const;
+    bool hasSolutionLowerBounds() const;
+    bool hasSolutionUpperBounds() const;
 
     /*!
      * Retrieves sound bounds on the solution that the last call to this solver computed.
-     * @pre Such bounds were computed, see hasSolutionBounds().
+     * @pre The respective bound was computed, see hasSolutionLowerBounds() resp. hasSolutionUpperBounds().
      */
     std::vector<ValueType> const& getSolutionLowerBounds() const;
     std::vector<ValueType> const& getSolutionUpperBounds() const;
@@ -230,7 +232,7 @@ class AbstractEquationSolver {
      * Stores sound bounds on the solution that were obtained while solving. Note that solving is const, so
      * that this is as well.
      */
-    void setSolutionBounds(std::vector<ValueType> lower, std::vector<ValueType> upper) const;
+    void setSolutionBounds(SolutionBounds<ValueType> bounds) const;
 
     /*!
      * Discards any bounds on the solution obtained by a previous call. This must happen whenever solving

--- a/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
@@ -596,8 +596,12 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
             guessingFactor = storm::utility::convertNumber<ValueType>(*env.solver().ovi().getUpperBoundGuessingFactor());
         }
         this->startMeasureProgress();
+        storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = oviHelper.OVI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), prec, dir, guessingFactor, lowerBound,
-                                    upperBound, oviCallback);
+                                    upperBound, oviCallback, &solutionBounds);
+        if (solutionBounds) {
+            this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+        }
         this->reportStatus(status, numIterations);
 
         // If requested, we store the scheduler for retrieval.
@@ -806,8 +810,12 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
             optionalRelevantValues = this->getRelevantValues();
         }
         this->startMeasureProgress();
+        storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = iiHelper.II(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback,
-                                  dir, iiCallback, optionalRelevantValues);
+                                  dir, iiCallback, optionalRelevantValues, &solutionBounds);
+        if (solutionBounds) {
+            this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+        }
         this->reportStatus(status, numIterations);
 
         // If requested, we store the scheduler for retrieval.

--- a/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
@@ -599,8 +599,8 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = oviHelper.OVI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), prec, dir, guessingFactor, lowerBound,
                                     upperBound, oviCallback, &solutionBounds);
-        if (solutionBounds) {
-            this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+        if (solutionBounds.hasAny()) {
+            this->setSolutionBounds(std::move(solutionBounds));
         }
         this->reportStatus(status, numIterations);
 
@@ -813,8 +813,8 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = iiHelper.II(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback,
                                   dir, iiCallback, optionalRelevantValues, &solutionBounds);
-        if (solutionBounds) {
-            this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+        if (solutionBounds.hasAny()) {
+            this->setSolutionBounds(std::move(solutionBounds));
         }
         this->reportStatus(status, numIterations);
 

--- a/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
@@ -598,7 +598,7 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         this->startMeasureProgress();
         storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = oviHelper.OVI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), prec, dir, guessingFactor, lowerBound,
-                                    upperBound, oviCallback, &solutionBounds);
+                                    upperBound, oviCallback, solutionBounds);
         if (solutionBounds.hasAny()) {
             this->setSolutionBounds(std::move(solutionBounds));
         }
@@ -812,7 +812,7 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         this->startMeasureProgress();
         storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = iiHelper.II(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback,
-                                  dir, iiCallback, optionalRelevantValues, &solutionBounds);
+                                  dir, iiCallback, optionalRelevantValues, solutionBounds);
         if (solutionBounds.hasAny()) {
             this->setSolutionBounds(std::move(solutionBounds));
         }

--- a/src/storm/solver/LinearEquationSolver.cpp
+++ b/src/storm/solver/LinearEquationSolver.cpp
@@ -24,6 +24,8 @@ LinearEquationSolver<ValueType>::LinearEquationSolver() : cachingEnabled(false) 
 
 template<typename ValueType>
 bool LinearEquationSolver<ValueType>::solveEquations(Environment const& env, std::vector<ValueType>& x, std::vector<ValueType> const& b) const {
+    // A reused solver must not report bounds that a previous call computed.
+    this->clearSolutionBounds();
     return this->internalSolveEquations(env, x, b);
 }
 

--- a/src/storm/solver/MinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/MinMaxLinearEquationSolver.cpp
@@ -40,6 +40,8 @@ bool MinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquations(Environ
     STORM_LOG_WARN_COND_DEBUG(this->isRequirementsCheckedSet(),
                               "The requirements of the solver have not been marked as checked. Please provide the appropriate check or mark the requirements "
                               "as checked (if applicable).");
+    // A reused solver must not report bounds that a previous call computed.
+    this->clearSolutionBounds();
     return internalSolveEquations(env, d, x, b);
 }
 

--- a/src/storm/solver/NativeLinearEquationSolver.cpp
+++ b/src/storm/solver/NativeLinearEquationSolver.cpp
@@ -441,8 +441,12 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsIntervalIteration(Envi
         optionalRelevantValues = this->getRelevantValues();
     }
     this->startMeasureProgress();
+    storm::solver::SolutionBounds<ValueType> solutionBounds;
     auto status = iiHelper.II(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback, {},
-                              iiCallback, optionalRelevantValues);
+                              iiCallback, optionalRelevantValues, &solutionBounds);
+    if (solutionBounds) {
+        this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+    }
     this->reportStatus(status, numIterations);
 
     if (!this->isCachingEnabled()) {
@@ -525,7 +529,12 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsOptimisticValueIterati
         guessingFactor = storm::utility::convertNumber<ValueType>(*env.solver().ovi().getUpperBoundGuessingFactor());
     }
     this->startMeasureProgress();
-    auto status = oviHelper.OVI(x, b, env.solver().native().getRelativeTerminationCriterion(), prec, {}, guessingFactor, lowerBound, upperBound, oviCallback);
+    storm::solver::SolutionBounds<ValueType> solutionBounds;
+    auto status = oviHelper.OVI(x, b, env.solver().native().getRelativeTerminationCriterion(), prec, {}, guessingFactor, lowerBound, upperBound, oviCallback,
+                                &solutionBounds);
+    if (solutionBounds) {
+        this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+    }
     this->reportStatus(status, numIterations);
 
     if (!this->isCachingEnabled()) {

--- a/src/storm/solver/NativeLinearEquationSolver.cpp
+++ b/src/storm/solver/NativeLinearEquationSolver.cpp
@@ -443,7 +443,7 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsIntervalIteration(Envi
     this->startMeasureProgress();
     storm::solver::SolutionBounds<ValueType> solutionBounds;
     auto status = iiHelper.II(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback, {},
-                              iiCallback, optionalRelevantValues, &solutionBounds);
+                              iiCallback, optionalRelevantValues, solutionBounds);
     if (solutionBounds.hasAny()) {
         this->setSolutionBounds(std::move(solutionBounds));
     }
@@ -531,7 +531,7 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsOptimisticValueIterati
     this->startMeasureProgress();
     storm::solver::SolutionBounds<ValueType> solutionBounds;
     auto status = oviHelper.OVI(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), prec, {}, guessingFactor, lowerBound, upperBound,
-                                oviCallback, &solutionBounds);
+                                oviCallback, solutionBounds);
     if (solutionBounds.hasAny()) {
         this->setSolutionBounds(std::move(solutionBounds));
     }

--- a/src/storm/solver/NativeLinearEquationSolver.cpp
+++ b/src/storm/solver/NativeLinearEquationSolver.cpp
@@ -444,8 +444,8 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsIntervalIteration(Envi
     storm::solver::SolutionBounds<ValueType> solutionBounds;
     auto status = iiHelper.II(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback, {},
                               iiCallback, optionalRelevantValues, &solutionBounds);
-    if (solutionBounds) {
-        this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+    if (solutionBounds.hasAny()) {
+        this->setSolutionBounds(std::move(solutionBounds));
     }
     this->reportStatus(status, numIterations);
 
@@ -530,10 +530,10 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsOptimisticValueIterati
     }
     this->startMeasureProgress();
     storm::solver::SolutionBounds<ValueType> solutionBounds;
-    auto status = oviHelper.OVI(x, b, env.solver().native().getRelativeTerminationCriterion(), prec, {}, guessingFactor, lowerBound, upperBound, oviCallback,
-                                &solutionBounds);
-    if (solutionBounds) {
-        this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+    auto status = oviHelper.OVI(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), prec, {}, guessingFactor, lowerBound, upperBound,
+                                oviCallback, &solutionBounds);
+    if (solutionBounds.hasAny()) {
+        this->setSolutionBounds(std::move(solutionBounds));
     }
     this->reportStatus(status, numIterations);
 

--- a/src/storm/solver/SolutionBounds.h
+++ b/src/storm/solver/SolutionBounds.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace storm::solver {
+
+/*!
+ * Sound lower and upper bounds on a solution vector, as computed by e.g. interval iteration.
+ * The first component bounds the solution from below, the second one from above. Both have the same size as
+ * the solution. An unset value means that the algorithm in question did not provide any bounds.
+ */
+template<typename ValueType>
+using SolutionBounds = std::optional<std::pair<std::vector<ValueType>, std::vector<ValueType>>>;
+
+}  // namespace storm::solver

--- a/src/storm/solver/SolutionBounds.h
+++ b/src/storm/solver/SolutionBounds.h
@@ -14,18 +14,30 @@ struct SolutionBounds {
     std::optional<std::vector<ValueType>> lower;
     std::optional<std::vector<ValueType>> upper;
 
+    /*
+     * Returns true if the lower bound is set.
+     */
     bool hasLower() const {
         return lower.has_value();
     }
 
+    /*
+     * Returns true if the upper bound is set.
+     */
     bool hasUpper() const {
         return upper.has_value();
     }
 
+    /*
+     * Returns true if at least one of the bounds is set.
+     */
     bool hasAny() const {
         return hasLower() || hasUpper();
     }
 
+    /*
+     * Clears both bounds.
+     */
     void clear() {
         lower = std::nullopt;
         upper = std::nullopt;

--- a/src/storm/solver/SolutionBounds.h
+++ b/src/storm/solver/SolutionBounds.h
@@ -6,11 +6,8 @@
 namespace storm::solver {
 
 /*!
- * Sound lower and upper bounds on a solution vector, as computed by e.g. interval iteration.
- * Both bounds have the same size as the solution. They are tracked independently because an algorithm may
- * well establish only one of them: optimistic value iteration, for instance, keeps a sound lower bound in
- * every iteration but only verifies its upper bound once it converges. An unset bound means that the
- * algorithm in question did not provide that side.
+ * Sound lower and upper bounds on a solution vector. Both have the same size as the solution. They are tracked
+ * independently, as an algorithm may establish only one of them; an unset bound means that side is not known.
  */
 template<typename ValueType>
 struct SolutionBounds {
@@ -25,9 +22,6 @@ struct SolutionBounds {
         return upper.has_value();
     }
 
-    /*!
-     * Retrieves whether at least one of the two bounds is known.
-     */
     bool hasAny() const {
         return hasLower() || hasUpper();
     }

--- a/src/storm/solver/SolutionBounds.h
+++ b/src/storm/solver/SolutionBounds.h
@@ -1,17 +1,41 @@
 #pragma once
 
 #include <optional>
-#include <utility>
 #include <vector>
 
 namespace storm::solver {
 
 /*!
  * Sound lower and upper bounds on a solution vector, as computed by e.g. interval iteration.
- * The first component bounds the solution from below, the second one from above. Both have the same size as
- * the solution. An unset value means that the algorithm in question did not provide any bounds.
+ * Both bounds have the same size as the solution. They are tracked independently because an algorithm may
+ * well establish only one of them: optimistic value iteration, for instance, keeps a sound lower bound in
+ * every iteration but only verifies its upper bound once it converges. An unset bound means that the
+ * algorithm in question did not provide that side.
  */
 template<typename ValueType>
-using SolutionBounds = std::optional<std::pair<std::vector<ValueType>, std::vector<ValueType>>>;
+struct SolutionBounds {
+    std::optional<std::vector<ValueType>> lower;
+    std::optional<std::vector<ValueType>> upper;
+
+    bool hasLower() const {
+        return lower.has_value();
+    }
+
+    bool hasUpper() const {
+        return upper.has_value();
+    }
+
+    /*!
+     * Retrieves whether at least one of the two bounds is known.
+     */
+    bool hasAny() const {
+        return hasLower() || hasUpper();
+    }
+
+    void clear() {
+        lower = std::nullopt;
+        upper = std::nullopt;
+    }
+};
 
 }  // namespace storm::solver

--- a/src/storm/solver/helper/IntervalterationHelper.cpp
+++ b/src/storm/solver/helper/IntervalterationHelper.cpp
@@ -116,13 +116,11 @@ SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(std::pai
 }
 
 template<typename ValueType, bool TrivialRowGrouping>
-SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets,
-                                                                        uint64_t& numIterations, bool relative, ValueType const& precision,
-                                                                        std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,
-                                                                        std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds,
-                                                                        std::optional<storm::OptimizationDirection> const& dir,
-                                                                        std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback,
-                                                                        std::optional<storm::storage::BitVector> const& relevantValues) const {
+SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(
+    std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
+    std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds, std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds,
+    std::optional<storm::OptimizationDirection> const& dir, std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback,
+    std::optional<storm::storage::BitVector> const& relevantValues, SolutionBounds<ValueType>* solutionBounds) const {
     // Create two vectors x and y using the given operand plus an auxiliary vector.
     std::pair<std::vector<ValueType>, std::vector<ValueType>> xy;
     auto& auxVector = viOperator->allocateAuxiliaryVector(operand.size());
@@ -139,6 +137,12 @@ SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(std::vec
         status = II<OptimizationDirection::Maximize>(xy, offsets, numIterations, relative, precision, iterationCallback, relevantValues);
     } else {
         status = II<OptimizationDirection::Minimize>(xy, offsets, numIterations, relative, precision, iterationCallback, relevantValues);
+    }
+    if (solutionBounds != nullptr) {
+        // Hand out the enclosure before it is collapsed into the point estimate below. Interval iteration
+        // maintains xy.first below and xy.second above the solution in every iteration, so these are sound
+        // even if the iteration was aborted before converging.
+        *solutionBounds = std::make_pair(xy.first, xy.second);
     }
     auto two = storm::utility::convertNumber<ValueType>(2.0);
     // get the average of lower- and upper result

--- a/src/storm/solver/helper/IntervalterationHelper.cpp
+++ b/src/storm/solver/helper/IntervalterationHelper.cpp
@@ -139,9 +139,8 @@ SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(
         status = II<OptimizationDirection::Minimize>(xy, offsets, numIterations, relative, precision, iterationCallback, relevantValues);
     }
     if (solutionBounds.has_value()) {
-        // Hand out the enclosure before it is collapsed into the point estimate below. Interval iteration
-        // maintains xy.first below and xy.second above the solution in every iteration, so both sides are
-        // sound even if the iteration was aborted before converging.
+        // Interval iteration keeps xy.first below and xy.second above the solution in every iteration, so both
+        // sides are sound even if it was aborted. Read them out before they are collapsed into the estimate.
         solutionBounds->lower = xy.first;
         solutionBounds->upper = xy.second;
     }

--- a/src/storm/solver/helper/IntervalterationHelper.cpp
+++ b/src/storm/solver/helper/IntervalterationHelper.cpp
@@ -120,7 +120,7 @@ SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
     std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds, std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds,
     std::optional<storm::OptimizationDirection> const& dir, std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback,
-    std::optional<storm::storage::BitVector> const& relevantValues, SolutionBounds<ValueType>* solutionBounds) const {
+    std::optional<storm::storage::BitVector> const& relevantValues, storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds) const {
     // Create two vectors x and y using the given operand plus an auxiliary vector.
     std::pair<std::vector<ValueType>, std::vector<ValueType>> xy;
     auto& auxVector = viOperator->allocateAuxiliaryVector(operand.size());
@@ -138,7 +138,7 @@ SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(
     } else {
         status = II<OptimizationDirection::Minimize>(xy, offsets, numIterations, relative, precision, iterationCallback, relevantValues);
     }
-    if (solutionBounds != nullptr) {
+    if (solutionBounds.has_value()) {
         // Hand out the enclosure before it is collapsed into the point estimate below. Interval iteration
         // maintains xy.first below and xy.second above the solution in every iteration, so both sides are
         // sound even if the iteration was aborted before converging.

--- a/src/storm/solver/helper/IntervalterationHelper.cpp
+++ b/src/storm/solver/helper/IntervalterationHelper.cpp
@@ -140,9 +140,10 @@ SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(
     }
     if (solutionBounds != nullptr) {
         // Hand out the enclosure before it is collapsed into the point estimate below. Interval iteration
-        // maintains xy.first below and xy.second above the solution in every iteration, so these are sound
-        // even if the iteration was aborted before converging.
-        *solutionBounds = std::make_pair(xy.first, xy.second);
+        // maintains xy.first below and xy.second above the solution in every iteration, so both sides are
+        // sound even if the iteration was aborted before converging.
+        solutionBounds->lower = xy.first;
+        solutionBounds->upper = xy.second;
     }
     auto two = storm::utility::convertNumber<ValueType>(2.0);
     // get the average of lower- and upper result

--- a/src/storm/solver/helper/IntervalterationHelper.h
+++ b/src/storm/solver/helper/IntervalterationHelper.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "storm/solver/OptimizationDirection.h"
+#include "storm/solver/SolutionBounds.h"
 #include "storm/solver/SolverStatus.h"
 #include "storm/solver/helper/ValueIterationOperatorForward.h"
 #include "storm/storage/BitVector.h"
@@ -37,7 +38,7 @@ class IntervalIterationHelper {
                     std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,
                     std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds, std::optional<storm::OptimizationDirection> const& dir = {},
                     std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback = {},
-                    std::optional<storm::storage::BitVector> const& relevantValues = {}) const;
+                    std::optional<storm::storage::BitVector> const& relevantValues = {}, SolutionBounds<ValueType>* solutionBounds = nullptr) const;
 
     SolverStatus II(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
                     std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,

--- a/src/storm/solver/helper/IntervalterationHelper.h
+++ b/src/storm/solver/helper/IntervalterationHelper.h
@@ -10,6 +10,7 @@
 #include "storm/solver/SolverStatus.h"
 #include "storm/solver/helper/ValueIterationOperatorForward.h"
 #include "storm/storage/BitVector.h"
+#include "storm/utility/OptionalRef.h"
 
 namespace storm::solver::helper {
 
@@ -38,7 +39,8 @@ class IntervalIterationHelper {
                     std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,
                     std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds, std::optional<storm::OptimizationDirection> const& dir = {},
                     std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback = {},
-                    std::optional<storm::storage::BitVector> const& relevantValues = {}, SolutionBounds<ValueType>* solutionBounds = nullptr) const;
+                    std::optional<storm::storage::BitVector> const& relevantValues = {},
+                    storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds = storm::NullRef) const;
 
     SolverStatus II(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
                     std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
@@ -269,8 +269,8 @@ template<typename ValueType, bool TrivialRowGrouping>
 SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& guessValue, std::optional<ValueType> const& lowerBound,
-    std::optional<ValueType> const& upperBound,
-    std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback) const {
+    std::optional<ValueType> const& upperBound, std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback,
+    SolutionBounds<ValueType>* solutionBounds) const {
     // Create two vectors v and u using the given operand plus an auxiliary vector.
     std::pair<std::vector<ValueType>, std::vector<ValueType>> vu;
     auto& auxVector = viOperator->allocateAuxiliaryVector(operand.size());
@@ -281,6 +281,11 @@ SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
         doublePrec -= precision * 1e-6;  // be slightly more precise to avoid a good chunk of floating point issues
     }
     auto status = OVI(vu, offsets, numIterations, relative, doublePrec, dir, guessValue ? *guessValue : doublePrec, lowerBound, upperBound, iterationCallback);
+    if (solutionBounds != nullptr && status == SolverStatus::Converged) {
+        // Only a converged run has verified that vu.second lies above the solution. Until the verification
+        // phase succeeds it is merely a guess, so handing it out as an upper bound would be unsound.
+        *solutionBounds = std::make_pair(vu.first, vu.second);
+    }
     auto two = storm::utility::convertNumber<ValueType>(2.0);
     // get the average of lower- and upper result
     storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
@@ -296,10 +301,10 @@ template<typename ValueType, bool TrivialRowGrouping>
 SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& guessValue, std::optional<ValueType> const& lowerBound,
-    std::optional<ValueType> const& upperBound,
-    std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback) const {
+    std::optional<ValueType> const& upperBound, std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback,
+    SolutionBounds<ValueType>* solutionBounds) const {
     uint64_t numIterations = 0;
-    return OVI(operand, offsets, numIterations, relative, precision, dir, guessValue, lowerBound, upperBound, iterationCallback);
+    return OVI(operand, offsets, numIterations, relative, precision, dir, guessValue, lowerBound, upperBound, iterationCallback, solutionBounds);
 }
 
 template class OptimisticValueIterationHelper<double, true>;

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
@@ -281,15 +281,26 @@ SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
         doublePrec -= precision * 1e-6;  // be slightly more precise to avoid a good chunk of floating point issues
     }
     auto status = OVI(vu, offsets, numIterations, relative, doublePrec, dir, guessValue ? *guessValue : doublePrec, lowerBound, upperBound, iterationCallback);
-    if (solutionBounds != nullptr && status == SolverStatus::Converged) {
+    bool const converged = status == SolverStatus::Converged;
+    if (solutionBounds != nullptr) {
+        // The operand was initialized below the solution and every iteration -- both the ones of the value
+        // iteration phase and the ones of the verification phase -- applies the (monotone) operator to it, so
+        // vu.first lies below the solution no matter why we stopped iterating.
+        solutionBounds->lower = vu.first;
         // Only a converged run has verified that vu.second lies above the solution. Until the verification
         // phase succeeds it is merely a guess, so handing it out as an upper bound would be unsound.
-        *solutionBounds = std::make_pair(vu.first, vu.second);
+        if (converged) {
+            solutionBounds->upper = vu.second;
+        }
     }
-    auto two = storm::utility::convertNumber<ValueType>(2.0);
-    // get the average of lower- and upper result
-    storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
-        vu.first, vu.second, vu.first, [&two](ValueType const& a, ValueType const& b) -> ValueType { return (a + b) / two; });
+    if (converged) {
+        auto two = storm::utility::convertNumber<ValueType>(2.0);
+        // get the average of lower- and upper result
+        storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
+            vu.first, vu.second, vu.first, [&two](ValueType const& a, ValueType const& b) -> ValueType { return (a + b) / two; });
+    }
+    // Otherwise vu.second holds an unverified guess (or, if we never got to guessing, uninitialized data), so
+    // averaging it into the result would be meaningless and could even push the result below vu.first.
     // Swap operand and aux vector back to original positions.
     vu.first.swap(operand);
     vu.second.swap(auxVector);

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
@@ -270,7 +270,7 @@ SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& guessValue, std::optional<ValueType> const& lowerBound,
     std::optional<ValueType> const& upperBound, std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback,
-    SolutionBounds<ValueType>* solutionBounds) const {
+    storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds) const {
     // Create two vectors v and u using the given operand plus an auxiliary vector.
     std::pair<std::vector<ValueType>, std::vector<ValueType>> vu;
     auto& auxVector = viOperator->allocateAuxiliaryVector(operand.size());
@@ -282,7 +282,7 @@ SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
     }
     auto status = OVI(vu, offsets, numIterations, relative, doublePrec, dir, guessValue ? *guessValue : doublePrec, lowerBound, upperBound, iterationCallback);
     bool const converged = status == SolverStatus::Converged;
-    if (solutionBounds != nullptr) {
+    if (solutionBounds.has_value()) {
         // The operand was initialized below the solution and every iteration -- both the ones of the value
         // iteration phase and the ones of the verification phase -- applies the (monotone) operator to it, so
         // vu.first lies below the solution no matter why we stopped iterating.
@@ -313,7 +313,7 @@ SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& guessValue, std::optional<ValueType> const& lowerBound,
     std::optional<ValueType> const& upperBound, std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback,
-    SolutionBounds<ValueType>* solutionBounds) const {
+    storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds) const {
     uint64_t numIterations = 0;
     return OVI(operand, offsets, numIterations, relative, precision, dir, guessValue, lowerBound, upperBound, iterationCallback, solutionBounds);
 }

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
@@ -283,24 +283,19 @@ SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
     auto status = OVI(vu, offsets, numIterations, relative, doublePrec, dir, guessValue ? *guessValue : doublePrec, lowerBound, upperBound, iterationCallback);
     bool const converged = status == SolverStatus::Converged;
     if (solutionBounds.has_value()) {
-        // The operand was initialized below the solution and every iteration -- both the ones of the value
-        // iteration phase and the ones of the verification phase -- applies the (monotone) operator to it, so
-        // vu.first lies below the solution no matter why we stopped iterating.
+        // The operand started below the solution and every iteration applies the monotone operator to it, so
+        // vu.first lies below the solution whatever stopped the iteration.
         solutionBounds->lower = vu.first;
-        // Only a converged run has verified that vu.second lies above the solution. Until the verification
-        // phase succeeds it is merely a guess, so handing it out as an upper bound would be unsound.
+        // Until the verification phase succeeds vu.second is merely a guess, not an upper bound.
         if (converged) {
             solutionBounds->upper = vu.second;
         }
     }
     if (converged) {
         auto two = storm::utility::convertNumber<ValueType>(2.0);
-        // get the average of lower- and upper result
         storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
             vu.first, vu.second, vu.first, [&two](ValueType const& a, ValueType const& b) -> ValueType { return (a + b) / two; });
     }
-    // Otherwise vu.second holds an unverified guess (or, if we never got to guessing, uninitialized data), so
-    // averaging it into the result would be meaningless and could even push the result below vu.first.
     // Swap operand and aux vector back to original positions.
     vu.first.swap(operand);
     vu.second.swap(auxVector);

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.h
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "storm/solver/OptimizationDirection.h"
+#include "storm/solver/SolutionBounds.h"
 #include "storm/solver/SolverStatus.h"
 
 #include "storm/solver/helper/ValueIterationOperatorForward.h"
@@ -36,12 +37,14 @@ class OptimisticValueIterationHelper {
     SolverStatus OVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
                      std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& guessValue = {},
                      std::optional<ValueType> const& lowerBound = {}, std::optional<ValueType> const& upperBound = {},
-                     std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {}) const;
+                     std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {},
+                     SolutionBounds<ValueType>* solutionBounds = nullptr) const;
 
     SolverStatus OVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
                      std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& guessValue = {},
                      std::optional<ValueType> const& lowerBound = {}, std::optional<ValueType> const& upperBound = {},
-                     std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {}) const;
+                     std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {},
+                     SolutionBounds<ValueType>* solutionBounds = nullptr) const;
 
    private:
     template<storm::OptimizationDirection Dir, bool Relative>

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.h
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.h
@@ -11,6 +11,7 @@
 #include "storm/solver/SolverStatus.h"
 
 #include "storm/solver/helper/ValueIterationOperatorForward.h"
+#include "storm/utility/OptionalRef.h"
 
 namespace storm::solver::helper {
 
@@ -38,13 +39,13 @@ class OptimisticValueIterationHelper {
                      std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& guessValue = {},
                      std::optional<ValueType> const& lowerBound = {}, std::optional<ValueType> const& upperBound = {},
                      std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {},
-                     SolutionBounds<ValueType>* solutionBounds = nullptr) const;
+                     storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds = storm::NullRef) const;
 
     SolverStatus OVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
                      std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& guessValue = {},
                      std::optional<ValueType> const& lowerBound = {}, std::optional<ValueType> const& upperBound = {},
                      std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {},
-                     SolutionBounds<ValueType>* solutionBounds = nullptr) const;
+                     storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds = storm::NullRef) const;
 
    private:
     template<storm::OptimizationDirection Dir, bool Relative>

--- a/src/test/storm/CMakeLists.txt
+++ b/src/test/storm/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${GTEST_INCLUDE_DIR})
 
 # Set split and non-split test directories
 set(NON_SPLIT_TESTS adapter automata builder logic model parser settings simulator solver storage transformer utility)
-set(MODELCHECKER_TEST_SPLITS csl exploration lexicographic multiobjective reachability)
+set(MODELCHECKER_TEST_SPLITS bounds csl exploration lexicographic multiobjective reachability)
 set(MODELCHECKER_PRCTL_TEST_SPLITS dtmc mdp)
 
 function(configure_testsuite_target testsuite)

--- a/src/test/storm/modelchecker/bounds/SolutionBoundsTest.cpp
+++ b/src/test/storm/modelchecker/bounds/SolutionBoundsTest.cpp
@@ -65,6 +65,12 @@ class SolutionBoundsTest : public ::testing::Test {
 
     SolutionBoundsTest() : _environment(TestType::createEnvironment()) {}
 
+    void SetUp() override {
+#ifndef STORM_HAVE_Z3
+        GTEST_SKIP() << "Z3 not available.";
+#endif
+    }
+
     storm::Environment const& env() const {
         return _environment;
     }

--- a/src/test/storm/modelchecker/bounds/SolutionBoundsTest.cpp
+++ b/src/test/storm/modelchecker/bounds/SolutionBoundsTest.cpp
@@ -1,0 +1,143 @@
+#include "storm-config.h"
+#include "test/storm_gtest.h"
+
+#include "storm-parsers/api/model_descriptions.h"
+#include "storm-parsers/api/properties.h"
+#include "storm/api/builder.h"
+#include "storm/api/properties.h"
+#include "storm/environment/solver/MinMaxSolverEnvironment.h"
+#include "storm/environment/solver/NativeSolverEnvironment.h"
+#include "storm/environment/solver/SolverEnvironment.h"
+#include "storm/modelchecker/CheckTask.h"
+#include "storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.h"
+#include "storm/modelchecker/prctl/SparseMdpPrctlModelChecker.h"
+#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
+#include "storm/models/sparse/Dtmc.h"
+#include "storm/models/sparse/Mdp.h"
+#include "storm/models/sparse/StandardRewardModel.h"
+#include "storm/utility/constants.h"
+
+/*
+ * These tests are about the sound bounds that a model checking call reports alongside its values, not about the
+ * values themselves. The claim under test is the one the bounds make, so every property here has an answer that
+ * is known in closed form and each case asserts
+ *
+ *     lower <= exact <= upper   and   lower <= reported value <= upper.
+ *
+ * Every configuration listed below is one that must report both bounds, so a path that silently stops reporting
+ * them fails these tests rather than passing them vacuously.
+ */
+
+namespace {
+
+class NativeIiEnvironment {
+   public:
+    typedef double ValueType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setForceSoundness(true);
+        env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Native);
+        env.solver().native().setMethod(storm::solver::NativeLinearEquationSolverMethod::IntervalIteration);
+        env.solver().minMax().setMethod(storm::solver::MinMaxMethod::IntervalIteration);
+        return env;
+    }
+};
+
+class NativeOviEnvironment {
+   public:
+    typedef double ValueType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setForceSoundness(true);
+        env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Native);
+        env.solver().native().setMethod(storm::solver::NativeLinearEquationSolverMethod::OptimisticValueIteration);
+        env.solver().minMax().setMethod(storm::solver::MinMaxMethod::OptimisticValueIteration);
+        return env;
+    }
+};
+
+template<typename TestType>
+class SolutionBoundsTest : public ::testing::Test {
+   public:
+    typedef typename TestType::ValueType ValueType;
+    typedef storm::utility::ExtendedValueType<ValueType> ExtendedValueType;
+    typedef storm::modelchecker::ExplicitQuantitativeCheckResult<ValueType> QuantitativeResult;
+
+    SolutionBoundsTest() : _environment(TestType::createEnvironment()) {}
+
+    storm::Environment const& env() const {
+        return _environment;
+    }
+
+    ExtendedValueType parseNumber(std::string const& input) const {
+        return storm::utility::convertNumber<ExtendedValueType>(storm::utility::convertNumber<ValueType>(input));
+    }
+
+    /*!
+     * How far outside the reported enclosure the exact answer may still lie. A bound is only ever as sound as the
+     * arithmetic it is computed in: a procedure working in doubles can land a bound an ulp or two on the wrong
+     * side of an answer that is not representable at all. That is the rounding we accept, not a gap in the
+     * reasoning, so the slack is far below the solver precision these configurations ask for.
+     */
+    ExtendedValueType tolerance() const {
+        return this->parseNumber("1e-12");
+    }
+
+    /*!
+     * Builds the given PRISM model and checks the given property on it.
+     */
+    template<typename ModelType>
+    std::unique_ptr<storm::modelchecker::CheckResult> check(std::string const& modelFile, std::string const& propertyString) const {
+        storm::prism::Program program = storm::api::parseProgram(modelFile);
+        program = program.preprocess();
+        auto formulas = storm::api::extractFormulasFromProperties(storm::api::parsePropertiesForPrismProgram(propertyString, program));
+        auto model = storm::api::buildSparseModel<ValueType>(program, formulas)->template as<ModelType>();
+        storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> task(*formulas.front(), true);
+        if constexpr (std::is_same_v<ModelType, storm::models::sparse::Dtmc<ValueType>>) {
+            return storm::modelchecker::SparseDtmcPrctlModelChecker<ModelType>(*model).check(this->env(), task);
+        } else {
+            return storm::modelchecker::SparseMdpPrctlModelChecker<ModelType>(*model).check(this->env(), task);
+        }
+    }
+
+    /*!
+     * Asserts that the bounds the given result reports for the initial state enclose the given exact answer, and
+     * that the value it reports lies between them as well.
+     */
+    void expectEncloses(std::unique_ptr<storm::modelchecker::CheckResult> const& result, ExtendedValueType const& exact) const {
+        QuantitativeResult const& quantitative = result->template asExplicitQuantitativeCheckResult<ValueType>();
+        ASSERT_TRUE(quantitative.hasLowerBounds()) << "No lower bound on the solution was reported at all.";
+        ASSERT_TRUE(quantitative.hasUpperBounds()) << "No upper bound on the solution was reported at all.";
+        uint64_t const offset = 0;
+        ExtendedValueType const& value = quantitative.getValueVector()[offset];
+        ExtendedValueType const& lower = quantitative.getLowerBoundVector()[offset];
+        ExtendedValueType const& upper = quantitative.getUpperBoundVector()[offset];
+        EXPECT_LE(lower, exact + this->tolerance()) << "The lower bound exceeds the exact answer.";
+        EXPECT_LE(exact, upper + this->tolerance()) << "The upper bound falls below the exact answer.";
+        EXPECT_LE(lower, value) << "The lower bound exceeds the reported value.";
+        EXPECT_LE(value, upper) << "The reported value exceeds the upper bound.";
+    }
+
+   private:
+    storm::Environment _environment;
+};
+
+typedef ::testing::Types<NativeIiEnvironment, NativeOviEnvironment> TestingTypes;
+
+TYPED_TEST_SUITE(SolutionBoundsTest, TestingTypes, );
+
+// The Knuth-Yao die yields a one with probability exactly 1/6.
+TYPED_TEST(SolutionBoundsTest, DtmcUntilProbabilities) {
+    typedef typename TestFixture::ValueType ValueType;
+    auto result = this->template check<storm::models::sparse::Dtmc<ValueType>>(STORM_TEST_RESOURCES_DIR "/dtmc/die.pm", "P=? [F s=7 & d=1]");
+    this->expectEncloses(result, this->parseNumber("1/6"));
+}
+
+TYPED_TEST(SolutionBoundsTest, MdpUntilProbabilities) {
+    typedef typename TestFixture::ValueType ValueType;
+    auto result = this->template check<storm::models::sparse::Mdp<ValueType>>(STORM_TEST_RESOURCES_DIR "/mdp/coin2-2.nm",
+                                                                              "Pmin=? [F \"finished\" & \"all_coins_equal_1\"]");
+    this->expectEncloses(result, this->parseNumber("49/128"));
+}
+
+}  // namespace


### PR DESCRIPTION
This PR adds upper and lower bounds to `ExplicitQuantitativeCheckResults` and implements this for OVI and II. Further algorithms are implemented it #1048. 

Upper and lower bounds are stored in a class `SolutionBounds`. It has an optional vector of lower bounds and an optional vector of upper bounds. No bound mean the algorithm did not try to give any bounds, infinity as a value in the bound means the algorithm tried and that is the best it came up with.

The `ExplicitQuantitativeCheckResults` and `ExplicitQualitativeCheckResults` have had there map option removed and instead get an optional bitvector `states` holding the states for which the values and bounds hold. This was done such that the vectors in the SolutionBounds can be used easily in conjuction with any values stored in the check results. `ExplicitQualitativeCheckResults` was update to be consistent with `ExplicitQuantitativeCheckResults`.

Solution bounds are passed around from helper to PRCTLmodel checker using `(MDP/DTMC)SparseModelCheckingHelperReturnType`, the dtmc variant is new.

Solution bounds in this PR have been implemented for OVI and II.

Printing of bounds has been implemented where no bound is reported with a `-` if no bound is present. This was done to differentiate it from infinities.

So far I have the convention that any non-maybe states get bounds that exist from the algorithm. So if only lower bounds are produced, the maybe states get 1 [1, -] where - is no bound. This could be changed.