### PR TITLE
Remove uses of infinity that do not need a number

### DIFF
--- a/src/storm-dft/builder/DftExplorationHeuristic.cpp
+++ b/src/storm-dft/builder/DftExplorationHeuristic.cpp
@@ -18,8 +18,9 @@ double DFTExplorationHeuristicProbability<ValueType>::getPriority() const {
 
 template<>
 double DFTExplorationHeuristicBoundDifference<double>::getPriority() const {
-    double difference = lowerBound - upperBound;  // Lower bound is larger than upper bound
-    difference = 2 * difference / (upperBound + lowerBound);
+    STORM_LOG_ASSERT(lowerBound && upperBound, "Bounds have not been set for this heuristic.");
+    double difference = *lowerBound - *upperBound;  // Lower bound is larger than upper bound
+    difference = 2 * difference / (*upperBound + *lowerBound);
     return probability * difference;
 }
 

--- a/src/storm-dft/builder/DftExplorationHeuristic.h
+++ b/src/storm-dft/builder/DftExplorationHeuristic.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <memory>
 
 #include "storm/exceptions/NotImplementedException.h"
@@ -140,13 +142,10 @@ class DFTExplorationHeuristicProbability : public DFTExplorationHeuristic<ValueT
 template<typename ValueType>
 class DFTExplorationHeuristicBoundDifference : public DFTExplorationHeuristicProbability<ValueType> {
    public:
-    DFTExplorationHeuristicBoundDifference(size_t id)
-        : DFTExplorationHeuristicProbability<ValueType>(id), lowerBound(storm::utility::zero<ValueType>()), upperBound(storm::utility::infinity<ValueType>()) {}
+    DFTExplorationHeuristicBoundDifference(size_t id) : DFTExplorationHeuristicProbability<ValueType>(id) {}
 
     DFTExplorationHeuristicBoundDifference(size_t id, DFTExplorationHeuristic<ValueType> const& predecessor, ValueType rate, ValueType exitRate)
-        : DFTExplorationHeuristicProbability<ValueType>(id, predecessor, rate, exitRate),
-          lowerBound(storm::utility::zero<ValueType>()),
-          upperBound(storm::utility::infinity<ValueType>()) {}
+        : DFTExplorationHeuristicProbability<ValueType>(id, predecessor, rate, exitRate) {}
 
     void setBounds(ValueType lowerBound, ValueType upperBound) override {
         this->lowerBound = lowerBound;
@@ -154,18 +153,22 @@ class DFTExplorationHeuristicBoundDifference : public DFTExplorationHeuristicPro
     }
 
     ValueType getLowerBound() const override {
-        return lowerBound;
+        STORM_LOG_ASSERT(lowerBound.has_value(), "Bounds have not been set for this heuristic.");
+        return *lowerBound;
     }
 
     ValueType getUpperBound() const override {
-        return upperBound;
+        STORM_LOG_ASSERT(upperBound.has_value(), "Bounds have not been set for this heuristic.");
+        return *upperBound;
     }
 
     double getPriority() const override;
 
    protected:
-    ValueType lowerBound;
-    ValueType upperBound;
+    /// The bounds are set by the model builder before the heuristic enters the exploration queue. Until then there are
+    /// no bounds at all, rather than bounds that happen to be infinite.
+    std::optional<ValueType> lowerBound;
+    std::optional<ValueType> upperBound;
 };
 
 }  // namespace builder

--- a/src/storm-gamebased-ar/abstraction/MenuGameRefiner.cpp
+++ b/src/storm-gamebased-ar/abstraction/MenuGameRefiner.cpp
@@ -1192,13 +1192,17 @@ boost::optional<ExplicitPivotStateResult<ValueType>> pickPivotState(
 
     bool probabilityDistances = pivotSelectionHeuristic == storm::settings::modules::AbstractionSettings::PivotSelectionHeuristic::MostProbablePath;
     uint64_t numberOfStates = initialStates.size();
-    ValueType inftyDistance = probabilityDistances ? storm::utility::zero<ValueType>() : storm::utility::infinity<ValueType>();
+    // The distance of a state that has not been reached yet, i.e. one that any real distance improves upon. With
+    // probability distances that is zero. With hop distances no reachable state is more than numberOfStates - 1 hops
+    // away, so numberOfStates lies beyond every achievable distance.
+    ValueType unreachableDistance =
+        probabilityDistances ? storm::utility::zero<ValueType>() : storm::utility::convertNumber<ValueType, uint64_t>(numberOfStates);
     ValueType zeroDistance = probabilityDistances ? storm::utility::one<ValueType>() : storm::utility::zero<ValueType>();
 
     // Create storages for the lower and upper Dijkstra search.
-    std::vector<ValueType> lowerDistances(numberOfStates, inftyDistance);
+    std::vector<ValueType> lowerDistances(numberOfStates, unreachableDistance);
     std::vector<std::pair<uint64_t, uint64_t>> lowerPredecessors;
-    std::vector<ValueType> upperDistances(numberOfStates, inftyDistance);
+    std::vector<ValueType> upperDistances(numberOfStates, unreachableDistance);
     std::vector<std::pair<uint64_t, uint64_t>> upperPredecessors;
 
     if (generatePredecessors) {
@@ -1228,7 +1232,7 @@ boost::optional<ExplicitPivotStateResult<ValueType>> pickPivotState(
                              lowerValues && upperValues;
     bool foundPivotState = false;
 
-    ExplicitDijkstraQueueElement<ValueType> pivotState(inftyDistance, 0, true);
+    ExplicitDijkstraQueueElement<ValueType> pivotState(unreachableDistance, 0, true);
     ValueType pivotStateDeviation = storm::utility::zero<ValueType>();
     auto const& player2Grouping = transitionMatrix.getRowGroupIndices();
 

--- a/src/storm-pars/derivative/GradientDescentInstantiationSearcher.cpp
+++ b/src/storm-pars/derivative/GradientDescentInstantiationSearcher.cpp
@@ -389,17 +389,8 @@ GradientDescentInstantiationSearcher<FunctionType, ConstantType>::gradientDescen
     STORM_LOG_ASSERT(this->synthesisTask->isBoundSet(), "Task does not involve a bound.");
 
     std::map<VariableType<FunctionType>, CoefficientType<FunctionType>> bestInstantiation;
-    ConstantType bestValue;
-    switch (this->synthesisTask->getBound().comparisonType) {
-        case logic::ComparisonType::Greater:
-        case logic::ComparisonType::GreaterEqual:
-            bestValue = -utility::infinity<ConstantType>();
-            break;
-        case logic::ComparisonType::Less:
-        case logic::ComparisonType::LessEqual:
-            bestValue = utility::infinity<ConstantType>();
-            break;
-    }
+    // No value has been found yet; the first one we see is the best one so far, whichever direction we optimize in.
+    std::optional<ConstantType> bestValue;
 
     std::random_device device;
     std::default_random_engine engine(device());
@@ -437,23 +428,25 @@ GradientDescentInstantiationSearcher<FunctionType, ConstantType>::gradientDescen
         ConstantType prob = stochasticGradientDescent(point);
         stochasticWatch.stop();
 
-        bool isFoundPointBetter = false;
-        switch (this->synthesisTask->getBound().comparisonType) {
-            case logic::ComparisonType::Greater:
-            case logic::ComparisonType::GreaterEqual:
-                isFoundPointBetter = prob > bestValue;
-                break;
-            case logic::ComparisonType::Less:
-            case logic::ComparisonType::LessEqual:
-                isFoundPointBetter = prob < bestValue;
-                break;
+        bool isFoundPointBetter = !bestValue;
+        if (bestValue) {
+            switch (this->synthesisTask->getBound().comparisonType) {
+                case logic::ComparisonType::Greater:
+                case logic::ComparisonType::GreaterEqual:
+                    isFoundPointBetter = prob > *bestValue;
+                    break;
+                case logic::ComparisonType::Less:
+                case logic::ComparisonType::LessEqual:
+                    isFoundPointBetter = prob < *bestValue;
+                    break;
+            }
         }
         if (isFoundPointBetter) {
             bestInstantiation = point;
             bestValue = prob;
         }
 
-        if (synthesisTask->getBound().isSatisfied(bestValue)) {
+        if (synthesisTask->getBound().isSatisfied(*bestValue)) {
             STORM_LOG_PROGRESS("Aborting because the bound is satisfied\n");
             break;
         } else if (storm::utility::resources::isTerminate()) {
@@ -461,10 +454,10 @@ GradientDescentInstantiationSearcher<FunctionType, ConstantType>::gradientDescen
         } else {
             if (constraintMethod == GradientDescentConstraintMethod::BARRIER_LOGARITHMIC) {
                 logarithmicBarrierTerm = logarithmicBarrierTerm / 10;
-                STORM_LOG_PROGRESS("Smaller term\n" << bestValue << "\n" << logarithmicBarrierTerm << "\n");
+                STORM_LOG_PROGRESS("Smaller term\n" << *bestValue << "\n" << logarithmicBarrierTerm << "\n");
                 continue;
             }
-            STORM_LOG_PROGRESS("Sorry, couldn't satisfy the bound (yet). Best found value so far: " << bestValue << "\n");
+            STORM_LOG_PROGRESS("Sorry, couldn't satisfy the bound (yet). Best found value so far: " << *bestValue << "\n");
             continue;
         }
     }
@@ -479,7 +472,8 @@ GradientDescentInstantiationSearcher<FunctionType, ConstantType>::gradientDescen
         }
     }
 
-    return std::make_pair(bestInstantiation, bestValue);
+    STORM_LOG_ASSERT(bestValue.has_value(), "Expected at least one evaluated instantiation.");
+    return std::make_pair(bestInstantiation, *bestValue);
 }
 
 template<typename FunctionType, typename ConstantType>

--- a/src/storm-pars/transformer/RobustParameterLifter.cpp
+++ b/src/storm-pars/transformer/RobustParameterLifter.cpp
@@ -18,6 +18,7 @@
 #include "storm/solver/Z3SmtSolver.h"
 #include "storm/storage/expressions/Expression.h"
 #include "storm/storage/expressions/RationalFunctionToExpression.h"
+#include "storm/utility/Extremum.h"
 #include "storm/utility/constants.h"
 #include "storm/utility/logging.h"
 #include "storm/utility/macros.h"
@@ -514,19 +515,16 @@ Interval evaluateExtremaAnnotations(std::map<UniPoly, std::set<double>> extremaA
             }
         }
 
