### PR TITLE
Preparation for environments in other libraries

### DIFF
--- a/src/storm/environment/CoreEnvironments.cpp
+++ b/src/storm/environment/CoreEnvironments.cpp
@@ -1,7 +1,7 @@
-#include <memory>
+// Explicit instantiations of core environments
 
 #include "storm/environment/Environment.h"
-
+#include "storm/environment/SubEnvironment.h"
 #include "storm/environment/dd/AllDdEnvironments.h"
 #include "storm/environment/exploration/ExplorationEnvironment.h"
 #include "storm/environment/modelchecker/AllModelCheckerEnvironments.h"
@@ -9,44 +9,8 @@
 
 namespace storm {
 
-template<typename EnvironmentType>
-SubEnvironment<EnvironmentType>::SubEnvironment() : subEnv(nullptr) {
-    // Intentionally left empty
-}
-
-template<typename EnvironmentType>
-SubEnvironment<EnvironmentType>::SubEnvironment(SubEnvironment const& other) : subEnv(other.subEnv ? new EnvironmentType(*other.subEnv) : nullptr) {
-    // Intentionally left empty
-}
-
-template<typename EnvironmentType>
-SubEnvironment<EnvironmentType>& SubEnvironment<EnvironmentType>::operator=(SubEnvironment const& other) {
-    if (other.subEnv) {
-        subEnv = std::make_unique<EnvironmentType>(*other.subEnv);
-    } else {
-        subEnv.reset();
-    }
-    return *this;
-}
-
-template<typename EnvironmentType>
-EnvironmentType const& SubEnvironment<EnvironmentType>::get() const {
-    assertInitialized();
-    return *subEnv;
-}
-
-template<typename EnvironmentType>
-EnvironmentType& SubEnvironment<EnvironmentType>::get() {
-    assertInitialized();
-    return *subEnv;
-}
-
-template<typename EnvironmentType>
-void SubEnvironment<EnvironmentType>::assertInitialized() const {
-    if (!subEnv) {
-        subEnv = std::make_unique<EnvironmentType>();
-    }
-}
+// Not used within the core, but needed by other libraries
+template class SubEnvironment<Environment>;
 
 template class SubEnvironment<InternalEnvironment>;
 

--- a/src/storm/environment/Environment.cpp
+++ b/src/storm/environment/Environment.cpp
@@ -27,20 +27,12 @@ Environment& Environment::operator=(Environment const& other) {
     return *this;
 }
 
-SolverEnvironment& Environment::solver() {
-    return internalEnv.get().solverEnvironment.get();
+DdEnvironment& Environment::dd() {
+    return internalEnv.get().ddEnvironment.get();
 }
 
-SolverEnvironment const& Environment::solver() const {
-    return internalEnv.get().solverEnvironment.get();
-}
-
-ModelCheckerEnvironment& Environment::modelchecker() {
-    return internalEnv.get().modelcheckerEnvironment.get();
-}
-
-ModelCheckerEnvironment const& Environment::modelchecker() const {
-    return internalEnv.get().modelcheckerEnvironment.get();
+DdEnvironment const& Environment::dd() const {
+    return internalEnv.get().ddEnvironment.get();
 }
 
 ExplorationEnvironment& Environment::exploration() {
@@ -51,12 +43,20 @@ ExplorationEnvironment const& Environment::exploration() const {
     return internalEnv.get().explorationEnvironment.get();
 }
 
-DdEnvironment& Environment::dd() {
-    return internalEnv.get().ddEnvironment.get();
+ModelCheckerEnvironment& Environment::modelchecker() {
+    return internalEnv.get().modelcheckerEnvironment.get();
 }
 
-DdEnvironment const& Environment::dd() const {
-    return internalEnv.get().ddEnvironment.get();
+ModelCheckerEnvironment const& Environment::modelchecker() const {
+    return internalEnv.get().modelcheckerEnvironment.get();
+}
+
+SolverEnvironment& Environment::solver() {
+    return internalEnv.get().solverEnvironment.get();
+}
+
+SolverEnvironment const& Environment::solver() const {
+    return internalEnv.get().solverEnvironment.get();
 }
 
 double Environment::modelTolerance() const {

--- a/src/storm/environment/Environment.h
+++ b/src/storm/environment/Environment.h
@@ -41,4 +41,14 @@ class Environment {
     SubEnvironment<InternalEnvironment> internalEnv;
     double modelToleranceValue;
 };
+
+// Explicitly instantiated once in CoreEnvironments.cpp
+// Avoids redundant re-instantiation elsewhere
+extern template class SubEnvironment<Environment>;  // Not needed in core but needed for other libraries
+extern template class SubEnvironment<InternalEnvironment>;
+extern template class SubEnvironment<DdEnvironment>;
+extern template class SubEnvironment<ExplorationEnvironment>;
+extern template class SubEnvironment<ModelCheckerEnvironment>;
+extern template class SubEnvironment<SolverEnvironment>;
+
 }  // namespace storm

--- a/src/storm/environment/Environment.h
+++ b/src/storm/environment/Environment.h
@@ -5,17 +5,17 @@
 namespace storm {
 
 // Forward declare sub-environments
-class SolverEnvironment;
-class ModelCheckerEnvironment;
-class ExplorationEnvironment;
 class DdEnvironment;
+class ExplorationEnvironment;
+class ModelCheckerEnvironment;
+class SolverEnvironment;
 
 // Avoid implementing ugly copy constructors for environment by using an internal environment.
 struct InternalEnvironment {
-    SubEnvironment<SolverEnvironment> solverEnvironment;
-    SubEnvironment<ModelCheckerEnvironment> modelcheckerEnvironment;
-    SubEnvironment<ExplorationEnvironment> explorationEnvironment;
     SubEnvironment<DdEnvironment> ddEnvironment;
+    SubEnvironment<ExplorationEnvironment> explorationEnvironment;
+    SubEnvironment<ModelCheckerEnvironment> modelcheckerEnvironment;
+    SubEnvironment<SolverEnvironment> solverEnvironment;
 };
 
 class Environment {
@@ -25,14 +25,14 @@ class Environment {
     Environment(Environment const& other);
     Environment& operator=(Environment const& other);
 
-    SolverEnvironment& solver();
-    SolverEnvironment const& solver() const;
-    ModelCheckerEnvironment& modelchecker();
-    ModelCheckerEnvironment const& modelchecker() const;
-    ExplorationEnvironment& exploration();
-    ExplorationEnvironment const& exploration() const;
     DdEnvironment& dd();
     DdEnvironment const& dd() const;
+    ExplorationEnvironment& exploration();
+    ExplorationEnvironment const& exploration() const;
+    ModelCheckerEnvironment& modelchecker();
+    ModelCheckerEnvironment const& modelchecker() const;
+    SolverEnvironment& solver();
+    SolverEnvironment const& solver() const;
 
     double modelTolerance() const;
     void setModelTolerance(double value);

--- a/src/storm/environment/SubEnvironment.cpp
+++ b/src/storm/environment/SubEnvironment.cpp
@@ -50,30 +50,30 @@ void SubEnvironment<EnvironmentType>::assertInitialized() const {
 
 template class SubEnvironment<InternalEnvironment>;
 
+template class SubEnvironment<DdEnvironment>;
+template class SubEnvironment<CuddDdManagerEnvironment>;
+template class SubEnvironment<SylvanDdManagerEnvironment>;
+
 template class SubEnvironment<ExplorationEnvironment>;
 
-template class SubEnvironment<DdEnvironment>;
-template class SubEnvironment<SylvanDdManagerEnvironment>;
-template class SubEnvironment<CuddDdManagerEnvironment>;
-
+template class SubEnvironment<ModelCheckerEnvironment>;
 template class SubEnvironment<ConditionalModelCheckerEnvironment>;
 template class SubEnvironment<MultiObjectiveModelCheckerEnvironment>;
-template class SubEnvironment<ModelCheckerEnvironment>;
 
 template class SubEnvironment<SolverEnvironment>;
-template class SubEnvironment<EliminationSolverEnvironment>;
 template class SubEnvironment<EigenSolverEnvironment>;
+template class SubEnvironment<EliminationSolverEnvironment>;
+template class SubEnvironment<GameSolverEnvironment>;
+template class SubEnvironment<GlpkSolverEnvironment>;
 template class SubEnvironment<GmmxxSolverEnvironment>;
-template class SubEnvironment<NativeSolverEnvironment>;
+template class SubEnvironment<GurobiSolverEnvironment>;
 template class SubEnvironment<LongRunAverageSolverEnvironment>;
-template class SubEnvironment<TimeBoundedSolverEnvironment>;
 template class SubEnvironment<MinMaxSolverEnvironment>;
 template class SubEnvironment<MinMaxLpSolverEnvironment>;
 template class SubEnvironment<MultiplierEnvironment>;
+template class SubEnvironment<NativeSolverEnvironment>;
 template class SubEnvironment<OviSolverEnvironment>;
-template class SubEnvironment<GameSolverEnvironment>;
+template class SubEnvironment<TimeBoundedSolverEnvironment>;
 template class SubEnvironment<TopologicalSolverEnvironment>;
-template class SubEnvironment<GurobiSolverEnvironment>;
-template class SubEnvironment<GlpkSolverEnvironment>;
 
 }  // namespace storm

--- a/src/storm/environment/SubEnvironment.h
+++ b/src/storm/environment/SubEnvironment.h
@@ -4,6 +4,9 @@
 
 namespace storm {
 
+// The member functions below are declared but defined out-of-line afterwards.
+// This is needed because `extern template class` otherwise still implicitly inlines and instantiates member functions.
+
 template<typename EnvironmentType>
 class SubEnvironment {
    public:
@@ -17,4 +20,44 @@ class SubEnvironment {
     void assertInitialized() const;
     mutable std::unique_ptr<EnvironmentType> subEnv;
 };
+
+template<typename EnvironmentType>
+SubEnvironment<EnvironmentType>::SubEnvironment() : subEnv(nullptr) {
+    // Intentionally left empty
+}
+
+template<typename EnvironmentType>
+SubEnvironment<EnvironmentType>::SubEnvironment(SubEnvironment const& other) : subEnv(other.subEnv ? new EnvironmentType(*other.subEnv) : nullptr) {
+    // Intentionally left empty
+}
+
+template<typename EnvironmentType>
+SubEnvironment<EnvironmentType>& SubEnvironment<EnvironmentType>::operator=(SubEnvironment const& other) {
+    if (other.subEnv) {
+        subEnv = std::make_unique<EnvironmentType>(*other.subEnv);
+    } else {
+        subEnv.reset();
+    }
+    return *this;
+}
+
+template<typename EnvironmentType>
+EnvironmentType const& SubEnvironment<EnvironmentType>::get() const {
+    assertInitialized();
+    return *subEnv;
+}
+
+template<typename EnvironmentType>
+EnvironmentType& SubEnvironment<EnvironmentType>::get() {
+    assertInitialized();
+    return *subEnv;
+}
+
+template<typename EnvironmentType>
+void SubEnvironment<EnvironmentType>::assertInitialized() const {
+    if (!subEnv) {
+        subEnv = std::make_unique<EnvironmentType>();
+    }
+}
+
 }  // namespace storm

--- a/src/storm/environment/dd/DdEnvironment.h
+++ b/src/storm/environment/dd/DdEnvironment.h
@@ -8,21 +8,21 @@
 
 namespace storm {
 
-class SylvanDdManagerEnvironment;
 class CuddDdManagerEnvironment;
+class SylvanDdManagerEnvironment;
 
 // Select the sub-environment that belongs to the given DD type.
 template<storm::dd::DdType Type>
 struct DdEnvironmentSelector {
-    static_assert(Type == storm::dd::DdType::Sylvan || Type == storm::dd::DdType::CUDD, "Unhandled DD type.");
-};
-template<>
-struct DdEnvironmentSelector<storm::dd::DdType::Sylvan> {
-    using type = SylvanDdManagerEnvironment;
+    static_assert(Type == storm::dd::DdType::CUDD || Type == storm::dd::DdType::Sylvan, "Unhandled DD type.");
 };
 template<>
 struct DdEnvironmentSelector<storm::dd::DdType::CUDD> {
     using type = CuddDdManagerEnvironment;
+};
+template<>
+struct DdEnvironmentSelector<storm::dd::DdType::Sylvan> {
+    using type = SylvanDdManagerEnvironment;
 };
 
 class DdEnvironment {
@@ -30,11 +30,11 @@ class DdEnvironment {
     DdEnvironment();
     ~DdEnvironment();
 
-    SylvanDdManagerEnvironment& sylvan();
-    SylvanDdManagerEnvironment const& sylvan() const;
-
     CuddDdManagerEnvironment& cudd();
     CuddDdManagerEnvironment const& cudd() const;
+
+    SylvanDdManagerEnvironment& sylvan();
+    SylvanDdManagerEnvironment const& sylvan() const;
 
     /*!
      * Retrieves the sub-environment belonging to the given DD type.
@@ -46,8 +46,8 @@ class DdEnvironment {
     typename DdEnvironmentSelector<Type>::type const& get() const;
 
    private:
-    SubEnvironment<SylvanDdManagerEnvironment> sylvanEnvironment;
     SubEnvironment<CuddDdManagerEnvironment> cuddEnvironment;
+    SubEnvironment<SylvanDdManagerEnvironment> sylvanEnvironment;
 };
 
 }  // namespace storm

--- a/src/storm/environment/dd/DdEnvironment.h
+++ b/src/storm/environment/dd/DdEnvironment.h
@@ -11,6 +11,11 @@ namespace storm {
 class CuddDdManagerEnvironment;
 class SylvanDdManagerEnvironment;
 
+// Explicitly instantiated once in CoreEnvironments.cpp
+// Avoids redundant re-instantiation elsewhere
+extern template class SubEnvironment<CuddDdManagerEnvironment>;
+extern template class SubEnvironment<SylvanDdManagerEnvironment>;
+
 // Select the sub-environment that belongs to the given DD type.
 template<storm::dd::DdType Type>
 struct DdEnvironmentSelector {

--- a/src/storm/environment/modelchecker/ModelCheckerEnvironment.cpp
+++ b/src/storm/environment/modelchecker/ModelCheckerEnvironment.cpp
@@ -41,20 +41,20 @@ ConditionalModelCheckerEnvironment const& ModelCheckerEnvironment::conditional()
     return conditionalModelCheckerEnvironment.get();
 }
 
-SteadyStateDistributionAlgorithm ModelCheckerEnvironment::getSteadyStateDistributionAlgorithm() const {
-    return steadyStateDistributionAlgorithm;
-}
-
-void ModelCheckerEnvironment::setSteadyStateDistributionAlgorithm(SteadyStateDistributionAlgorithm value) {
-    steadyStateDistributionAlgorithm = value;
-}
-
 MultiObjectiveModelCheckerEnvironment& ModelCheckerEnvironment::multi() {
     return multiObjectiveModelCheckerEnvironment.get();
 }
 
 MultiObjectiveModelCheckerEnvironment const& ModelCheckerEnvironment::multi() const {
     return multiObjectiveModelCheckerEnvironment.get();
+}
+
+SteadyStateDistributionAlgorithm ModelCheckerEnvironment::getSteadyStateDistributionAlgorithm() const {
+    return steadyStateDistributionAlgorithm;
+}
+
+void ModelCheckerEnvironment::setSteadyStateDistributionAlgorithm(SteadyStateDistributionAlgorithm value) {
+    steadyStateDistributionAlgorithm = value;
 }
 
 bool ModelCheckerEnvironment::isLtl2daToolSet() const {

--- a/src/storm/environment/modelchecker/ModelCheckerEnvironment.h
+++ b/src/storm/environment/modelchecker/ModelCheckerEnvironment.h
@@ -43,10 +43,12 @@ class ModelCheckerEnvironment {
    private:
     SubEnvironment<ConditionalModelCheckerEnvironment> conditionalModelCheckerEnvironment;
     SubEnvironment<MultiObjectiveModelCheckerEnvironment> multiObjectiveModelCheckerEnvironment;
+
     boost::optional<std::string> ltl2daTool;
     SteadyStateDistributionAlgorithm steadyStateDistributionAlgorithm;
     bool filterRewZero;
     bool exportCdfEnabled;
     std::string exportCdfDirectory;
 };
+
 }  // namespace storm

--- a/src/storm/environment/modelchecker/ModelCheckerEnvironment.h
+++ b/src/storm/environment/modelchecker/ModelCheckerEnvironment.h
@@ -13,6 +13,11 @@ namespace storm {
 class ConditionalModelCheckerEnvironment;
 class MultiObjectiveModelCheckerEnvironment;
 
+// Explicitly instantiated once in CoreEnvironments.cpp
+// Avoids redundant re-instantiation elsewhere
+extern template class SubEnvironment<ConditionalModelCheckerEnvironment>;
+extern template class SubEnvironment<MultiObjectiveModelCheckerEnvironment>;
+
 class ModelCheckerEnvironment {
    public:
     ModelCheckerEnvironment();

--- a/src/storm/environment/solver/MinMaxSolverEnvironment.cpp
+++ b/src/storm/environment/solver/MinMaxSolverEnvironment.cpp
@@ -32,6 +32,14 @@ MinMaxSolverEnvironment::~MinMaxSolverEnvironment() {
     // Intentionally left empty
 }
 
+MinMaxLpSolverEnvironment& MinMaxSolverEnvironment::lp() {
+    return lpEnvironment.get();
+}
+
+MinMaxLpSolverEnvironment const& MinMaxSolverEnvironment::lp() const {
+    return lpEnvironment.get();
+}
+
 storm::solver::MinMaxMethod const& MinMaxSolverEnvironment::getMethod() const {
     return minMaxMethod;
 }
@@ -75,13 +83,6 @@ storm::solver::MultiplicationStyle const& MinMaxSolverEnvironment::getMultiplica
 
 void MinMaxSolverEnvironment::setMultiplicationStyle(storm::solver::MultiplicationStyle value) {
     multiplicationStyle = value;
-}
-
-MinMaxLpSolverEnvironment const& MinMaxSolverEnvironment::lp() const {
-    return lpEnvironment.get();
-}
-MinMaxLpSolverEnvironment& MinMaxSolverEnvironment::lp() {
-    return lpEnvironment.get();
 }
 
 bool MinMaxSolverEnvironment::isForceRequireUnique() const {

--- a/src/storm/environment/solver/MinMaxSolverEnvironment.h
+++ b/src/storm/environment/solver/MinMaxSolverEnvironment.h
@@ -11,6 +11,9 @@ namespace storm {
 
 class MinMaxLpSolverEnvironment;
 
+// Explicitly instantiated once in CoreEnvironments.cpp; this avoids redundant re-instantiation elsewhere.
+extern template class SubEnvironment<MinMaxLpSolverEnvironment>;
+
 class MinMaxSolverEnvironment {
    public:
     MinMaxSolverEnvironment();

--- a/src/storm/environment/solver/MinMaxSolverEnvironment.h
+++ b/src/storm/environment/solver/MinMaxSolverEnvironment.h
@@ -16,6 +16,9 @@ class MinMaxSolverEnvironment {
     MinMaxSolverEnvironment();
     ~MinMaxSolverEnvironment();
 
+    MinMaxLpSolverEnvironment& lp();
+    MinMaxLpSolverEnvironment const& lp() const;
+
     storm::solver::MinMaxMethod const& getMethod() const;
     bool const& isMethodSetFromDefault() const;
     void setMethod(storm::solver::MinMaxMethod value, bool isSetFromDefault = false);
@@ -29,10 +32,10 @@ class MinMaxSolverEnvironment {
     void setMultiplicationStyle(storm::solver::MultiplicationStyle value);
     bool isForceRequireUnique() const;
     void setForceRequireUnique(bool value);
-    MinMaxLpSolverEnvironment const& lp() const;
-    MinMaxLpSolverEnvironment& lp();
 
    private:
+    SubEnvironment<MinMaxLpSolverEnvironment> lpEnvironment;
+
     storm::solver::MinMaxMethod minMaxMethod;
     bool methodSetFromDefault;
     uint64_t maxIterationCount;
@@ -40,6 +43,5 @@ class MinMaxSolverEnvironment {
     bool considerRelativeTerminationCriterion;
     storm::solver::MultiplicationStyle multiplicationStyle;
     bool forceRequireUnique;
-    SubEnvironment<MinMaxLpSolverEnvironment> lpEnvironment;
 };
 }  // namespace storm

--- a/src/storm/environment/solver/SolverEnvironment.cpp
+++ b/src/storm/environment/solver/SolverEnvironment.cpp
@@ -31,20 +31,60 @@ SolverEnvironment::~SolverEnvironment() {
     // Intentionally left empty
 }
 
+EigenSolverEnvironment& SolverEnvironment::eigen() {
+    return eigenSolverEnvironment.get();
+}
+
+EigenSolverEnvironment const& SolverEnvironment::eigen() const {
+    return eigenSolverEnvironment.get();
+}
+
+EliminationSolverEnvironment& SolverEnvironment::elimination() {
+    return eliminationSolverEnvironment.get();
+}
+
+EliminationSolverEnvironment const& SolverEnvironment::elimination() const {
+    return eliminationSolverEnvironment.get();
+}
+
+GameSolverEnvironment& SolverEnvironment::game() {
+    return gameSolverEnvironment.get();
+}
+
+GameSolverEnvironment const& SolverEnvironment::game() const {
+    return gameSolverEnvironment.get();
+}
+
+GlpkSolverEnvironment& SolverEnvironment::glpk() {
+    return glpkSolverEnvironment.get();
+}
+
+GlpkSolverEnvironment const& SolverEnvironment::glpk() const {
+    return glpkSolverEnvironment.get();
+}
+
+GmmxxSolverEnvironment& SolverEnvironment::gmmxx() {
+    return gmmxxSolverEnvironment.get();
+}
+
+GmmxxSolverEnvironment const& SolverEnvironment::gmmxx() const {
+    return gmmxxSolverEnvironment.get();
+}
+
+GurobiSolverEnvironment& SolverEnvironment::gurobi() {
+    return gurobiSolverEnvironment.get();
+}
+
+GurobiSolverEnvironment const& SolverEnvironment::gurobi() const {
+    return gurobiSolverEnvironment.get();
+}
+
 LongRunAverageSolverEnvironment& SolverEnvironment::lra() {
     return longRunAverageSolverEnvironment.get();
 }
 
 LongRunAverageSolverEnvironment const& SolverEnvironment::lra() const {
     return longRunAverageSolverEnvironment.get();
-}
-
-TimeBoundedSolverEnvironment& SolverEnvironment::timeBounded() {
-    return timeBoundedSolverEnvironment.get();
-}
-
-TimeBoundedSolverEnvironment const& SolverEnvironment::timeBounded() const {
-    return timeBoundedSolverEnvironment.get();
 }
 
 MinMaxSolverEnvironment& SolverEnvironment::minMax() {
@@ -63,52 +103,12 @@ MultiplierEnvironment const& SolverEnvironment::multiplier() const {
     return multiplierEnvironment.get();
 }
 
-EigenSolverEnvironment& SolverEnvironment::eigen() {
-    return eigenSolverEnvironment.get();
-}
-
-EigenSolverEnvironment const& SolverEnvironment::eigen() const {
-    return eigenSolverEnvironment.get();
-}
-
-GmmxxSolverEnvironment& SolverEnvironment::gmmxx() {
-    return gmmxxSolverEnvironment.get();
-}
-
-GmmxxSolverEnvironment const& SolverEnvironment::gmmxx() const {
-    return gmmxxSolverEnvironment.get();
-}
-
 NativeSolverEnvironment& SolverEnvironment::native() {
     return nativeSolverEnvironment.get();
 }
 
 NativeSolverEnvironment const& SolverEnvironment::native() const {
     return nativeSolverEnvironment.get();
-}
-
-GameSolverEnvironment& SolverEnvironment::game() {
-    return gameSolverEnvironment.get();
-}
-
-GameSolverEnvironment const& SolverEnvironment::game() const {
-    return gameSolverEnvironment.get();
-}
-
-TopologicalSolverEnvironment& SolverEnvironment::topological() {
-    return topologicalSolverEnvironment.get();
-}
-
-TopologicalSolverEnvironment const& SolverEnvironment::topological() const {
-    return topologicalSolverEnvironment.get();
-}
-
-EliminationSolverEnvironment& SolverEnvironment::elimination() {
-    return eliminationSolverEnvironment.get();
-}
-
-EliminationSolverEnvironment const& SolverEnvironment::elimination() const {
-    return eliminationSolverEnvironment.get();
 }
 
 OviSolverEnvironment& SolverEnvironment::ovi() {
@@ -119,44 +119,20 @@ OviSolverEnvironment const& SolverEnvironment::ovi() const {
     return oviSolverEnvironment.get();
 }
 
-GurobiSolverEnvironment& SolverEnvironment::gurobi() {
-    return gurobiSolverEnvironment.get();
+TimeBoundedSolverEnvironment& SolverEnvironment::timeBounded() {
+    return timeBoundedSolverEnvironment.get();
 }
 
-GurobiSolverEnvironment const& SolverEnvironment::gurobi() const {
-    return gurobiSolverEnvironment.get();
+TimeBoundedSolverEnvironment const& SolverEnvironment::timeBounded() const {
+    return timeBoundedSolverEnvironment.get();
 }
 
-GlpkSolverEnvironment& SolverEnvironment::glpk() {
-    return glpkSolverEnvironment.get();
+TopologicalSolverEnvironment& SolverEnvironment::topological() {
+    return topologicalSolverEnvironment.get();
 }
 
-GlpkSolverEnvironment const& SolverEnvironment::glpk() const {
-    return glpkSolverEnvironment.get();
-}
-
-bool SolverEnvironment::isForceSoundness() const {
-    return forceSoundness;
-}
-
-void SolverEnvironment::setForceSoundness(bool value) {
-    SolverEnvironment::forceSoundness = value;
-}
-
-bool SolverEnvironment::isForceExact() const {
-    return forceExact;
-}
-
-void SolverEnvironment::setForceExact(bool value) {
-    SolverEnvironment::forceExact = value;
-}
-
-bool SolverEnvironment::isDebugSet() const {
-    return debug;
-}
-
-void SolverEnvironment::setDebug(bool value) {
-    SolverEnvironment::debug = value;
+TopologicalSolverEnvironment const& SolverEnvironment::topological() const {
+    return topologicalSolverEnvironment.get();
 }
 
 bool SolverEnvironment::isVerboseSet() const {
@@ -246,4 +222,28 @@ void SolverEnvironment::setLinearEquationSolverPrecision(boost::optional<storm::
         // gmm, eigen, elimination, and topological solvers do not have a precision
     }
 }
+
+bool SolverEnvironment::isForceSoundness() const {
+    return forceSoundness;
+}
+
+void SolverEnvironment::setForceSoundness(bool value) {
+    SolverEnvironment::forceSoundness = value;
+}
+bool SolverEnvironment::isForceExact() const {
+    return forceExact;
+}
+
+void SolverEnvironment::setForceExact(bool value) {
+    SolverEnvironment::forceExact = value;
+}
+
+bool SolverEnvironment::isDebugSet() const {
+    return debug;
+}
+
+void SolverEnvironment::setDebug(bool value) {
+    SolverEnvironment::debug = value;
+}
+
 }  // namespace storm

--- a/src/storm/environment/solver/SolverEnvironment.h
+++ b/src/storm/environment/solver/SolverEnvironment.h
@@ -25,7 +25,7 @@ class OviSolverEnvironment;
 class TimeBoundedSolverEnvironment;
 class TopologicalSolverEnvironment;
 
-// Explicitly instantiated once in SubEnvironment.cpp
+// Explicitly instantiated once in CoreEnvironments.cpp
 // Avoids redundant re-instantiation elsewhere
 extern template class SubEnvironment<EigenSolverEnvironment>;
 extern template class SubEnvironment<EliminationSolverEnvironment>;

--- a/src/storm/environment/solver/SolverEnvironment.h
+++ b/src/storm/environment/solver/SolverEnvironment.h
@@ -12,18 +12,34 @@ namespace storm {
 
 // Forward declare subenvironments
 class EigenSolverEnvironment;
+class EliminationSolverEnvironment;
+class GameSolverEnvironment;
+class GlpkSolverEnvironment;
 class GmmxxSolverEnvironment;
-class NativeSolverEnvironment;
+class GurobiSolverEnvironment;
 class LongRunAverageSolverEnvironment;
-class TimeBoundedSolverEnvironment;
 class MinMaxSolverEnvironment;
 class MultiplierEnvironment;
-class GameSolverEnvironment;
-class TopologicalSolverEnvironment;
+class NativeSolverEnvironment;
 class OviSolverEnvironment;
-class GurobiSolverEnvironment;
-class GlpkSolverEnvironment;
-class EliminationSolverEnvironment;
+class TimeBoundedSolverEnvironment;
+class TopologicalSolverEnvironment;
+
+// Explicitly instantiated once in SubEnvironment.cpp
+// Avoids redundant re-instantiation elsewhere
+extern template class SubEnvironment<EigenSolverEnvironment>;
+extern template class SubEnvironment<EliminationSolverEnvironment>;
+extern template class SubEnvironment<GameSolverEnvironment>;
+extern template class SubEnvironment<GlpkSolverEnvironment>;
+extern template class SubEnvironment<GmmxxSolverEnvironment>;
+extern template class SubEnvironment<GurobiSolverEnvironment>;
+extern template class SubEnvironment<LongRunAverageSolverEnvironment>;
+extern template class SubEnvironment<MinMaxSolverEnvironment>;
+extern template class SubEnvironment<MultiplierEnvironment>;
+extern template class SubEnvironment<NativeSolverEnvironment>;
+extern template class SubEnvironment<OviSolverEnvironment>;
+extern template class SubEnvironment<TimeBoundedSolverEnvironment>;
+extern template class SubEnvironment<TopologicalSolverEnvironment>;
 
 class SolverEnvironment {
    public:
@@ -32,41 +48,42 @@ class SolverEnvironment {
 
     EigenSolverEnvironment& eigen();
     EigenSolverEnvironment const& eigen() const;
-    GmmxxSolverEnvironment& gmmxx();
-    GmmxxSolverEnvironment const& gmmxx() const;
-    NativeSolverEnvironment& native();
-    NativeSolverEnvironment const& native() const;
-    LongRunAverageSolverEnvironment& lra();
-    LongRunAverageSolverEnvironment const& lra() const;
-    TimeBoundedSolverEnvironment& timeBounded();
-    TimeBoundedSolverEnvironment const& timeBounded() const;
-    MinMaxSolverEnvironment& minMax();
-    MinMaxSolverEnvironment const& minMax() const;
-    MultiplierEnvironment& multiplier();
-    MultiplierEnvironment const& multiplier() const;
-    OviSolverEnvironment const& ovi() const;
-    OviSolverEnvironment& ovi();
-    GameSolverEnvironment& game();
-    GameSolverEnvironment const& game() const;
-    TopologicalSolverEnvironment& topological();
-    TopologicalSolverEnvironment const& topological() const;
-    GurobiSolverEnvironment& gurobi();
-    GurobiSolverEnvironment const& gurobi() const;
-    GlpkSolverEnvironment& glpk();
-    GlpkSolverEnvironment const& glpk() const;
+
     EliminationSolverEnvironment& elimination();
     EliminationSolverEnvironment const& elimination() const;
 
-    bool isForceSoundness() const;
-    void setForceSoundness(bool value);
-    bool isForceExact() const;
-    void setForceExact(bool value);
-    bool isDebugSet() const;
-    void setDebug(bool value);
-    bool isVerboseSet() const;
-    void setVerbose(bool value);
-    uint64_t getShowProgressDelay() const;
-    void setShowProgressDelay(uint64_t delay);
+    GameSolverEnvironment& game();
+    GameSolverEnvironment const& game() const;
+
+    GlpkSolverEnvironment& glpk();
+    GlpkSolverEnvironment const& glpk() const;
+
+    GmmxxSolverEnvironment& gmmxx();
+    GmmxxSolverEnvironment const& gmmxx() const;
+
+    GurobiSolverEnvironment& gurobi();
+    GurobiSolverEnvironment const& gurobi() const;
+
+    LongRunAverageSolverEnvironment& lra();
+    LongRunAverageSolverEnvironment const& lra() const;
+
+    MinMaxSolverEnvironment& minMax();
+    MinMaxSolverEnvironment const& minMax() const;
+
+    MultiplierEnvironment& multiplier();
+    MultiplierEnvironment const& multiplier() const;
+
+    NativeSolverEnvironment& native();
+    NativeSolverEnvironment const& native() const;
+
+    OviSolverEnvironment& ovi();
+    OviSolverEnvironment const& ovi() const;
+
+    TimeBoundedSolverEnvironment& timeBounded();
+    TimeBoundedSolverEnvironment const& timeBounded() const;
+
+    TopologicalSolverEnvironment& topological();
+    TopologicalSolverEnvironment const& topological() const;
 
     storm::solver::EquationSolverType const& getLinearEquationSolverType() const;
     void setLinearEquationSolverType(storm::solver::EquationSolverType const& value, bool isSetFromDefault = false);
@@ -81,20 +98,31 @@ class SolverEnvironment {
     void setLinearEquationSolverPrecision(boost::optional<storm::RationalNumber> const& newPrecision,
                                           boost::optional<bool> const& relativePrecision = boost::none);
 
+    bool isForceSoundness() const;
+    void setForceSoundness(bool value);
+    bool isForceExact() const;
+    void setForceExact(bool value);
+    bool isDebugSet() const;
+    void setDebug(bool value);
+    bool isVerboseSet() const;
+    void setVerbose(bool value);
+    uint64_t getShowProgressDelay() const;
+    void setShowProgressDelay(uint64_t delay);
+
    private:
     SubEnvironment<EigenSolverEnvironment> eigenSolverEnvironment;
-    SubEnvironment<GmmxxSolverEnvironment> gmmxxSolverEnvironment;
-    SubEnvironment<NativeSolverEnvironment> nativeSolverEnvironment;
+    SubEnvironment<EliminationSolverEnvironment> eliminationSolverEnvironment;
     SubEnvironment<GameSolverEnvironment> gameSolverEnvironment;
-    SubEnvironment<TopologicalSolverEnvironment> topologicalSolverEnvironment;
+    SubEnvironment<GlpkSolverEnvironment> glpkSolverEnvironment;
+    SubEnvironment<GmmxxSolverEnvironment> gmmxxSolverEnvironment;
+    SubEnvironment<GurobiSolverEnvironment> gurobiSolverEnvironment;
     SubEnvironment<LongRunAverageSolverEnvironment> longRunAverageSolverEnvironment;
-    SubEnvironment<TimeBoundedSolverEnvironment> timeBoundedSolverEnvironment;
     SubEnvironment<MinMaxSolverEnvironment> minMaxSolverEnvironment;
     SubEnvironment<MultiplierEnvironment> multiplierEnvironment;
+    SubEnvironment<NativeSolverEnvironment> nativeSolverEnvironment;
     SubEnvironment<OviSolverEnvironment> oviSolverEnvironment;
-    SubEnvironment<GurobiSolverEnvironment> gurobiSolverEnvironment;
-    SubEnvironment<GlpkSolverEnvironment> glpkSolverEnvironment;
-    SubEnvironment<EliminationSolverEnvironment> eliminationSolverEnvironment;
+    SubEnvironment<TimeBoundedSolverEnvironment> timeBoundedSolverEnvironment;
+    SubEnvironment<TopologicalSolverEnvironment> topologicalSolverEnvironment;
 
     storm::solver::EquationSolverType linearEquationSolverType;
     bool linearEquationSolverTypeSetFromDefault;


### PR DESCRIPTION
Preparation to use `storm::Environment` in other libraries such as `storm-dft`.

It required to move the function implementation of `SubEnvironment` from the cpp to the header file. Otherwise the instantiations of the form `SubEnvironment<XEnvironment>` are not possible.
To avoid re-instantiation for each include, we define all instantiations in `CoreEnvironments.cpp`. The relevant header files also use `extern template class SubEnvironment<XEnvironment>;`.
Note that the member functions are declared inside the `SubEnvironment` class but defined out-of-line afterwards. This is needed because `extern template class` otherwise still [implicitly inlines](https://www.informit.com/articles/article.aspx?p=3146433&seqNum=3) and instantiates member functions. I did not check the impact on the compilation though.


Also sorted environments alphabetically for easier maintenance.