-        double minValue = utility::infinity<double>();
-        double maxValue = -utility::infinity<double>();
+        utility::Minimum<double> minValue;
+        utility::Maximum<double> maxValue;
 
         for (auto const& potentialExtremum : potentialExtrema) {
             auto value = utility::convertNumber<double>(poly.evaluate(utility::convertNumber<RationalFunctionCoefficient>(potentialExtremum)));
-            if (value > maxValue) {
-                maxValue = value;
-            }
-            if (value < minValue) {
-                minValue = value;
-            }
+            maxValue &= value;
+            minValue &= value;
         }
-        sumOfTerms += Interval(minValue, maxValue);
+        STORM_LOG_ASSERT(!minValue.empty(), "Expected at least one potential extremum.");
+        sumOfTerms += Interval(*minValue, *maxValue);
     }
     return sumOfTerms;
 }
@@ -537,8 +535,8 @@ bool RobustParameterLifter<ParametricType, ConstantType>::FunctionValuationColle
     std::unordered_map<RobustAbstractValuation, Interval, RobustAbstractValuationHash> insertThese;
     for (auto& [abstrValuation, placeholder] : collectedValuations) {
         // Results of our computations go here, we use different methods
-        ConstantType lowerBound = utility::infinity<ConstantType>();
-        ConstantType upperBound = -utility::infinity<ConstantType>();
+        ConstantType lowerBound = utility::zero<ConstantType>();
+        ConstantType upperBound = utility::zero<ConstantType>();
 
         if (abstrValuation.getExtrema()) {
             // We know the extrema of this abstract valuation => we can get the exact bounds easily
@@ -562,16 +560,17 @@ bool RobustParameterLifter<ParametricType, ConstantType>::FunctionValuationColle
                     }
                 }
 
+                utility::Minimum<ConstantType> minimum;
+                utility::Maximum<ConstantType> maximum;
                 for (auto const& potentialExtremum : potentialExtrema) {
                     // Possible optimization: evaluate all transitions together, keeping track of intermediate results
                     auto value = maybeAnnotation->evaluate(utility::convertNumber<double>(potentialExtremum));
-                    if (value > upperBound) {
-                        upperBound = value;
-                    }
-                    if (value < lowerBound) {
-                        lowerBound = value;
-                    }
+                    maximum &= value;
+                    minimum &= value;
                 }
+                STORM_LOG_ASSERT(!minimum.empty(), "Expected at least one potential extremum.");
+                lowerBound = *minimum;
+                upperBound = *maximum;
             } else {
                 // We may have multiple parameters, but the derivatives w.r.t. each parameter only contain that parameter
                 // We first figure out the positions of the lower and upper bounds per parameter
@@ -593,8 +592,8 @@ bool RobustParameterLifter<ParametricType, ConstantType>::FunctionValuationColle
 
                     CoefficientType minPosP;
                     CoefficientType maxPosP;
-                    CoefficientType minValue = utility::infinity<CoefficientType>();
-                    CoefficientType maxValue = -utility::infinity<CoefficientType>();
+                    utility::Minimum<CoefficientType> minValue;
+                    utility::Maximum<CoefficientType> maxValue;
 
                     auto instantiation = std::map<VariableType, CoefficientType>(region.getLowerBoundaries());
 
@@ -602,15 +601,14 @@ bool RobustParameterLifter<ParametricType, ConstantType>::FunctionValuationColle
                         // We modify the instantiation to have value potentialExtremum at p, keeping other parameters the same
                         instantiation[p] = potentialExtremum;
                         auto value = abstrValuation.getTransition().evaluate(instantiation);
-                        if (value > maxValue) {
-                            maxValue = value;
+                        if (maxValue &= value) {
                             maxPosP = potentialExtremum;
                         }
-                        if (value < minValue) {
-                            minValue = value;
+                        if (minValue &= value) {
                             minPosP = potentialExtremum;
                         }
                     }
+                    STORM_LOG_ASSERT(!minValue.empty(), "Expected at least one potential extremum.");
 
                     lowerPositions[p] = minPosP;
                     upperPositions[p] = maxPosP;

--- a/src/storm-pomdp/api/verification.h
+++ b/src/storm-pomdp/api/verification.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -80,7 +81,7 @@ storm::pomdp::modelchecker::BeliefExplorationPomdpModelChecker<storm::models::sp
     options.skipHeuristicSchedulers = false;
     options.useClipping = useClipping;
     options.useStateEliminationCutoff = false;
-    options.sizeThresholdInit = storm::utility::infinity<uint64_t>();
+    options.sizeThresholdInit = std::numeric_limits<uint64_t>::max();  // i.e. no size limit
     options.interactiveUnfolding = true;
     options.refine = false;
     options.gapThresholdInit = 0;

--- a/src/storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.cpp
+++ b/src/storm-pomdp/modelchecker/PreprocessingPomdpValueBoundsModelChecker.cpp
@@ -140,12 +140,14 @@ std::pair<std::vector<ValueType>, storm::storage::Scheduler<ValueType>> Preproce
     std::vector<ValueType> pomdpSchedulerResult = std::move(resultPtr->template asExplicitQuantitativeCheckResult<ValueType>().getValueVector());
 
     // Take the optimal value in ANY of the unfolded states for a POMDP state as the resulting state value
-    std::vector<ValueType> res(pomdp.getNumberOfStates(), info.minimize() ? storm::utility::infinity<ValueType>() : -storm::utility::infinity<ValueType>());
+    std::vector<ValueType> res(pomdp.getNumberOfStates(), storm::utility::zero<ValueType>());
+    storm::storage::BitVector hasValue(pomdp.getNumberOfStates(), false);
     for (uint64_t memPomdpState = 0; memPomdpState < pomdpSchedulerResult.size(); ++memPomdpState) {
         uint64_t modelState = memPomdpState / memoryBound;
-        if ((info.minimize() && pomdpSchedulerResult[memPomdpState] < res[modelState]) ||
+        if (!hasValue.get(modelState) || (info.minimize() && pomdpSchedulerResult[memPomdpState] < res[modelState]) ||
             (!info.minimize() && pomdpSchedulerResult[memPomdpState] > res[modelState])) {
             res[modelState] = pomdpSchedulerResult[memPomdpState];
+            hasValue.set(modelState);
         }
     }
     return std::make_pair(res, pomdpScheduler);

--- a/src/storm/modelchecker/csl/HybridCtmcCslModelChecker.cpp
+++ b/src/storm/modelchecker/csl/HybridCtmcCslModelChecker.cpp
@@ -106,14 +106,12 @@ std::unique_ptr<CheckResult> HybridCtmcCslModelChecker<ModelType>::computeBounde
         STORM_LOG_THROW(pathFormula.getTimeBoundReference().isTimeBound(), storm::exceptions::NotImplementedException,
                         "Currently step-bounded and reward-bounded properties on CTMCs are not supported.");
         ValueType lowerBound = 0;
-        ValueType upperBound = 0;
+        std::optional<ValueType> upperBound;
         if (pathFormula.hasLowerBound()) {
             lowerBound = pathFormula.getLowerBound<ValueType>();
         }
         if (pathFormula.hasUpperBound()) {
             upperBound = pathFormula.getNonStrictUpperBound<ValueType>();
-        } else {
-            upperBound = storm::utility::infinity<ValueType>();
         }
 
         return storm::modelchecker::helper::HybridCtmcCslHelper::computeBoundedUntilProbabilities<DdType, ValueType>(

--- a/src/storm/modelchecker/csl/HybridMarkovAutomatonCslModelChecker.cpp
+++ b/src/storm/modelchecker/csl/HybridMarkovAutomatonCslModelChecker.cpp
@@ -109,14 +109,12 @@ std::unique_ptr<CheckResult> HybridMarkovAutomatonCslModelChecker<ModelType>::co
     STORM_LOG_THROW(pathFormula.getTimeBoundReference().isTimeBound(), storm::exceptions::NotImplementedException,
                     "Currently step-bounded and reward-bounded properties on MarkovAutomatons are not supported.");
     double lowerBound = 0;
-    double upperBound = 0;
+    std::optional<double> upperBound;
     if (pathFormula.hasLowerBound()) {
         lowerBound = pathFormula.getLowerBound<double>();
     }
     if (pathFormula.hasUpperBound()) {
         upperBound = pathFormula.getNonStrictUpperBound<double>();
-    } else {
-        upperBound = storm::utility::infinity<double>();
     }
 
     return storm::modelchecker::helper::HybridMarkovAutomatonCslHelper::computeBoundedUntilProbabilities<DdType, ValueType>(

--- a/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
+++ b/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
@@ -60,14 +60,12 @@ std::unique_ptr<CheckResult> SparseCtmcCslModelChecker<SparseCtmcModelType>::com
         STORM_LOG_THROW(pathFormula.getTimeBoundReference().isTimeBound(), storm::exceptions::NotImplementedException,
                         "Currently step-bounded or reward-bounded properties on CTMCs are not supported.");
         ValueType lowerBound = 0;
-        ValueType upperBound = 0;
+        std::optional<ValueType> upperBound;
         if (pathFormula.hasLowerBound()) {
             lowerBound = pathFormula.getLowerBound<ValueType>();
         }
         if (pathFormula.hasUpperBound()) {
             upperBound = pathFormula.getNonStrictUpperBound<ValueType>();
-        } else {
-            upperBound = storm::utility::infinity<ValueType>();
         }
 
         std::vector<ValueType> numericResult = storm::modelchecker::helper::SparseCtmcCslHelper::computeBoundedUntilProbabilities(

--- a/src/storm/modelchecker/csl/SparseMarkovAutomatonCslModelChecker.cpp
+++ b/src/storm/modelchecker/csl/SparseMarkovAutomatonCslModelChecker.cpp
@@ -80,14 +80,12 @@ std::unique_ptr<CheckResult> SparseMarkovAutomatonCslModelChecker<SparseMarkovAu
     STORM_LOG_THROW(pathFormula.getTimeBoundReference().isTimeBound(), storm::exceptions::NotImplementedException,
                     "Currently step-bounded and reward-bounded properties on MAs are not supported.");
     double lowerBound = 0;
-    double upperBound = 0;
+    std::optional<double> upperBound;
     if (pathFormula.hasLowerBound()) {
         lowerBound = pathFormula.getLowerBound<double>();
     }
     if (pathFormula.hasUpperBound()) {
         upperBound = pathFormula.getNonStrictUpperBound<double>();
-    } else {
-        upperBound = storm::utility::infinity<double>();
     }
 
     std::vector<ValueType> result = storm::modelchecker::helper::SparseMarkovAutomatonCslHelper::computeBoundedUntilProbabilities(

--- a/src/storm/modelchecker/csl/helper/HybridCtmcCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/HybridCtmcCslHelper.cpp
@@ -57,9 +57,9 @@ template<storm::dd::DdType DdType, typename ValueType>
 std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilProbabilities(
     Environment const& env, storm::models::symbolic::Ctmc<DdType, ValueType> const& model, bool onlyInitialStatesRelevant,
     storm::dd::Add<DdType, ValueType> const& rateMatrix, storm::dd::Add<DdType, ValueType> const& exitRateVector, storm::dd::Bdd<DdType> const& phiStates,
-    storm::dd::Bdd<DdType> const& psiStates, bool qualitative, ValueType lowerBound, ValueType upperBound) {
+    storm::dd::Bdd<DdType> const& psiStates, bool qualitative, ValueType lowerBound, std::optional<ValueType> const& upperBound) {
     // If the time bounds are [0, inf], we rather call untimed reachability.
-    if (storm::utility::isZero(lowerBound) && upperBound == storm::utility::infinity<ValueType>()) {
+    if (storm::utility::isZero(lowerBound) && !upperBound) {
         return computeUntilProbabilities(env, model, rateMatrix, exitRateVector, phiStates, psiStates, qualitative);
     }
 
@@ -99,7 +99,7 @@ std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilProbabiliti
     STORM_LOG_INFO("Found " << statesWithProbabilityGreater0NonPsi.getNonZeroCount() << " 'maybe' states.");
 
     if (!statesWithProbabilityGreater0NonPsi.isZero()) {
-        if (storm::utility::isZero(upperBound)) {
+        if (upperBound && storm::utility::isZero(*upperBound)) {
             // In this case, the interval is of the form [0, 0].
             return std::unique_ptr<CheckResult>(
                 new SymbolicQuantitativeCheckResult<DdType, ValueType>(model.getReachableStates(), psiStates.template toAdd<ValueType>()));
@@ -136,12 +136,12 @@ std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilProbabiliti
                 // Finally compute the transient probabilities.
                 std::vector<ValueType> values(statesWithProbabilityGreater0NonPsi.getNonZeroCount(), storm::utility::zero<ValueType>());
                 std::vector<ValueType> subresult = storm::modelchecker::helper::SparseCtmcCslHelper::computeTransientProbabilities(
-                    env, explicitUniformizedMatrix, &explicitB, upperBound, uniformizationRate, values, epsilon);
+                    env, explicitUniformizedMatrix, &explicitB, *upperBound, uniformizationRate, values, epsilon);
 
                 return std::unique_ptr<CheckResult>(new HybridQuantitativeCheckResult<DdType>(
                     model.getReachableStates(), (psiStates || !statesWithProbabilityGreater0) && model.getReachableStates(),
                     psiStates.template toAdd<ValueType>(), statesWithProbabilityGreater0NonPsi, odd, subresult));
-            } else if (upperBound == storm::utility::infinity<ValueType>()) {
+            } else if (!upperBound) {
                 // In this case, the interval is of the form [t, inf] with t != 0.
 
                 // Start by computing the (unbounded) reachability probabilities of reaching psi states while
@@ -196,7 +196,7 @@ std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilProbabiliti
             } else {
                 // In this case, the interval is of the form [t, t'] with t != 0 and t' != inf.
 
-                if (lowerBound != upperBound) {
+                if (lowerBound != *upperBound) {
                     // In this case, the interval is of the form [t, t'] with t != 0, t' != inf and t != t'.
 
                     // Find the maximal rate of all 'maybe' states to take it as the uniformization rate.
@@ -223,7 +223,7 @@ std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilProbabiliti
                     // Compute the transient probabilities.
                     std::vector<ValueType> values(statesWithProbabilityGreater0NonPsi.getNonZeroCount(), storm::utility::zero<ValueType>());
                     std::vector<ValueType> subResult = storm::modelchecker::helper::SparseCtmcCslHelper::computeTransientProbabilities(
-                        env, explicitUniformizedMatrix, &explicitB, upperBound - lowerBound, uniformizationRate, values, epsilon);
+                        env, explicitUniformizedMatrix, &explicitB, *upperBound - lowerBound, uniformizationRate, values, epsilon);
 
                     // Transform the explicit result to a hybrid check result, so we can easily convert it to
                     // a symbolic qualitative format.
@@ -252,7 +252,7 @@ std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilProbabiliti
 
                     // If the lower and upper bounds coincide, we have only determined the relevant states at this
                     // point, but we still need to construct the starting vector.
-                    if (lowerBound == upperBound) {
+                    if (lowerBound == *upperBound) {
                         odd = relevantStates.createOdd();
                         newSubresult = psiStates.template toAdd<ValueType>().toVector(odd);
                     }
@@ -488,7 +488,7 @@ template std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilPr
     Environment const& env, storm::models::symbolic::Ctmc<storm::dd::DdType::CUDD, double> const& model, bool onlyInitialStatesRelevant,
     storm::dd::Add<storm::dd::DdType::CUDD, double> const& rateMatrix, storm::dd::Add<storm::dd::DdType::CUDD, double> const& exitRateVector,
     storm::dd::Bdd<storm::dd::DdType::CUDD> const& phiStates, storm::dd::Bdd<storm::dd::DdType::CUDD> const& psiStates, bool qualitative, double lowerBound,
-    double upperBound);
+    std::optional<double> const& upperBound);
 template std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeInstantaneousRewards(
     Environment const& env, storm::models::symbolic::Ctmc<storm::dd::DdType::CUDD, double> const& model, bool onlyInitialStatesRelevant,
     storm::dd::Add<storm::dd::DdType::CUDD, double> const& rateMatrix, storm::dd::Add<storm::dd::DdType::CUDD, double> const& exitRateVector,
@@ -523,7 +523,7 @@ template std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeBoundedUntilPr
     Environment const& env, storm::models::symbolic::Ctmc<storm::dd::DdType::Sylvan, double> const& model, bool onlyInitialStatesRelevant,
     storm::dd::Add<storm::dd::DdType::Sylvan, double> const& rateMatrix, storm::dd::Add<storm::dd::DdType::Sylvan, double> const& exitRateVector,
     storm::dd::Bdd<storm::dd::DdType::Sylvan> const& phiStates, storm::dd::Bdd<storm::dd::DdType::Sylvan> const& psiStates, bool qualitative, double lowerBound,
-    double upperBound);
+    std::optional<double> const& upperBound);
 template std::unique_ptr<CheckResult> HybridCtmcCslHelper::computeInstantaneousRewards(
     Environment const& env, storm::models::symbolic::Ctmc<storm::dd::DdType::Sylvan, double> const& model, bool onlyInitialStatesRelevant,
     storm::dd::Add<storm::dd::DdType::Sylvan, double> const& rateMatrix, storm::dd::Add<storm::dd::DdType::Sylvan, double> const& exitRateVector,

--- a/src/storm/modelchecker/csl/helper/HybridCtmcCslHelper.h
+++ b/src/storm/modelchecker/csl/helper/HybridCtmcCslHelper.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <memory>
 
 #include "storm/models/symbolic/Ctmc.h"
@@ -24,7 +26,7 @@ class HybridCtmcCslHelper {
                                                                          bool onlyInitialStatesRelevant, storm::dd::Add<DdType, ValueType> const& rateMatrix,
                                                                          storm::dd::Add<DdType, ValueType> const& exitRateVector,
                                                                          storm::dd::Bdd<DdType> const& phiStates, storm::dd::Bdd<DdType> const& psiStates,
-                                                                         bool qualitative, ValueType lowerBound, ValueType upperBound);
+                                                                         bool qualitative, ValueType lowerBound, std::optional<ValueType> const& upperBound);
 
     template<storm::dd::DdType DdType, typename ValueType>
         requires storm::NumberTraits<ValueType>::SupportsExponential

--- a/src/storm/modelchecker/csl/helper/HybridMarkovAutomatonCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/HybridMarkovAutomatonCslHelper.cpp
@@ -54,14 +54,14 @@ std::unique_ptr<CheckResult> HybridMarkovAutomatonCslHelper::computeBoundedUntil
     Environment const& env, OptimizationDirection dir, storm::models::symbolic::MarkovAutomaton<DdType, ValueType> const& model,
     storm::dd::Add<DdType, ValueType> const& transitionMatrix, storm::dd::Bdd<DdType> const& markovianStates,
     storm::dd::Add<DdType, ValueType> const& exitRateVector, storm::dd::Bdd<DdType> const& phiStates, storm::dd::Bdd<DdType> const& psiStates, bool qualitative,
-    double lowerBound, double upperBound) {
+    double lowerBound, std::optional<double> const& upperBound) {
     // If the time bounds are [0, inf], we rather call untimed reachability.
-    if (storm::utility::isZero(lowerBound) && upperBound == storm::utility::infinity<ValueType>()) {
+    if (storm::utility::isZero(lowerBound) && !upperBound) {
         return storm::modelchecker::helper::HybridMdpPrctlHelper<DdType, ValueType>::computeUntilProbabilities(env, dir, model, transitionMatrix, phiStates,
                                                                                                                psiStates, qualitative);
     }
     // If the interval is of the form [0,0], we can return the result directly
-    if (storm::utility::isZero(upperBound)) {
+    if (upperBound && storm::utility::isZero(*upperBound)) {
         // In this case, the interval is of the form [0, 0].
         return std::unique_ptr<CheckResult>(
             new SymbolicQuantitativeCheckResult<DdType, ValueType>(model.getReachableStates(), psiStates.template toAdd<ValueType>()));
@@ -88,7 +88,7 @@ template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<!
 std::unique_ptr<CheckResult> HybridMarkovAutomatonCslHelper::computeBoundedUntilProbabilities(
     Environment const&, OptimizationDirection, storm::models::symbolic::MarkovAutomaton<DdType, ValueType> const&, storm::dd::Add<DdType, ValueType> const&,
     storm::dd::Bdd<DdType> const&, storm::dd::Add<DdType, ValueType> const&, storm::dd::Bdd<DdType> const&, storm::dd::Bdd<DdType> const&, bool, double,
-    double) {
+    std::optional<double> const&) {
     STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Computing bounded until probabilities is unsupported for this value type.");
 }
 
@@ -105,7 +105,7 @@ template std::unique_ptr<CheckResult> HybridMarkovAutomatonCslHelper::computeBou
     Environment const& env, OptimizationDirection dir, storm::models::symbolic::MarkovAutomaton<storm::dd::DdType::CUDD, double> const& model,
     storm::dd::Add<storm::dd::DdType::CUDD, double> const& transitionMatrix, storm::dd::Bdd<storm::dd::DdType::CUDD> const& markovianStates,
     storm::dd::Add<storm::dd::DdType::CUDD, double> const& exitRateVector, storm::dd::Bdd<storm::dd::DdType::CUDD> const& phiStates,
-    storm::dd::Bdd<storm::dd::DdType::CUDD> const& psiStates, bool qualitative, double lowerBound, double upperBound);
+    storm::dd::Bdd<storm::dd::DdType::CUDD> const& psiStates, bool qualitative, double lowerBound, std::optional<double> const& upperBound);
 
 // Sylvan, double.
 template std::unique_ptr<CheckResult> HybridMarkovAutomatonCslHelper::computeReachabilityRewards(
@@ -118,7 +118,7 @@ template std::unique_ptr<CheckResult> HybridMarkovAutomatonCslHelper::computeBou
     Environment const& env, OptimizationDirection dir, storm::models::symbolic::MarkovAutomaton<storm::dd::DdType::Sylvan, double> const& model,
     storm::dd::Add<storm::dd::DdType::Sylvan, double> const& transitionMatrix, storm::dd::Bdd<storm::dd::DdType::Sylvan> const& markovianStates,
     storm::dd::Add<storm::dd::DdType::Sylvan, double> const& exitRateVector, storm::dd::Bdd<storm::dd::DdType::Sylvan> const& phiStates,
-    storm::dd::Bdd<storm::dd::DdType::Sylvan> const& psiStates, bool qualitative, double lowerBound, double upperBound);
+    storm::dd::Bdd<storm::dd::DdType::Sylvan> const& psiStates, bool qualitative, double lowerBound, std::optional<double> const& upperBound);
 
 // Sylvan, rational number.
 template std::unique_ptr<CheckResult> HybridMarkovAutomatonCslHelper::computeReachabilityRewards(
@@ -131,7 +131,7 @@ template std::unique_ptr<CheckResult> HybridMarkovAutomatonCslHelper::computeBou
     Environment const& env, OptimizationDirection dir, storm::models::symbolic::MarkovAutomaton<storm::dd::DdType::Sylvan, storm::RationalNumber> const& model,
     storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalNumber> const& transitionMatrix, storm::dd::Bdd<storm::dd::DdType::Sylvan> const& markovianStates,
     storm::dd::Add<storm::dd::DdType::Sylvan, storm::RationalNumber> const& exitRateVector, storm::dd::Bdd<storm::dd::DdType::Sylvan> const& phiStates,
-    storm::dd::Bdd<storm::dd::DdType::Sylvan> const& psiStates, bool qualitative, double lowerBound, double upperBound);
+    storm::dd::Bdd<storm::dd::DdType::Sylvan> const& psiStates, bool qualitative, double lowerBound, std::optional<double> const& upperBound);
 
 }  // namespace helper
 }  // namespace modelchecker

--- a/src/storm/modelchecker/csl/helper/HybridMarkovAutomatonCslHelper.h
+++ b/src/storm/modelchecker/csl/helper/HybridMarkovAutomatonCslHelper.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <memory>
 
 #include "storm/models/symbolic/MarkovAutomaton.h"
@@ -32,7 +34,7 @@ class HybridMarkovAutomatonCslHelper {
                                                                          storm::dd::Bdd<DdType> const& markovianStates,
                                                                          storm::dd::Add<DdType, ValueType> const& exitRateVector,
                                                                          storm::dd::Bdd<DdType> const& phiStates, storm::dd::Bdd<DdType> const& psiStates,
-                                                                         bool qualitative, double lowerBound, double upperBound);
+                                                                         bool qualitative, double lowerBound, std::optional<double> const& upperBound);
 
     template<storm::dd::DdType DdType, typename ValueType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
     static std::unique_ptr<CheckResult> computeBoundedUntilProbabilities(Environment const& env, OptimizationDirection dir,
@@ -41,7 +43,7 @@ class HybridMarkovAutomatonCslHelper {
                                                                          storm::dd::Bdd<DdType> const& markovianStates,
                                                                          storm::dd::Add<DdType, ValueType> const& exitRateVector,
                                                                          storm::dd::Bdd<DdType> const& phiStates, storm::dd::Bdd<DdType> const& psiStates,
-                                                                         bool qualitative, double lowerBound, double upperBound);
+                                                                         bool qualitative, double lowerBound, std::optional<double> const& upperBound);
 };
 
 }  // namespace helper

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
@@ -57,14 +57,14 @@ template<typename ValueType>
 std::vector<ValueType> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-    std::vector<ValueType> const& exitRates, bool qualitative, ValueType lowerBound, ValueType upperBound) {
+    std::vector<ValueType> const& exitRates, bool qualitative, ValueType lowerBound, std::optional<ValueType> const& upperBound) {
     STORM_LOG_THROW(!env.solver().isForceExact(), storm::exceptions::InvalidOperationException,
                     "Exact computations not possible for bounded until probabilities.");
 
     uint_fast64_t numberOfStates = rateMatrix.getRowCount();
 
     // If the time bounds are [0, inf], we rather call untimed reachability.
-    if (storm::utility::isZero(lowerBound) && upperBound == storm::utility::infinity<ValueType>()) {
+    if (storm::utility::isZero(lowerBound) && !upperBound) {
         return computeUntilProbabilities(env, std::move(goal), rateMatrix, backwardTransitions, exitRates, phiStates, psiStates, qualitative);
     }
 
@@ -95,7 +95,7 @@ std::vector<ValueType> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
 
     do {  // Iterate until the desired precision is reached (only relevant for relative precision criterion)
         if (!statesWithProbabilityGreater0.empty()) {
-            if (storm::utility::isZero(upperBound)) {
+            if (upperBound && storm::utility::isZero(*upperBound)) {
                 // In this case, the interval is of the form [0, 0].
                 result = std::vector<ValueType>(numberOfStates, storm::utility::zero<ValueType>());
                 storm::utility::vector::setVectorValues<ValueType>(result, psiStates, storm::utility::one<ValueType>());
@@ -128,10 +128,10 @@ std::vector<ValueType> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
                         // Finally compute the transient probabilities.
                         std::vector<ValueType> values(statesWithProbabilityGreater0NonPsi.getNumberOfSetBits(), storm::utility::zero<ValueType>());
                         std::vector<ValueType> subresult =
-                            computeTransientProbabilities(env, uniformizedMatrix, &b, upperBound, uniformizationRate, values, epsilon);
+                            computeTransientProbabilities(env, uniformizedMatrix, &b, *upperBound, uniformizationRate, values, epsilon);
                         storm::utility::vector::setVectorValues(result, statesWithProbabilityGreater0NonPsi, subresult);
                     }
-                } else if (upperBound == storm::utility::infinity<ValueType>()) {
+                } else if (!upperBound) {
                     // In this case, the interval is of the form [t, inf] with t != 0.
 
                     // Start by computing the (unbounded) reachability probabilities of reaching psi states while
@@ -164,7 +164,7 @@ std::vector<ValueType> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
                 } else {
                     // In this case, the interval is of the form [t, t'] with t != 0 and t' != inf.
 
-                    if (lowerBound != upperBound) {
+                    if (lowerBound != *upperBound) {
                         // In this case, the interval is of the form [t, t'] with t != 0, t' != inf and t != t'.
 
                         storm::storage::BitVector relevantStates = statesWithProbabilityGreater0 & phiStates;
@@ -193,7 +193,7 @@ std::vector<ValueType> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
                             std::vector<ValueType> values(statesWithProbabilityGreater0NonPsi.getNumberOfSetBits(), storm::utility::zero<ValueType>());
                             // divide the possible error by two since we will make this error two times.
                             std::vector<ValueType> subresult =
-                                computeTransientProbabilities(env, uniformizedMatrix, &b, upperBound - lowerBound, uniformizationRate, values,
+                                computeTransientProbabilities(env, uniformizedMatrix, &b, *upperBound - lowerBound, uniformizationRate, values,
                                                               epsilon / storm::utility::convertNumber<ValueType>(2.0));
                             storm::utility::vector::setVectorValues(newSubresult, statesWithProbabilityGreater0NonPsi % relevantStates, subresult);
                         }
@@ -753,7 +753,7 @@ storm::storage::SparseMatrix<ValueType> SparseCtmcCslHelper::computeGeneratorMat
 template std::vector<double> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<double>&& goal, storm::storage::SparseMatrix<double> const& rateMatrix,
     storm::storage::SparseMatrix<double> const& backwardTransitions, storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-    std::vector<double> const& exitRates, bool qualitative, double lowerBound, double upperBound);
+    std::vector<double> const& exitRates, bool qualitative, double lowerBound, std::optional<double> const& upperBound);
 
 template std::vector<double> SparseCtmcCslHelper::computeUntilProbabilities(Environment const& env, storm::solver::SolveGoal<double>&& goal,
                                                                             storm::storage::SparseMatrix<double> const& rateMatrix,

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.h
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "storm/storage/BitVector.h"
 
 #include "storm/logic/OperatorFormula.h"
@@ -24,7 +26,7 @@ class SparseCtmcCslHelper {
                                                                    storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                    storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
                                                                    std::vector<ValueType> const& exitRates, bool qualitative, ValueType lowerBound,
-                                                                   ValueType upperBound);
+                                                                   std::optional<ValueType> const& upperBound);
 
     template<typename ValueType>
     static std::vector<ValueType> computeUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,

--- a/src/storm/modelchecker/csl/helper/SparseMarkovAutomatonCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseMarkovAutomatonCslHelper.cpp
@@ -7,6 +7,7 @@
 #include "storm/environment/solver/TimeBoundedSolverEnvironment.h"
 #include "storm/environment/solver/TopologicalSolverEnvironment.h"
 #include "storm/exceptions/InvalidOperationException.h"
+#include "storm/exceptions/NotSupportedException.h"
 #include "storm/exceptions/UncheckedRequirementException.h"
 #include "storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.h"
 #include "storm/models/sparse/StandardRewardModel.h"
@@ -69,7 +70,7 @@ class UnifPlusHelper {
 
     std::vector<ValueType> computeBoundedUntilProbabilities(storm::Environment const& env, OptimizationDirection dir,
                                                             storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-                                                            ValueType const& upperTimeBound,
+                                                            std::optional<ValueType> const& upperTimeBound,
                                                             boost::optional<storm::storage::BitVector> const& relevantStates = boost::none) {
         // Since there is no lower time bound, we can treat the psiStates as if they are absorbing.
 
@@ -80,8 +81,8 @@ class UnifPlusHelper {
         storm::storage::BitVector markovianStatesModMaybeStates = markovianMaybeStates % maybeStates;
         storm::storage::BitVector probabilisticStatesModMaybeStates = probabilisticMaybeStates % maybeStates;
         // Catch the case where this query can be solved by solving the untimed variant instead.
-        // This is the case if there is no Markovian maybe state (e.g. if the initial state is already a psi state) of if the time bound is infinity.
-        if (markovianMaybeStates.empty() || storm::utility::isInfinity(upperTimeBound)) {
+        // This is the case if there is no Markovian maybe state (e.g. if the initial state is already a psi state) or if there is no time bound.
+        if (markovianMaybeStates.empty() || !upperTimeBound) {
             return SparseMarkovAutomatonCslHelper::computeUntilProbabilities<ValueType>(env, dir, transitionMatrix, transitionMatrix.transpose(true), phiStates,
                                                                                         psiStates, false, false)
                 .values;
@@ -162,10 +163,11 @@ class UnifPlusHelper {
         bool abortedInnerIterations = false;
         while (!converged) {
             // Maximal step size
-            uint64_t N = storm::utility::ceil(lambda * upperTimeBound * std::exp(2) - storm::utility::log(kappa * epsilon));
+            uint64_t N = storm::utility::ceil(lambda * *upperTimeBound * std::exp(2) - storm::utility::log(kappa * epsilon));
             // Compute poisson distribution.
             // The division by 8 is similar to what is done for CTMCs (probably to reduce numerical impacts?)
-            auto foxGlynnResult = storm::utility::numerical::foxGlynn(lambda * upperTimeBound, epsilon * kappa / storm::utility::convertNumber<ValueType>(8.0));
+            auto foxGlynnResult =
+                storm::utility::numerical::foxGlynn(lambda * *upperTimeBound, epsilon * kappa / storm::utility::convertNumber<ValueType>(8.0));
             // Scale the weights so they sum to one.
             // storm::utility::vector::scaleVectorInPlace(foxGlynnResult.weights, storm::utility::one<ValueType>() / foxGlynnResult.totalWeight);
 
@@ -632,14 +634,17 @@ template<typename ValueType>
 std::vector<ValueType> computeBoundedUntilProbabilitiesImca(Environment const& env, OptimizationDirection dir,
                                                             storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                             std::vector<ValueType> const& exitRateVector, storm::storage::BitVector const& markovianStates,
-                                                            storm::storage::BitVector const& psiStates, std::pair<double, double> const& boundsPair) {
+                                                            storm::storage::BitVector const& psiStates,
+                                                            std::pair<double, std::optional<double>> const& boundsPair) {
     STORM_LOG_TRACE("Using IMCA's technique to compute bounded until probabilities.");
 
     uint64_t numberOfStates = transitionMatrix.getRowGroupCount();
 
     // 'Unpack' the bounds to make them more easily accessible.
+    STORM_LOG_THROW(boundsPair.second.has_value(), storm::exceptions::NotSupportedException,
+                    "IMCA's technique requires an upper time bound, but the given property has none.");
     double lowerBound = boundsPair.first;
-    double upperBound = boundsPair.second;
+    double upperBound = *boundsPair.second;
 
     // (1) Compute the accuracy we need to achieve the required error bound.
     ValueType maxExitRate = 0;
@@ -702,7 +707,7 @@ template<typename ValueType, typename std::enable_if<storm::NumberTraits<ValueTy
 std::vector<ValueType> SparseMarkovAutomatonCslHelper::computeBoundedUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     std::vector<ValueType> const& exitRateVector, storm::storage::BitVector const& markovianStates, storm::storage::BitVector const& phiStates,
-    storm::storage::BitVector const& psiStates, std::pair<double, double> const& boundsPair) {
+    storm::storage::BitVector const& psiStates, std::pair<double, std::optional<double>> const& boundsPair) {
     STORM_LOG_THROW(!env.solver().isForceExact(), storm::exceptions::InvalidOperationException,
                     "Exact computations not possible for bounded until probabilities.");
 
@@ -738,7 +743,7 @@ std::vector<ValueType> SparseMarkovAutomatonCslHelper::computeBoundedUntilProbab
                                                                                         storm::storage::SparseMatrix<ValueType> const&,
                                                                                         std::vector<ValueType> const&, storm::storage::BitVector const&,
                                                                                         storm::storage::BitVector const&, storm::storage::BitVector const&,
-                                                                                        std::pair<double, double> const&) {
+                                                                                        std::pair<double, std::optional<double>> const&) {
     STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Computing bounded until probabilities is unsupported for this value type.");
 }
 
@@ -803,7 +808,7 @@ MDPSparseModelCheckingHelperReturnType<ValueType> SparseMarkovAutomatonCslHelper
 template std::vector<double> SparseMarkovAutomatonCslHelper::computeBoundedUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<double>&& goal, storm::storage::SparseMatrix<double> const& transitionMatrix,
     std::vector<double> const& exitRateVector, storm::storage::BitVector const& markovianStates, storm::storage::BitVector const& phiStates,
-    storm::storage::BitVector const& psiStates, std::pair<double, double> const& boundsPair);
+    storm::storage::BitVector const& psiStates, std::pair<double, std::optional<double>> const& boundsPair);
 
 template MDPSparseModelCheckingHelperReturnType<double> SparseMarkovAutomatonCslHelper::computeUntilProbabilities(
     Environment const& env, OptimizationDirection dir, storm::storage::SparseMatrix<double> const& transitionMatrix,
@@ -829,7 +834,7 @@ template MDPSparseModelCheckingHelperReturnType<double> SparseMarkovAutomatonCsl
 template std::vector<storm::RationalNumber> SparseMarkovAutomatonCslHelper::computeBoundedUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& transitionMatrix,
     std::vector<storm::RationalNumber> const& exitRateVector, storm::storage::BitVector const& markovianStates, storm::storage::BitVector const& phiStates,
-    storm::storage::BitVector const& psiStates, std::pair<double, double> const& boundsPair);
+    storm::storage::BitVector const& psiStates, std::pair<double, std::optional<double>> const& boundsPair);
 
 template MDPSparseModelCheckingHelperReturnType<storm::RationalNumber> SparseMarkovAutomatonCslHelper::computeUntilProbabilities(
     Environment const& env, OptimizationDirection dir, storm::storage::SparseMatrix<storm::RationalNumber> const& transitionMatrix,

--- a/src/storm/modelchecker/csl/helper/SparseMarkovAutomatonCslHelper.h
+++ b/src/storm/modelchecker/csl/helper/SparseMarkovAutomatonCslHelper.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "storm/modelchecker/prctl/helper/MDPModelCheckingHelperReturnType.h"
 #include "storm/solver/MinMaxLinearEquationSolver.h"
 #include "storm/solver/OptimizationDirection.h"
@@ -23,14 +25,16 @@ class SparseMarkovAutomatonCslHelper {
                                                                    storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                    std::vector<ValueType> const& exitRateVector,
                                                                    storm::storage::BitVector const& markovianStates, storm::storage::BitVector const& phiStates,
-                                                                   storm::storage::BitVector const& psiStates, std::pair<double, double> const& boundsPair);
+                                                                   storm::storage::BitVector const& psiStates,
+                                                                   std::pair<double, std::optional<double>> const& boundsPair);
 
     template<typename ValueType, typename std::enable_if<!storm::NumberTraits<ValueType>::SupportsExponential, int>::type = 0>
     static std::vector<ValueType> computeBoundedUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
                                                                    storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                    std::vector<ValueType> const& exitRateVector,
                                                                    storm::storage::BitVector const& markovianStates, storm::storage::BitVector const& phiStates,
-                                                                   storm::storage::BitVector const& psiStates, std::pair<double, double> const& boundsPair);
+                                                                   storm::storage::BitVector const& psiStates,
+                                                                   std::pair<double, std::optional<double>> const& boundsPair);
 
     template<typename ValueType>
     static MDPSparseModelCheckingHelperReturnType<ValueType> computeUntilProbabilities(Environment const& env, OptimizationDirection dir,

--- a/src/storm/solver/AcyclicLinearEquationSolver.cpp
+++ b/src/storm/solver/AcyclicLinearEquationSolver.cpp
@@ -73,7 +73,13 @@ bool AcyclicLinearEquationSolver<ValueType>::internalSolveEquations(Environment 
         auxiliaryRowVector->resize(b.size());
         storm::utility::vector::selectVectorValues(*auxiliaryRowVector, *rowOrdering, b);
         for (auto const& bFactor : bFactors) {
-            (*auxiliaryRowVector)[bFactor.first] *= bFactor.second;
+            if (bFactor.second) {
+                (*auxiliaryRowVector)[bFactor.first] *= *bFactor.second;
+            } else {
+                // A selfloop of probability one: the equation for this row can only be satisfied if it contributes nothing.
+                STORM_LOG_ASSERT(storm::utility::isZero((*auxiliaryRowVector)[bFactor.first]),
+                                 "Expected a zero b vector entry for a row with a selfloop of probability one.");
+            }
         }
         bPtr = &auxiliaryRowVector.get();
         xPtr = &auxiliaryRowVector2.get();

--- a/src/storm/solver/AcyclicLinearEquationSolver.h
+++ b/src/storm/solver/AcyclicLinearEquationSolver.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <memory>
 #include "storm/solver/LinearEquationSolver.h"
 #include "storm/solver/multiplier/Multiplier.h"
@@ -56,7 +58,7 @@ class AcyclicLinearEquationSolver : public LinearEquationSolver<ValueType> {
     // can be used if the entries in 'x' need to be reordered
     mutable boost::optional<std::vector<ValueType>> auxiliaryRowVector2;  // A.rowCount() entries
     // contains factors applied to scale the entries of the 'b' vector
-    mutable std::vector<std::pair<uint64_t, ValueType>> bFactors;
+    mutable std::vector<std::pair<uint64_t, std::optional<ValueType>>> bFactors;
 };
 }  // namespace solver
 }  // namespace storm

--- a/src/storm/solver/AcyclicMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/AcyclicMinMaxLinearEquationSolver.cpp
@@ -60,7 +60,13 @@ bool AcyclicMinMaxLinearEquationSolver<ValueType>::internalSolveEquations(Enviro
             }
         }
         for (auto const& bFactor : bFactors) {
-            (*auxiliaryRowVector)[bFactor.first] *= bFactor.second;
+            if (bFactor.second) {
+                (*auxiliaryRowVector)[bFactor.first] *= *bFactor.second;
+            } else {
+                // A selfloop of probability one: the equation for this row can only be satisfied if it contributes nothing.
+                STORM_LOG_ASSERT(storm::utility::isZero((*auxiliaryRowVector)[bFactor.first]),
+                                 "Expected a zero b vector entry for a row with a selfloop of probability one.");
+            }
         }
         xPtr = &auxiliaryRowGroupVector.get();
         bPtr = &auxiliaryRowVector.get();

--- a/src/storm/solver/AcyclicMinMaxLinearEquationSolver.h
+++ b/src/storm/solver/AcyclicMinMaxLinearEquationSolver.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include <memory>
 
 #include "storm/solver/StandardMinMaxLinearEquationSolver.h"
@@ -48,7 +50,7 @@ class AcyclicMinMaxLinearEquationSolver : public StandardMinMaxLinearEquationSol
     // can be used if the performed scheduler choices need to be reordered
     mutable boost::optional<std::vector<uint64_t>> auxiliaryRowGroupIndexVector;  // A.rowGroupCount() entries
     // contains factors applied to scale the entries of the 'b' vector
-    mutable std::vector<std::pair<uint64_t, ValueType>> bFactors;
+    mutable std::vector<std::pair<uint64_t, std::optional<ValueType>>> bFactors;
 };
 }  // namespace solver
 }  // namespace storm

--- a/src/storm/solver/helper/AcyclicSolverHelper.h
+++ b/src/storm/solver/helper/AcyclicSolverHelper.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "storm/exceptions/UnmetRequirementException.h"
 #include "storm/storage/SparseMatrix.h"
 #include "storm/utility/constants.h"
@@ -72,11 +74,14 @@ boost::optional<std::vector<uint64_t>> computeTopologicalGroupOrdering(storm::st
 }
 
 /// reorders the row group such that the i'th row of the new matrix corresponds to the order[i]'th row of the source matrix.
-/// Also eliminates selfloops p>0 and inserts 1/p into the bFactors
+/// Also eliminates selfloops p>0 and inserts 1/p into the bFactors.
+/// A factor of std::nullopt marks a row with a selfloop of probability one. Such a row has no scaling factor at all: the
+/// equation for it can only be satisfied if the row contributes nothing, i.e. if the corresponding entry of the b vector
+/// is zero.
 template<typename ValueType>
 storm::storage::SparseMatrix<ValueType> createReorderedMatrix(storm::storage::SparseMatrix<ValueType> const& matrix,
                                                               std::vector<uint64_t> const& newToOrigIndexMap,
-                                                              std::vector<std::pair<uint64_t, ValueType>>& bFactors) {
+                                                              std::vector<std::pair<uint64_t, std::optional<ValueType>>>& bFactors) {
     std::vector<uint64_t> origToNewMap(newToOrigIndexMap.size(), std::numeric_limits<uint64_t>::max());
     for (uint64_t i = 0; i < newToOrigIndexMap.size(); ++i) {
         origToNewMap[newToOrigIndexMap[i]] = i;
@@ -98,12 +103,13 @@ storm::storage::SparseMatrix<ValueType> createReorderedMatrix(storm::storage::Sp
                 }
                 if (entry.getColumn() == origRowGroup) {
                     if (storm::utility::isOne(entry.getValue())) {
-                        // a one selfloop can only mean that there is never a non-zero value at the b vector for the current row.
-                        // Let's "assert" this by considering infinity. (This is necessary to avoid division by zero)
-                        bFactors.emplace_back(newRow, storm::utility::infinity<ValueType>());
+                        // A one selfloop can only mean that there is never a non-zero value at the b vector for the current row.
+                        // There is no factor to apply here; computing one would divide by zero.
+                        bFactors.emplace_back(newRow, std::nullopt);
+                    } else {
+                        ValueType factor = storm::utility::one<ValueType>() / (storm::utility::one<ValueType>() - entry.getValue());
+                        bFactors.emplace_back(newRow, factor);
                     }
-                    ValueType factor = storm::utility::one<ValueType>() / (storm::utility::one<ValueType>() - entry.getValue());
-                    bFactors.emplace_back(newRow, factor);
                 }
                 builder.addNextValue(newRow, origToNewMap[entry.getColumn()], entry.getValue());
             }
@@ -113,10 +119,13 @@ storm::storage::SparseMatrix<ValueType> createReorderedMatrix(storm::storage::Sp
     auto result = builder.build(matrix.getRowCount(), matrix.getColumnCount(), matrix.getRowGroupCount());
     // apply the bFactors to the relevant rows
     for (auto const& bFactor : bFactors) {
-        STORM_LOG_ASSERT(!storm::utility::isInfinity(bFactor.second) || storm::utility::isZero(result.getRowSum(bFactor.first)),
-                         "The input matrix does not seem to be probabilistic.");
+        if (!bFactor.second) {
+            // A selfloop of probability one: the row is not scaled, but it may not contribute anything either.
+            STORM_LOG_ASSERT(storm::utility::isZero(result.getRowSum(bFactor.first)), "The input matrix does not seem to be probabilistic.");
+            continue;
+        }
         for (auto& entry : result.getRow(bFactor.first)) {
-            entry.setValue(entry.getValue() * bFactor.second);
+            entry.setValue(entry.getValue() * *bFactor.second);
         }
     }
     STORM_LOG_DEBUG("Reordered " << matrix.getDimensionsAsString() << " with " << bFactors.size() << " selfloop entries for acyclic solving.");

--- a/src/storm/storage/dd/DdManager.cpp
+++ b/src/storm/storage/dd/DdManager.cpp
@@ -526,7 +526,6 @@ template Add<DdType::CUDD, uint_fast64_t> DdManager<DdType::CUDD>::getAddOne() c
 template Add<DdType::CUDD, storm::RationalNumber> DdManager<DdType::CUDD>::getAddOne() const;
 
 template Add<DdType::CUDD, double> DdManager<DdType::CUDD>::getInfinity<double>() const;
-template Add<DdType::CUDD, uint_fast64_t> DdManager<DdType::CUDD>::getInfinity<uint_fast64_t>() const;
 
 template Add<DdType::CUDD, double> DdManager<DdType::CUDD>::getConstant(double const& value) const;
 template Add<DdType::CUDD, uint_fast64_t> DdManager<DdType::CUDD>::getConstant(uint_fast64_t const& value) const;
@@ -553,7 +552,6 @@ template Add<DdType::Sylvan, storm::RationalNumber> DdManager<DdType::Sylvan>::g
 template Add<DdType::Sylvan, storm::RationalFunction> DdManager<DdType::Sylvan>::getAddOne() const;
 
 template Add<DdType::Sylvan, double> DdManager<DdType::Sylvan>::getInfinity<double>() const;
-template Add<DdType::Sylvan, uint_fast64_t> DdManager<DdType::Sylvan>::getInfinity<uint_fast64_t>() const;
 template Add<DdType::Sylvan, storm::RationalNumber> DdManager<DdType::Sylvan>::getInfinity<storm::RationalNumber>() const;
 template Add<DdType::Sylvan, storm::RationalFunction> DdManager<DdType::Sylvan>::getInfinity<storm::RationalFunction>() const;
 

--- a/src/storm/utility/constants.cpp
+++ b/src/storm/utility/constants.cpp
@@ -27,6 +27,9 @@ ValueType zero() {
 
 template<typename ValueType>
 ValueType infinity() {
+    // std::numeric_limits<T>::infinity() is zero for types that have no infinity, so asking for the infinity of an
+    // integral type used to silently yield zero. Reject it instead.
+    static_assert(!std::numeric_limits<ValueType>::is_integer, "There is no infinity for integral types.");
     return std::numeric_limits<ValueType>::infinity();
 }
 
@@ -106,7 +109,12 @@ bool isConstant(ValueType const&) {
 
 template<typename ValueType>
 bool isInfinity(ValueType const& a) {
-    return a == infinity<ValueType>();
+    if constexpr (std::numeric_limits<ValueType>::is_integer) {
+        // Integral types have no infinity, so no value of them is infinite.
+        return false;
+    } else {
+        return a == infinity<ValueType>();
+    }
 }
 
 template<typename ValueType>
@@ -1200,7 +1208,6 @@ template std::string to_string(double const& value);
 // int
 template int one();
 template int zero();
-template int infinity();
 template bool isOne(int const& value);
 template bool isZero(int const& value);
 template bool isConstant(int const& value);
@@ -1213,7 +1220,6 @@ template bool isBetween(int const& a, int const& b, int const& c, bool strict);
 // uint32_t
 template uint32_t one();
 template uint32_t zero();
-template uint32_t infinity();
 template bool isOne(uint32_t const& value);
 template bool isZero(uint32_t const& value);
 template bool isConstant(uint32_t const& value);
@@ -1225,7 +1231,6 @@ template bool isBetween(uint32_t const& a, uint32_t const& b, uint32_t const& c,
 // storm::storage::sparse::state_type
 template storm::storage::sparse::state_type one();
 template storm::storage::sparse::state_type zero();
-template storm::storage::sparse::state_type infinity();
 template bool isApproxEqual(storm::storage::sparse::state_type const& a, storm::storage::sparse::state_type const& b,
                             storm::storage::sparse::state_type const& precision, bool relative);
 template bool isOne(storm::storage::sparse::state_type const& value);


### PR DESCRIPTION
Several places used `storm::utility::infinity<T>()`, which is the literal 100000000000 for the exact value types, as a stand-in for something structural rather than for a value. These locations can use combinations of optionals or finite upper bounds on the value.

This is part of a several PRs that aim to solve the rational infinity problem. The next PR will introduce a wrapper around `ValueTypes` that adds infinity and which can be used when solutions like in this PR do not work.