### PR TITLE
Reduced direct carl calls

### DIFF
--- a/resources/3rdparty/sylvan/src/storm_wrapper.cpp
+++ b/resources/3rdparty/sylvan/src/storm_wrapper.cpp
@@ -212,7 +212,7 @@ storm_rational_number_ptr storm_rational_number_pow(storm_rational_number_ptr a,
     storm::RationalNumber const& srn_a = *static_cast<storm::RationalNumber const*>(a);
     storm::RationalNumber const& srn_b = *static_cast<storm::RationalNumber const*>(b);
 
-    int_fast64_t exponentAsInteger = storm::utility::convertNumber<int_fast64_t>(srn_b);
+    int64_t exponentAsInteger = storm::utility::convertNumber<int64_t>(srn_b);
     storm::RationalNumber* result_srn = new storm::RationalNumber(storm::utility::pow(srn_a, exponentAsInteger));
     return static_cast<storm_rational_number_ptr>(result_srn);
 }
@@ -551,7 +551,7 @@ storm_rational_function_ptr storm_rational_function_pow(storm_rational_function_
     storm::RationalFunction const& srf_a = *static_cast<storm::RationalFunction const*>(a);
     storm::RationalFunction const& srf_b = *static_cast<storm::RationalFunction const*>(b);
 
-    uint_fast64_t exponentAsInteger = storm::utility::convertNumber<uint_fast64_t>(srf_b.nominatorAsNumber());
+    uint64_t exponentAsInteger = storm::utility::convertNumber<uint64_t>(srf_b.nominatorAsNumber());
     storm::RationalFunction* result_srf = new storm::RationalFunction(storm::utility::pow(srf_a, exponentAsInteger));
     return static_cast<storm_rational_function_ptr>(result_srf);
 }

--- a/resources/3rdparty/sylvan/src/storm_wrapper.cpp
+++ b/resources/3rdparty/sylvan/src/storm_wrapper.cpp
@@ -212,7 +212,7 @@ storm_rational_number_ptr storm_rational_number_pow(storm_rational_number_ptr a,
     storm::RationalNumber const& srn_a = *static_cast<storm::RationalNumber const*>(a);
     storm::RationalNumber const& srn_b = *static_cast<storm::RationalNumber const*>(b);
 
-    carl::sint exponentAsInteger = carl::toInt<carl::sint>(srn_b);
+    int_fast64_t exponentAsInteger = storm::utility::convertNumber<int_fast64_t>(srn_b);
     storm::RationalNumber* result_srn = new storm::RationalNumber(storm::utility::pow(srn_a, exponentAsInteger));
     return static_cast<storm_rational_number_ptr>(result_srn);
 }
@@ -224,8 +224,9 @@ storm_rational_number_ptr storm_rational_number_mod(storm_rational_number_ptr a,
 
     storm::RationalNumber const& srn_a = *static_cast<storm::RationalNumber const*>(a);
     storm::RationalNumber const& srn_b = *static_cast<storm::RationalNumber const*>(b);
-    if (carl::isInteger(srn_a) && carl::isInteger(srn_b)) {
-        storm::RationalNumber* result_srn = new storm::RationalNumber(carl::mod(carl::getNum(srn_a), carl::getNum(srn_b)));
+    if (storm::utility::isInteger(srn_a) && storm::utility::isInteger(srn_b)) {
+        storm::RationalNumber* result_srn =
+            new storm::RationalNumber(storm::utility::mod(storm::utility::numerator(srn_a), storm::utility::numerator(srn_b)));
         return static_cast<storm_rational_number_ptr>(result_srn);
     }
     throw storm::exceptions::InvalidOperationException() << "Modulo not supported for rational, non-integer numbers.";
@@ -289,7 +290,7 @@ storm_rational_number_ptr storm_rational_number_floor(storm_rational_number_ptr 
 #endif
 
     storm::RationalNumber const& srn_a = *static_cast<storm::RationalNumber const*>(a);
-    storm::RationalNumber* result_srn = new storm::RationalNumber(carl::floor(srn_a));
+    storm::RationalNumber* result_srn = new storm::RationalNumber(storm::utility::floor(srn_a));
     return static_cast<storm_rational_number_ptr>(result_srn);
 }
 
@@ -299,7 +300,7 @@ storm_rational_number_ptr storm_rational_number_ceil(storm_rational_number_ptr a
 #endif
 
     storm::RationalNumber const& srn_a = *static_cast<storm::RationalNumber const*>(a);
-    storm::RationalNumber* result_srn = new storm::RationalNumber(carl::ceil(srn_a));
+    storm::RationalNumber* result_srn = new storm::RationalNumber(storm::utility::ceil(srn_a));
     return static_cast<storm_rational_number_ptr>(result_srn);
 }
 
@@ -341,10 +342,10 @@ int storm_rational_number_equal_modulo_precision(int relative, storm_rational_nu
         if (storm::utility::isZero<storm::RationalNumber>(srn_a)) {
             return storm::utility::isZero<storm::RationalNumber>(srn_b);
         } else {
-            return carl::abs(srn_a - srn_b)/srn_a < srn_p ? 1 : 0;
+            return storm::utility::abs(storm::RationalNumber(srn_a - srn_b)) / srn_a < srn_p ? 1 : 0;
         }
     } else {
-        return carl::abs(srn_a - srn_b) < srn_p ? 1 : 0;
+        return storm::utility::abs(storm::RationalNumber(srn_a - srn_b)) < srn_p ? 1 : 0;
     }
 }
 
@@ -550,8 +551,8 @@ storm_rational_function_ptr storm_rational_function_pow(storm_rational_function_
     storm::RationalFunction const& srf_a = *static_cast<storm::RationalFunction const*>(a);
     storm::RationalFunction const& srf_b = *static_cast<storm::RationalFunction const*>(b);
 
-    carl::uint exponentAsInteger = carl::toInt<carl::uint>(srf_b.nominatorAsNumber());
-    storm::RationalFunction* result_srf = new storm::RationalFunction(carl::pow(srf_a, exponentAsInteger));
+    uint_fast64_t exponentAsInteger = storm::utility::convertNumber<uint_fast64_t>(srf_b.nominatorAsNumber());
+    storm::RationalFunction* result_srf = new storm::RationalFunction(storm::utility::pow(srf_a, exponentAsInteger));
     return static_cast<storm_rational_function_ptr>(result_srf);
 }
 
@@ -642,7 +643,8 @@ storm_rational_function_ptr storm_rational_function_floor(storm_rational_functio
     if (!storm::utility::isConstant(srf_a)) {
         throw storm::exceptions::InvalidOperationException() << "Operand of floor must not be non-constant rational function.";
     }
-    storm::RationalFunction* result_srf = new storm::RationalFunction(carl::floor(storm::utility::convertNumber<storm::RationalFunctionCoefficient>(srf_a)));
+    storm::RationalFunction* result_srf =
+        new storm::RationalFunction(storm::utility::floor(storm::utility::convertNumber<storm::RationalFunctionCoefficient>(srf_a)));
     return static_cast<storm_rational_function_ptr>(result_srf);
 }
 
@@ -655,7 +657,8 @@ storm_rational_function_ptr storm_rational_function_ceil(storm_rational_function
     if (!storm::utility::isConstant(srf_a)) {
         throw storm::exceptions::InvalidOperationException() << "Operand of ceil must not be non-constant rational function.";
     }
-    storm::RationalFunction* result_srf = new storm::RationalFunction(carl::ceil(storm::utility::convertNumber<storm::RationalFunctionCoefficient>(srf_a)));
+    storm::RationalFunction* result_srf =
+        new storm::RationalFunction(storm::utility::ceil(storm::utility::convertNumber<storm::RationalFunctionCoefficient>(srf_a)));
     return static_cast<storm_rational_function_ptr>(result_srf);
 }
 
@@ -677,9 +680,9 @@ int storm_rational_function_equal_modulo_precision(int relative, storm_rational_
     storm::RationalFunctionCoefficient srn_p = storm::utility::convertNumber<storm::RationalFunctionCoefficient>(srf_p);
 
     if (relative) {
-        return carl::abs(srn_a - srn_b)/srn_a < srn_p ? 1 : 0;
+        return storm::utility::abs(storm::RationalFunctionCoefficient(srn_a - srn_b)) / srn_a < srn_p ? 1 : 0;
     } else {
-        return carl::abs(srn_a - srn_b) < srn_p ? 1 : 0;
+        return storm::utility::abs(storm::RationalFunctionCoefficient(srn_a - srn_b)) < srn_p ? 1 : 0;
     }
 }
 

--- a/src/storm-dft/storage/DFT.h
+++ b/src/storm-dft/storage/DFT.h
@@ -12,6 +12,7 @@
 #include "storm-dft/storage/DftModule.h"
 #include "storm-dft/storage/DftSymmetries.h"
 #include "storm-dft/storage/elements/DFTElements.h"
+#include "storm/adapters/RationalFunctionForward.h"
 #include "storm/exceptions/NotSupportedException.h"
 #include "storm/storage/BitVector.h"
 #include "storm/utility/macros.h"

--- a/src/storm-dft/storage/OrderDFTElementsById.cpp
+++ b/src/storm-dft/storage/OrderDFTElementsById.cpp
@@ -1,5 +1,7 @@
 #include "storm-dft/storage/OrderDFTElementsById.h"
+
 #include "storm-dft/storage/elements/DFTElements.h"
+#include "storm/adapters/RationalFunctionAdapter.h"
 
 namespace storm::dft {
 namespace storage {
@@ -26,8 +28,8 @@ bool OrderElementsByRank<ValueType>::operator()(const std::shared_ptr<storm::dft
 template struct OrderElementsById<double>;
 template struct OrderElementsByRank<double>;
 
-template struct OrderElementsById<RationalFunction>;
-template struct OrderElementsByRank<RationalFunction>;
+template struct OrderElementsById<storm::RationalFunction>;
+template struct OrderElementsByRank<storm::RationalFunction>;
 
 }  // namespace storage
 }  // namespace storm::dft

--- a/src/storm-pars-cli/sampling.h
+++ b/src/storm-pars-cli/sampling.h
@@ -360,7 +360,9 @@ void sampleDerivatives(std::shared_ptr<storm::models::sparse::Model<ValueType>> 
     std::map<typename storm::utility::parametric::VariableType<ValueType>::type, typename storm::utility::parametric::CoefficientType<ValueType>::type>
         instantiation;
     for (auto const& pair : keyValue) {
-        auto variable = carl::VariablePool::getInstance().findVariableWithName(pair.first);
+        auto variable = storm::findRFVariable(pair.first);
+        STORM_LOG_THROW(variable != storm::RationalFunctionVariable::NO_VARIABLE, storm::exceptions::WrongFormatException,
+                        "Parameter '" << pair.first << "' does not exist in the model.");
         auto value = storm::utility::convertNumber<typename storm::utility::parametric::CoefficientType<ValueType>::type>(pair.second);
         instantiation.emplace(variable, value);
     }

--- a/src/storm-pars/api/export.cpp
+++ b/src/storm-pars/api/export.cpp
@@ -37,14 +37,12 @@ void exportParametricResultToFile(std::optional<storm::RationalFunction> result,
         filestream << "$Well-formed Constraints: \n";
         std::vector<std::string> stringConstraints;
         std::transform(constraintCollector->getWellformedConstraints().begin(), constraintCollector->getWellformedConstraints().end(),
-                       std::back_inserter(stringConstraints),
-                       [](carl::Formula<typename storm::Polynomial::PolyType> const& c) -> std::string { return c.toString(); });
+                       std::back_inserter(stringConstraints), [](auto const& c) -> std::string { return c.toString(); });
         std::copy(stringConstraints.begin(), stringConstraints.end(), std::ostream_iterator<std::string>(filestream, "\n"));
         filestream << "$Graph-preserving Constraints: \n";
         stringConstraints.clear();
         std::transform(constraintCollector->getGraphPreservingConstraints().begin(), constraintCollector->getGraphPreservingConstraints().end(),
-                       std::back_inserter(stringConstraints),
-                       [](carl::Formula<typename storm::Polynomial::PolyType> const& c) -> std::string { return c.toString(); });
+                       std::back_inserter(stringConstraints), [](auto const& c) -> std::string { return c.toString(); });
         std::copy(stringConstraints.begin(), stringConstraints.end(), std::ostream_iterator<std::string>(filestream, "\n"));
     }
     storm::io::closeFile(filestream);

--- a/src/storm-pars/derivative/GradientDescentInstantiationSearcher.h
+++ b/src/storm-pars/derivative/GradientDescentInstantiationSearcher.h
@@ -257,11 +257,7 @@ class GradientDescentInstantiationSearcher {
         std::map<typename utility::parametric::VariableType<FunctionType>::type, typename utility::parametric::CoefficientType<FunctionType>::type>& position,
         const std::map<typename utility::parametric::VariableType<FunctionType>::type, ConstantType>& gradient, uint_fast64_t stepNum);
     ConstantType constantTypeSqrt(ConstantType input) {
-        if (std::is_same<ConstantType, double>::value) {
-            return utility::sqrt(input);
-        } else {
-            return carl::sqrt(input);
-        }
+        return storm::utility::sqrt(input);
     }
 
     utility::Stopwatch stochasticWatch;

--- a/src/storm-pars/transformer/BigStep.cpp
+++ b/src/storm-pars/transformer/BigStep.cpp
@@ -34,7 +34,7 @@ using UniPoly = carl::UnivariatePolynomial<RationalFunctionCoefficient>;
 
 RationalFunction BigStep::uniPolyToRationalFunction(UniPoly uniPoly) {
     auto multivariatePol = storm::RawPolynomial(uniPoly);
-    auto multiNominator = carl::FactorizedPolynomial<storm::RawPolynomial>(multivariatePol, rawPolynomialCache);
+    auto multiNominator = storm::Polynomial(multivariatePol, rawPolynomialCache);
     return RationalFunction(multiNominator);
 }
 

--- a/src/storm-pars/transformer/BigStep.h
+++ b/src/storm-pars/transformer/BigStep.h
@@ -135,13 +135,13 @@ class Annotation : public std::unordered_map<std::vector<uint64_t>, RationalFunc
                 ConstantType innerSum = utility::zero<ConstantType>();
                 for (uint64_t exponent = 0; exponent < coefficients.size(); exponent++) {
                     if (exponent != 0) {
-                        innerSum += carl::pow(input, exponent) * utility::convertNumber<ConstantType>(coefficients[exponent]);
+                        innerSum += storm::utility::pow(input, exponent) * storm::utility::convertNumber<ConstantType>(coefficients[exponent]);
                     } else {
                         innerSum += utility::convertNumber<ConstantType>(coefficients[exponent]);
                     }
                 }
                 // Inner polynomial ^ exponent
-                outerMult *= carl::pow(innerSum, info[i]);
+                outerMult *= storm::utility::pow(innerSum, info[i]);
             }
             sumOfTerms += outerMult * utility::convertNumber<ConstantType>(constant);
         }

--- a/src/storm-pars/transformer/ParameterLifter.cpp
+++ b/src/storm-pars/transformer/ParameterLifter.cpp
@@ -267,13 +267,13 @@ template<typename ParametricType, typename ConstantType>
 std::size_t ParameterLifter<ParametricType, ConstantType>::AbstractValuation::getHashValue() const {
     std::size_t seed = 0;
     for (auto const& p : lowerPars) {
-        carl::hash_add(seed, p);
+        boost::hash_combine(seed, std::hash<VariableType>()(p));
     }
     for (auto const& p : upperPars) {
-        carl::hash_add(seed, p);
+        boost::hash_combine(seed, std::hash<VariableType>()(p));
     }
     for (auto const& p : unspecifiedPars) {
-        carl::hash_add(seed, p);
+        boost::hash_combine(seed, std::hash<VariableType>()(p));
     }
     return seed;
 }

--- a/src/storm-pars/transformer/ParameterLifter.h
+++ b/src/storm-pars/transformer/ParameterLifter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/functional/hash.hpp>
 #include <memory>
 #include <set>
 #include <unordered_map>
@@ -138,8 +139,8 @@ class ParameterLifter {
            public:
             std::size_t operator()(FunctionValuation const& fv) const {
                 std::size_t seed = 0;
-                carl::hash_add(seed, fv.first);
-                carl::hash_add(seed, fv.second.getHashValue());
+                boost::hash_combine(seed, fv.first);
+                boost::hash_combine(seed, fv.second.getHashValue());
                 return seed;
             }
         };

--- a/src/storm-pars/transformer/RobustParameterLifter.cpp
+++ b/src/storm-pars/transformer/RobustParameterLifter.cpp
@@ -9,6 +9,8 @@
 #include <set>
 #include <vector>
 
+#include <boost/functional/hash.hpp>
+
 #include "storm-pars/storage/ParameterRegion.h"
 #include "storm-pars/transformer/BigStep.h"
 #include "storm-pars/utility/parametric.h"
@@ -491,7 +493,7 @@ std::optional<Annotation> const& RobustParameterLifter<ParametricType, ConstantT
 template<typename ParametricType, typename ConstantType>
 std::size_t RobustParameterLifter<ParametricType, ConstantType>::RobustAbstractValuation::getHashValue() const {
     std::size_t seed = 0;
-    carl::hash_add(seed, transition);
+    boost::hash_combine(seed, transition);
     return seed;
 }
 

--- a/src/storm-pars/utility/parametric.cpp
+++ b/src/storm-pars/utility/parametric.cpp
@@ -22,17 +22,15 @@ double evaluate(storm::RationalFunction const& function, Valuation<storm::Ration
     return evaluateRationalFunction<double>(function, valuation);
 }
 
-#if defined(STORM_HAVE_CLN)
 template<>
-ClnRationalNumber evaluate(storm::RationalFunction const& function, Valuation<storm::RationalFunction> const& valuation) {
-    return evaluateRationalFunction<ClnRationalNumber>(function, valuation);
+storm::RationalNumber evaluate(storm::RationalFunction const& function, Valuation<storm::RationalFunction> const& valuation) {
+    return evaluateRationalFunction<storm::RationalNumber>(function, valuation);
 }
-#endif
 
-#if defined(STORM_HAVE_GMP)
+#if STORM_RATIONAL_NUMBER_DIFFERS_FROM_COEFFICIENT
 template<>
-GmpRationalNumber evaluate(storm::RationalFunction const& function, Valuation<storm::RationalFunction> const& valuation) {
-    return evaluateRationalFunction<GmpRationalNumber>(function, valuation);
+storm::RationalFunctionCoefficient evaluate(storm::RationalFunction const& function, Valuation<storm::RationalFunction> const& valuation) {
+    return evaluateRationalFunction<storm::RationalFunctionCoefficient>(function, valuation);
 }
 #endif
 

--- a/src/storm-parsers/parser/ValueParser.cpp
+++ b/src/storm-parsers/parser/ValueParser.cpp
@@ -84,19 +84,19 @@ bool parseInterval(std::string const& value, IntervalType& result) {
 
     std::string intermediate = value;
     boost::trim(intermediate);
-    carl::BoundType leftBound;
-    carl::BoundType rightBound;
+    storm::BoundType leftBound;
+    storm::BoundType rightBound;
     if (intermediate.front() == '(') {
-        leftBound = carl::BoundType::STRICT;
+        leftBound = storm::BoundType::STRICT;
     } else if (intermediate.front() == '[') {
-        leftBound = carl::BoundType::WEAK;
+        leftBound = storm::BoundType::WEAK;
     } else {
         return false;  // Expect start with '(' or '['.
     }
     if (intermediate.back() == ')') {
-        rightBound = carl::BoundType::STRICT;
+        rightBound = storm::BoundType::STRICT;
     } else if (intermediate.back() == ']') {
-        rightBound = carl::BoundType::WEAK;
+        rightBound = storm::BoundType::WEAK;
     } else {
         return false;  // Expected end with ')' or ']'.
     }
@@ -125,7 +125,7 @@ bool parseNumber(std::string const& value, NumberType& result) {
     if constexpr (std::is_same_v<NumberType, double>) {
         return parseDouble(value, result);
     } else if constexpr (std::is_same_v<NumberType, storm::RationalNumber>) {
-        return carl::try_parse(value, result);
+        return storm::utility::tryParseNumber(value, result);
     } else if constexpr (std::is_same_v<NumberType, storm::Interval>) {
         return parseInterval<storm::Interval>(value, result);
     } else if constexpr (std::is_same_v<NumberType, storm::RationalInterval>) {

--- a/src/storm-pomdp/analysis/WinningRegion.cpp
+++ b/src/storm-pomdp/analysis/WinningRegion.cpp
@@ -168,7 +168,7 @@ storm::RationalNumber WinningRegion::beliefSupportStates() const {
     storm::RationalNumber total = 0;
     storm::RationalNumber two = storm::utility::convertNumber<storm::RationalNumber>(2);
     for (auto const& size : observationSizes) {
-        total += carl::pow(two, size) - 1;
+        total += storm::utility::pow(two, size) - 1;
     }
     return total;
 }
@@ -182,9 +182,9 @@ std::pair<storm::RationalNumber, storm::RationalNumber> count(std::vector<storm:
     storm::RationalNumber two = storm::utility::convertNumber<storm::RationalNumber>(2);
     for (uint64_t i = 0; i < intersects.size(); ++i) {
         if (plus) {
-            newVal += carl::pow(two, intersects[i].getNumberOfSetBits());
+            newVal += storm::utility::pow(two, intersects[i].getNumberOfSetBits());
         } else {
-            newVal -= carl::pow(two, intersects[i].getNumberOfSetBits());
+            newVal -= storm::utility::pow(two, intersects[i].getNumberOfSetBits());
         }
     }
 
@@ -222,7 +222,7 @@ std::pair<storm::RationalNumber, storm::RationalNumber> count(std::vector<storm:
         std::vector<storm::storage::BitVector> useInfo;
         for (uint64_t i = 0; i < intersects.size(); ++i) {
             if (upperBoundElements > 10000 && intersects[i].getNumberOfSetBits() < intersectSetSkip - 3) {
-                skipped += (carl::pow(two, intersects[i].getNumberOfSetBits()) * origSets.size());
+                skipped += (storm::utility::pow(two, intersects[i].getNumberOfSetBits()) * origSets.size());
                 STORM_LOG_DEBUG("Skipped " << skipped);
             } else {
                 useIntersects.push_back(intersects[i]);
@@ -238,7 +238,7 @@ std::pair<storm::RationalNumber, storm::RationalNumber> count(std::vector<storm:
 
         for (uint64_t i = 0; i < origSets.size(); ++i) {
             if (upperBoundElements > 20000 && origSets[i].getNumberOfSetBits() < origSetSkip - 3) {
-                skipped += (carl::pow(two, origSets[i].getNumberOfSetBits()) * useIntersects.size());
+                skipped += (storm::utility::pow(two, origSets[i].getNumberOfSetBits()) * useIntersects.size());
                 STORM_LOG_DEBUG("Skipped " << skipped);
                 continue;
             }

--- a/src/storm/adapters/EigenAdapter.h
+++ b/src/storm/adapters/EigenAdapter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/functional/hash.hpp>
 #include <memory>
 
 #include "storm/adapters/RationalNumberAdapter.h"
@@ -34,7 +35,7 @@ struct hash<Eigen::Matrix<ValueType, Eigen::Dynamic, 1>> {
     std::size_t operator()(Eigen::Matrix<ValueType, Eigen::Dynamic, 1> const& vector) const {
         size_t seed = 0;
         for (uint_fast64_t i = 0; i < static_cast<uint_fast64_t>(vector.rows()); ++i) {
-            carl::hash_add(seed, std::hash<ValueType>()(vector(i)));
+            boost::hash_combine(seed, std::hash<ValueType>()(vector(i)));
         }
         return seed;
     }

--- a/src/storm/adapters/IntervalAdapter.h
+++ b/src/storm/adapters/IntervalAdapter.h
@@ -15,3 +15,12 @@ inline size_t hash_value(carl::Interval<Number> const& i) {
     return h(i);
 }
 }  // namespace carl
+
+namespace storm {
+
+/*!
+ * Type describing the interval bounds.
+ */
+using BoundType = carl::BoundType;
+
+}  // namespace storm

--- a/src/storm/adapters/MathsatExpressionAdapter.cpp
+++ b/src/storm/adapters/MathsatExpressionAdapter.cpp
@@ -1,7 +1,315 @@
-#include "storm/adapters/MathsatExpressionAdapter.h"
+#include "MathsatExpressionAdapter.h"
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+
+#include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/exceptions/ExpressionEvaluationException.h"
+#include "storm/exceptions/InvalidTypeException.h"
+#include "storm/storage/expressions/ExpressionManager.h"
+#include "storm/storage/expressions/Expressions.h"
+#include "storm/utility/NumberTraits.h"
+#include "storm/utility/constants.h"
+#include "storm/utility/macros.h"
 
 #ifdef STORM_HAVE_MATHSAT
+
 bool operator==(msat_decl decl1, msat_decl decl2) {
     return decl1.repr == decl2.repr;
 }
-#endif
+
+namespace storm {
+namespace adapters {
+
+MathsatExpressionAdapter::MathsatExpressionAdapter(storm::expressions::ExpressionManager& manager, msat_env& env)
+    : manager(manager), env(env), variableToDeclarationMapping() {
+    // Intentionally left empty.
+}
+
+msat_term MathsatExpressionAdapter::translateExpression(storm::expressions::Expression const& expression) {
+    additionalConstraints.clear();
+    msat_term result = boost::any_cast<msat_term>(expression.getBaseExpression().accept(*this, boost::none));
+    if (MSAT_ERROR_TERM(result)) {
+        std::string errorMessage(msat_last_error_message(env));
+        STORM_LOG_THROW(!MSAT_ERROR_TERM(result), storm::exceptions::ExpressionEvaluationException,
+                        "Could not translate expression to MathSAT's format. (Message: " << errorMessage << ").");
+    }
+
+    return result;
+}
+
+msat_term MathsatExpressionAdapter::translateExpression(storm::expressions::Variable const& variable) {
+    STORM_LOG_ASSERT(variable.getManager() == this->manager, "Invalid expression for solver.");
+
+    auto const& variableExpressionPair = variableToDeclarationMapping.find(variable);
+    if (variableExpressionPair == variableToDeclarationMapping.end()) {
+        return msat_make_constant(env, createVariable(variable));
+    }
+    return msat_make_constant(env, variableExpressionPair->second);
+}
+
+bool MathsatExpressionAdapter::hasAdditionalConstraints() const {
+    return !additionalConstraints.empty();
+}
+
+std::vector<msat_term> const& MathsatExpressionAdapter::getAdditionalConstraints() const {
+    return additionalConstraints;
+}
+
+storm::expressions::Variable const& MathsatExpressionAdapter::getVariable(msat_decl msatVariableDeclaration) const {
+    auto const& declarationVariablePair = declarationToVariableMapping.find(msatVariableDeclaration);
+    STORM_LOG_ASSERT(declarationVariablePair != declarationToVariableMapping.end(), "Unknown variable declaration.");
+    return declarationVariablePair->second;
+}
+
+std::unordered_map<storm::expressions::Variable, msat_decl> const& MathsatExpressionAdapter::getAllDeclaredVariables() const {
+    return variableToDeclarationMapping;
+}
+
+boost::any MathsatExpressionAdapter::visit(storm::expressions::BinaryBooleanFunctionExpression const& expression, boost::any const& data) {
+    msat_term leftResult = boost::any_cast<msat_term>(expression.getFirstOperand()->accept(*this, data));
+    msat_term rightResult = boost::any_cast<msat_term>(expression.getSecondOperand()->accept(*this, data));
+
+    switch (expression.getOperatorType()) {
+        case storm::expressions::BinaryBooleanFunctionExpression::OperatorType::And:
+            return msat_make_and(env, leftResult, rightResult);
+        case storm::expressions::BinaryBooleanFunctionExpression::OperatorType::Or:
+            return msat_make_or(env, leftResult, rightResult);
+        case storm::expressions::BinaryBooleanFunctionExpression::OperatorType::Iff:
+            return msat_make_iff(env, leftResult, rightResult);
+        case storm::expressions::BinaryBooleanFunctionExpression::OperatorType::Implies:
+            return msat_make_or(env, msat_make_not(env, leftResult), rightResult);
+        default:
+            STORM_LOG_THROW(false, storm::exceptions::ExpressionEvaluationException,
+                            "Cannot evaluate expression: unknown boolean binary operator '" << static_cast<uint_fast64_t>(expression.getOperatorType())
+                                                                                            << "' in expression " << expression << ".");
+    }
+}
+
+boost::any MathsatExpressionAdapter::visit(storm::expressions::BinaryNumericalFunctionExpression const& expression, boost::any const& data) {
+    msat_term leftResult = boost::any_cast<msat_term>(expression.getFirstOperand()->accept(*this, data));
+    msat_term rightResult = boost::any_cast<msat_term>(expression.getSecondOperand()->accept(*this, data));
+
+    msat_term result = leftResult;
+    int_fast64_t exponent;
+    int_fast64_t modulus;
+    storm::expressions::Variable freshAuxiliaryVariable;
+    msat_term modVariable;
+    msat_term lower;
+    msat_term upper;
+    typename storm::NumberTraits<storm::GmpRationalNumber>::IntegerType gmpModulus;
+    switch (expression.getOperatorType()) {
+        case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Plus:
+            return msat_make_plus(env, leftResult, rightResult);
+        case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Minus:
+            return msat_make_plus(env, leftResult, msat_make_times(env, msat_make_number(env, "-1"), rightResult));
+        case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Times:
+            return msat_make_times(env, leftResult, rightResult);
+        case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Divide:
+            return msat_make_divide(env, leftResult, rightResult);
+        case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Min:
+            return msat_make_term_ite(env, msat_make_leq(env, leftResult, rightResult), leftResult, rightResult);
+        case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Max:
+            return msat_make_term_ite(env, msat_make_leq(env, leftResult, rightResult), rightResult, leftResult);
+        case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Power:
+            exponent = expression.getSecondOperand()->evaluateAsInt();
+            STORM_LOG_THROW(exponent >= 0, storm::exceptions::ExpressionEvaluationException, "Cannot evaluate expression with negative exponent.");
+            --exponent;
+            if (exponent > 0) {
+                for (; exponent > 0; --exponent) {
+                    result = msat_make_times(env, result, leftResult);
+                }
+            }
+            return result;
+        case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Modulo:
+            modulus = expression.getSecondOperand()->evaluateAsInt();
+            STORM_LOG_THROW(modulus > 0, storm::exceptions::ExpressionEvaluationException, "Cannot evaluate expression with negative modulus.");
+
+            freshAuxiliaryVariable = manager.declareFreshVariable(manager.getIntegerType(), true);
+            modVariable = msat_make_constant(env, createVariable(freshAuxiliaryVariable));
+
+            gmpModulus = typename storm::NumberTraits<storm::GmpRationalNumber>::IntegerType(static_cast<unsigned>(modulus));
+
+            // Create the constraint that fixes the value of the fresh variable.
+            additionalConstraints.push_back(msat_make_int_modular_congruence(env, gmpModulus.get_mpz_t(), modVariable, leftResult));
+
+            // Create the constraint that limits the value of the modulo operation to 0 <= val <= modulus-1.
+            lower = msat_make_number(env, "-1");
+            upper = msat_make_number(env, std::to_string(modulus - 1).c_str());
+            additionalConstraints.push_back(
+                msat_make_and(env, msat_make_not(env, msat_make_leq(env, modVariable, lower)), msat_make_leq(env, modVariable, upper)));
+            return modVariable;
+        default:
+            STORM_LOG_THROW(false, storm::exceptions::ExpressionEvaluationException,
+                            "Cannot evaluate expression: unknown numerical binary operator '" << static_cast<uint_fast64_t>(expression.getOperatorType())
+                                                                                              << "' in expression " << expression << ".");
+    }
+}
+
+boost::any MathsatExpressionAdapter::visit(storm::expressions::BinaryRelationExpression const& expression, boost::any const& data) {
+    msat_term leftResult = boost::any_cast<msat_term>(expression.getFirstOperand()->accept(*this, data));
+    msat_term rightResult = boost::any_cast<msat_term>(expression.getSecondOperand()->accept(*this, data));
+
+    switch (expression.getRelationType()) {
+        case storm::expressions::RelationType::Equal:
+            if (expression.getFirstOperand()->getType().isBooleanType() && expression.getSecondOperand()->getType().isBooleanType()) {
+                return msat_make_iff(env, leftResult, rightResult);
+            } else {
+                return msat_make_equal(env, leftResult, rightResult);
+            }
+        case storm::expressions::RelationType::NotEqual:
+            if (expression.getFirstOperand()->getType().isBooleanType() && expression.getSecondOperand()->getType().isBooleanType()) {
+                return msat_make_not(env, msat_make_iff(env, leftResult, rightResult));
+            } else {
+                return msat_make_not(env, msat_make_equal(env, leftResult, rightResult));
+            }
+        case storm::expressions::RelationType::Less:
+            return msat_make_and(env, msat_make_not(env, msat_make_equal(env, leftResult, rightResult)), msat_make_leq(env, leftResult, rightResult));
+        case storm::expressions::RelationType::LessOrEqual:
+            return msat_make_leq(env, leftResult, rightResult);
+        case storm::expressions::RelationType::Greater:
+            return msat_make_not(env, msat_make_leq(env, leftResult, rightResult));
+        case storm::expressions::RelationType::GreaterOrEqual:
+            return msat_make_or(env, msat_make_equal(env, leftResult, rightResult), msat_make_not(env, msat_make_leq(env, leftResult, rightResult)));
+        default:
+            STORM_LOG_THROW(false, storm::exceptions::ExpressionEvaluationException,
+                            "Cannot evaluate expression: unknown boolean binary operator '" << static_cast<uint_fast64_t>(expression.getRelationType())
+                                                                                            << "' in expression " << expression << ".");
+    }
+}
+
+boost::any MathsatExpressionAdapter::visit(storm::expressions::IfThenElseExpression const& expression, boost::any const& data) {
+    msat_term conditionResult = boost::any_cast<msat_term>(expression.getCondition()->accept(*this, data));
+    msat_term thenResult = boost::any_cast<msat_term>(expression.getThenExpression()->accept(*this, data));
+    msat_term elseResult = boost::any_cast<msat_term>(expression.getElseExpression()->accept(*this, data));
+
+    // MathSAT does not allow ite with boolean arguments, so we have to encode it ourselves.
+    if (expression.getThenExpression()->hasBooleanType() && expression.getElseExpression()->hasBooleanType()) {
+        return msat_make_and(env, msat_make_or(env, msat_make_not(env, conditionResult), thenResult), msat_make_or(env, conditionResult, elseResult));
+    } else {
+        return msat_make_term_ite(env, conditionResult, thenResult, elseResult);
+    }
+}
+
+boost::any MathsatExpressionAdapter::visit(storm::expressions::BooleanLiteralExpression const& expression, boost::any const&) {
+    return expression.getValue() ? msat_make_true(env) : msat_make_false(env);
+}
+
+boost::any MathsatExpressionAdapter::visit(storm::expressions::RationalLiteralExpression const& expression, boost::any const&) {
+    std::stringstream fractionStream;
+    fractionStream << expression.getValue();
+    return msat_make_number(env, fractionStream.str().c_str());
+}
+
+boost::any MathsatExpressionAdapter::visit(storm::expressions::IntegerLiteralExpression const& expression, boost::any const&) {
+    return msat_make_number(env, std::to_string(static_cast<int>(expression.getValue())).c_str());
+}
+
+boost::any MathsatExpressionAdapter::visit(storm::expressions::UnaryBooleanFunctionExpression const& expression, boost::any const& data) {
+    msat_term childResult = boost::any_cast<msat_term>(expression.getOperand()->accept(*this, data));
+
+    switch (expression.getOperatorType()) {
+        case storm::expressions::UnaryBooleanFunctionExpression::OperatorType::Not:
+            return msat_make_not(env, childResult);
+            break;
+        default:
+            STORM_LOG_THROW(false, storm::exceptions::ExpressionEvaluationException,
+                            "Cannot evaluate expression: unknown boolean unary operator: '" << static_cast<uint_fast64_t>(expression.getOperatorType())
+                                                                                            << "' in expression " << expression << ".");
+    }
+}
+
+boost::any MathsatExpressionAdapter::visit(storm::expressions::UnaryNumericalFunctionExpression const& expression, boost::any const& data) {
+    msat_term childResult = boost::any_cast<msat_term>(expression.getOperand()->accept(*this, data));
+
+    switch (expression.getOperatorType()) {
+        case storm::expressions::UnaryNumericalFunctionExpression::OperatorType::Minus:
+            return msat_make_times(env, msat_make_number(env, "-1"), childResult);
+        case storm::expressions::UnaryNumericalFunctionExpression::OperatorType::Floor:
+            return msat_make_floor(env, childResult);
+        case storm::expressions::UnaryNumericalFunctionExpression::OperatorType::Ceil:
+            // Mathsat does not support ceil... but ceil(x) = -floor(-x)  wheeii \o/
+            return msat_make_times(env, msat_make_number(env, "-1"), msat_make_floor(env, msat_make_times(env, msat_make_number(env, "-1"), childResult)));
+        default:
+            STORM_LOG_THROW(false, storm::exceptions::ExpressionEvaluationException,
+                            "Cannot evaluate expression: unknown numerical unary operator: '" << static_cast<uint_fast64_t>(expression.getOperatorType())
+                                                                                              << "' in expression " << expression << ".");
+    }
+}
+
+boost::any MathsatExpressionAdapter::visit(storm::expressions::VariableExpression const& expression, boost::any const&) {
+    return translateExpression(expression.getVariable());
+}
+
+storm::expressions::Expression MathsatExpressionAdapter::translateExpression(msat_term const& term) {
+    if (msat_term_is_and(env, term)) {
+        return translateExpression(msat_term_get_arg(term, 0)) && translateExpression(msat_term_get_arg(term, 1));
+    } else if (msat_term_is_or(env, term)) {
+        return translateExpression(msat_term_get_arg(term, 0)) || translateExpression(msat_term_get_arg(term, 1));
+    } else if (msat_term_is_iff(env, term)) {
+        return storm::expressions::iff(translateExpression(msat_term_get_arg(term, 0)), translateExpression(msat_term_get_arg(term, 1)));
+    } else if (msat_term_is_not(env, term)) {
+        return !translateExpression(msat_term_get_arg(term, 0));
+    } else if (msat_term_is_plus(env, term)) {
+        return translateExpression(msat_term_get_arg(term, 0)) + translateExpression(msat_term_get_arg(term, 1));
+    } else if (msat_term_is_times(env, term)) {
+        return translateExpression(msat_term_get_arg(term, 0)) * translateExpression(msat_term_get_arg(term, 1));
+    } else if (msat_term_is_equal(env, term)) {
+        return translateExpression(msat_term_get_arg(term, 0)) == translateExpression(msat_term_get_arg(term, 1));
+    } else if (msat_term_is_leq(env, term)) {
+        return translateExpression(msat_term_get_arg(term, 0)) <= translateExpression(msat_term_get_arg(term, 1));
+    } else if (msat_term_is_true(env, term)) {
+        return manager.boolean(true);
+    } else if (msat_term_is_false(env, term)) {
+        return manager.boolean(false);
+    } else if (msat_term_is_constant(env, term)) {
+        char* name = msat_decl_get_name(msat_term_get_decl(term));
+        std::string nameString(name);
+        storm::expressions::Expression result = manager.getVariableExpression(nameString.substr(0, nameString.find('/')));
+        msat_free(name);
+        return result;
+    } else if (msat_term_is_number(env, term)) {
+        char* termAsCString = msat_term_repr(term);
+        std::string termString(termAsCString);
+        msat_free(termAsCString);
+        if (msat_is_integer_type(env, msat_term_get_type(term))) {
+            return manager.integer(std::stoll(msat_term_repr(term)));
+        } else if (msat_is_rational_type(env, msat_term_get_type(term))) {
+            return manager.rational(storm::utility::convertNumber<storm::RationalNumber>(termString));
+        }
+    } else if (msat_term_is_term_ite(env, term)) {
+        return storm::expressions::ite(translateExpression(msat_term_get_arg(term, 0)), translateExpression(msat_term_get_arg(term, 1)),
+                                       translateExpression(msat_term_get_arg(term, 2)));
+    }
+
+    // If all other cases did not apply, we cannot represent the term in our expression framework.
+    char* termAsCString = msat_term_repr(term);
+    std::string termString(termAsCString);
+    msat_free(termAsCString);
+    STORM_LOG_THROW(false, storm::exceptions::ExpressionEvaluationException, "Cannot translate expression: unknown term: '" << termString << "'.");
+}
+
+msat_decl MathsatExpressionAdapter::createVariable(storm::expressions::Variable const& variable) {
+    msat_decl msatDeclaration;
+    if (variable.getType().isBooleanType()) {
+        msatDeclaration = msat_declare_function(env, variable.getName().c_str(), msat_get_bool_type(env));
+    } else if (variable.getType().isIntegerType()) {
+        msatDeclaration = msat_declare_function(env, variable.getName().c_str(), msat_get_integer_type(env));
+    } else if (variable.getType().isBitVectorType()) {
+        msatDeclaration = msat_declare_function(env, variable.getName().c_str(), msat_get_bv_type(env, variable.getType().getWidth()));
+    } else if (variable.getType().isRationalType()) {
+        msatDeclaration = msat_declare_function(env, variable.getName().c_str(), msat_get_rational_type(env));
+    } else {
+        STORM_LOG_THROW(false, storm::exceptions::InvalidTypeException,
+                        "Encountered variable '" << variable.getName() << "' with unknown type while trying to create solver variables.");
+    }
+    variableToDeclarationMapping.insert(std::make_pair(variable, msatDeclaration));
+    declarationToVariableMapping.insert(std::make_pair(msatDeclaration, variable));
+    return msatDeclaration;
+}
+
+}  // namespace adapters
+}  // namespace storm
+
+#endif  // STORM_HAVE_MATHSAT

--- a/src/storm/adapters/MathsatExpressionAdapter.h
+++ b/src/storm/adapters/MathsatExpressionAdapter.h
@@ -2,21 +2,15 @@
 
 #include "storm-config.h"
 
-#include <stack>
+#include <unordered_map>
+#include <vector>
 
 #ifdef STORM_HAVE_MATHSAT
 #include <mathsat.h>
 #endif
 
-#include "storm/exceptions/ExpressionEvaluationException.h"
-#include "storm/exceptions/InvalidArgumentException.h"
-#include "storm/exceptions/InvalidTypeException.h"
-#include "storm/exceptions/NotImplementedException.h"
-#include "storm/storage/expressions/ExpressionManager.h"
 #include "storm/storage/expressions/ExpressionVisitor.h"
-#include "storm/storage/expressions/Expressions.h"
-#include "storm/utility/constants.h"
-#include "storm/utility/macros.h"
+#include "storm/storage/expressions/Variable.h"
 
 #ifdef STORM_HAVE_MATHSAT
 namespace std {
@@ -34,6 +28,11 @@ bool operator==(msat_decl decl1, msat_decl decl2);
 #endif
 
 namespace storm {
+namespace expressions {
+class Expression;
+class ExpressionManager;
+}  // namespace expressions
+
 namespace adapters {
 
 #ifdef STORM_HAVE_MATHSAT
@@ -46,9 +45,7 @@ class MathsatExpressionAdapter : public storm::expressions::ExpressionVisitor {
      * @param manager The manager that can be used to build expressions.
      * @param env The MathSAT environment in which to build the expressions.
      */
-    MathsatExpressionAdapter(storm::expressions::ExpressionManager& manager, msat_env& env) : manager(manager), env(env), variableToDeclarationMapping() {
-        // Intentionally left empty.
-    }
+    MathsatExpressionAdapter(storm::expressions::ExpressionManager& manager, msat_env& env);
 
     /*!
      * Translates the given expression to an equivalent term for MathSAT.
@@ -56,17 +53,7 @@ class MathsatExpressionAdapter : public storm::expressions::ExpressionVisitor {
      * @param expression The expression to be translated.
      * @return An equivalent term for MathSAT.
      */
-    msat_term translateExpression(storm::expressions::Expression const& expression) {
-        additionalConstraints.clear();
-        msat_term result = boost::any_cast<msat_term>(expression.getBaseExpression().accept(*this, boost::none));
-        if (MSAT_ERROR_TERM(result)) {
-            std::string errorMessage(msat_last_error_message(env));
-            STORM_LOG_THROW(!MSAT_ERROR_TERM(result), storm::exceptions::ExpressionEvaluationException,
-                            "Could not translate expression to MathSAT's format. (Message: " << errorMessage << ").");
-        }
-
-        return result;
-    }
+    msat_term translateExpression(storm::expressions::Expression const& expression);
 
     /*!
      * Translates the given variable to an equivalent expression for MathSAT.
@@ -74,26 +61,14 @@ class MathsatExpressionAdapter : public storm::expressions::ExpressionVisitor {
      * @param variable The variable to translate.
      * @return An equivalent term for MathSAT.
      */
-    msat_term translateExpression(storm::expressions::Variable const& variable) {
-        STORM_LOG_ASSERT(variable.getManager() == this->manager, "Invalid expression for solver.");
+    msat_term translateExpression(storm::expressions::Variable const& variable);
 
-        auto const& variableExpressionPair = variableToDeclarationMapping.find(variable);
-        if (variableExpressionPair == variableToDeclarationMapping.end()) {
-            return msat_make_constant(env, createVariable(variable));
-        }
-        return msat_make_constant(env, variableExpressionPair->second);
-    }
-
-    bool hasAdditionalConstraints() const {
-        return !additionalConstraints.empty();
-    }
+    bool hasAdditionalConstraints() const;
 
     /*!
      * Retrieves additional constraints that were created because of encodings using auxiliary variables.
      */
-    std::vector<msat_term> const& getAdditionalConstraints() const {
-        return additionalConstraints;
-    }
+    std::vector<msat_term> const& getAdditionalConstraints() const;
 
     /*!
      * Retrieves the variable that is associated with the given MathSAT variable declaration.
@@ -101,238 +76,31 @@ class MathsatExpressionAdapter : public storm::expressions::ExpressionVisitor {
      * @param msatVariableDeclaration The MathSAT variable declaration.
      * @return The variable associated with the given declaration.
      */
-    storm::expressions::Variable const& getVariable(msat_decl msatVariableDeclaration) const {
-        auto const& declarationVariablePair = declarationToVariableMapping.find(msatVariableDeclaration);
-        STORM_LOG_ASSERT(declarationVariablePair != declarationToVariableMapping.end(), "Unknown variable declaration.");
-        return declarationVariablePair->second;
-    }
+    storm::expressions::Variable const& getVariable(msat_decl msatVariableDeclaration) const;
 
-    std::unordered_map<storm::expressions::Variable, msat_decl> const& getAllDeclaredVariables() const {
-        return variableToDeclarationMapping;
-    }
+    std::unordered_map<storm::expressions::Variable, msat_decl> const& getAllDeclaredVariables() const;
 
-    virtual boost::any visit(storm::expressions::BinaryBooleanFunctionExpression const& expression, boost::any const& data) override {
-        msat_term leftResult = boost::any_cast<msat_term>(expression.getFirstOperand()->accept(*this, data));
-        msat_term rightResult = boost::any_cast<msat_term>(expression.getSecondOperand()->accept(*this, data));
+    virtual boost::any visit(storm::expressions::BinaryBooleanFunctionExpression const& expression, boost::any const& data) override;
 
-        switch (expression.getOperatorType()) {
-            case storm::expressions::BinaryBooleanFunctionExpression::OperatorType::And:
-                return msat_make_and(env, leftResult, rightResult);
-            case storm::expressions::BinaryBooleanFunctionExpression::OperatorType::Or:
-                return msat_make_or(env, leftResult, rightResult);
-            case storm::expressions::BinaryBooleanFunctionExpression::OperatorType::Iff:
-                return msat_make_iff(env, leftResult, rightResult);
-            case storm::expressions::BinaryBooleanFunctionExpression::OperatorType::Implies:
-                return msat_make_or(env, msat_make_not(env, leftResult), rightResult);
-            default:
-                STORM_LOG_THROW(false, storm::exceptions::ExpressionEvaluationException,
-                                "Cannot evaluate expression: unknown boolean binary operator '" << static_cast<uint_fast64_t>(expression.getOperatorType())
-                                                                                                << "' in expression " << expression << ".");
-        }
-    }
+    virtual boost::any visit(storm::expressions::BinaryNumericalFunctionExpression const& expression, boost::any const& data) override;
 
-    virtual boost::any visit(storm::expressions::BinaryNumericalFunctionExpression const& expression, boost::any const& data) override {
-        msat_term leftResult = boost::any_cast<msat_term>(expression.getFirstOperand()->accept(*this, data));
-        msat_term rightResult = boost::any_cast<msat_term>(expression.getSecondOperand()->accept(*this, data));
+    virtual boost::any visit(storm::expressions::BinaryRelationExpression const& expression, boost::any const& data) override;
 
-        msat_term result = leftResult;
-        int_fast64_t exponent;
-        int_fast64_t modulus;
-        storm::expressions::Variable freshAuxiliaryVariable;
-        msat_term modVariable;
-        msat_term lower;
-        msat_term upper;
-        typename storm::NumberTraits<storm::GmpRationalNumber>::IntegerType gmpModulus;
-        switch (expression.getOperatorType()) {
-            case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Plus:
-                return msat_make_plus(env, leftResult, rightResult);
-            case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Minus:
-                return msat_make_plus(env, leftResult, msat_make_times(env, msat_make_number(env, "-1"), rightResult));
-            case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Times:
-                return msat_make_times(env, leftResult, rightResult);
-            case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Divide:
-                return msat_make_divide(env, leftResult, rightResult);
-            case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Min:
-                return msat_make_term_ite(env, msat_make_leq(env, leftResult, rightResult), leftResult, rightResult);
-            case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Max:
-                return msat_make_term_ite(env, msat_make_leq(env, leftResult, rightResult), rightResult, leftResult);
-            case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Power:
-                exponent = expression.getSecondOperand()->evaluateAsInt();
-                STORM_LOG_THROW(exponent >= 0, storm::exceptions::ExpressionEvaluationException, "Cannot evaluate expression with negative exponent.");
-                --exponent;
-                if (exponent > 0) {
-                    for (; exponent > 0; --exponent) {
-                        result = msat_make_times(env, result, leftResult);
-                    }
-                }
-                return result;
-            case storm::expressions::BinaryNumericalFunctionExpression::OperatorType::Modulo:
-                modulus = expression.getSecondOperand()->evaluateAsInt();
-                STORM_LOG_THROW(modulus > 0, storm::exceptions::ExpressionEvaluationException, "Cannot evaluate expression with negative modulus.");
+    virtual boost::any visit(storm::expressions::IfThenElseExpression const& expression, boost::any const& data) override;
 
-                freshAuxiliaryVariable = manager.declareFreshVariable(manager.getIntegerType(), true);
-                modVariable = msat_make_constant(env, createVariable(freshAuxiliaryVariable));
+    virtual boost::any visit(storm::expressions::BooleanLiteralExpression const& expression, boost::any const& data) override;
 
-                gmpModulus = typename storm::NumberTraits<storm::GmpRationalNumber>::IntegerType(static_cast<unsigned>(modulus));
+    virtual boost::any visit(storm::expressions::RationalLiteralExpression const& expression, boost::any const& data) override;
 
-                // Create the constraint that fixes the value of the fresh variable.
-                additionalConstraints.push_back(msat_make_int_modular_congruence(env, gmpModulus.get_mpz_t(), modVariable, leftResult));
+    virtual boost::any visit(storm::expressions::IntegerLiteralExpression const& expression, boost::any const& data) override;
 
-                // Create the constraint that limits the value of the modulo operation to 0 <= val <= modulus-1.
-                lower = msat_make_number(env, "-1");
-                upper = msat_make_number(env, std::to_string(modulus - 1).c_str());
-                additionalConstraints.push_back(
-                    msat_make_and(env, msat_make_not(env, msat_make_leq(env, modVariable, lower)), msat_make_leq(env, modVariable, upper)));
-                return modVariable;
-            default:
-                STORM_LOG_THROW(false, storm::exceptions::ExpressionEvaluationException,
-                                "Cannot evaluate expression: unknown numerical binary operator '" << static_cast<uint_fast64_t>(expression.getOperatorType())
-                                                                                                  << "' in expression " << expression << ".");
-        }
-    }
+    virtual boost::any visit(storm::expressions::UnaryBooleanFunctionExpression const& expression, boost::any const& data) override;
 
-    virtual boost::any visit(storm::expressions::BinaryRelationExpression const& expression, boost::any const& data) override {
-        msat_term leftResult = boost::any_cast<msat_term>(expression.getFirstOperand()->accept(*this, data));
-        msat_term rightResult = boost::any_cast<msat_term>(expression.getSecondOperand()->accept(*this, data));
+    virtual boost::any visit(storm::expressions::UnaryNumericalFunctionExpression const& expression, boost::any const& data) override;
 
-        switch (expression.getRelationType()) {
-            case storm::expressions::RelationType::Equal:
-                if (expression.getFirstOperand()->getType().isBooleanType() && expression.getSecondOperand()->getType().isBooleanType()) {
-                    return msat_make_iff(env, leftResult, rightResult);
-                } else {
-                    return msat_make_equal(env, leftResult, rightResult);
-                }
-            case storm::expressions::RelationType::NotEqual:
-                if (expression.getFirstOperand()->getType().isBooleanType() && expression.getSecondOperand()->getType().isBooleanType()) {
-                    return msat_make_not(env, msat_make_iff(env, leftResult, rightResult));
-                } else {
-                    return msat_make_not(env, msat_make_equal(env, leftResult, rightResult));
-                }
-            case storm::expressions::RelationType::Less:
-                return msat_make_and(env, msat_make_not(env, msat_make_equal(env, leftResult, rightResult)), msat_make_leq(env, leftResult, rightResult));
-            case storm::expressions::RelationType::LessOrEqual:
-                return msat_make_leq(env, leftResult, rightResult);
-            case storm::expressions::RelationType::Greater:
-                return msat_make_not(env, msat_make_leq(env, leftResult, rightResult));
-            case storm::expressions::RelationType::GreaterOrEqual:
-                return msat_make_or(env, msat_make_equal(env, leftResult, rightResult), msat_make_not(env, msat_make_leq(env, leftResult, rightResult)));
-            default:
-                STORM_LOG_THROW(false, storm::exceptions::ExpressionEvaluationException,
-                                "Cannot evaluate expression: unknown boolean binary operator '" << static_cast<uint_fast64_t>(expression.getRelationType())
-                                                                                                << "' in expression " << expression << ".");
-        }
-    }
+    virtual boost::any visit(storm::expressions::VariableExpression const& expression, boost::any const& data) override;
 
-    virtual boost::any visit(storm::expressions::IfThenElseExpression const& expression, boost::any const& data) override {
-        msat_term conditionResult = boost::any_cast<msat_term>(expression.getCondition()->accept(*this, data));
-        msat_term thenResult = boost::any_cast<msat_term>(expression.getThenExpression()->accept(*this, data));
-        msat_term elseResult = boost::any_cast<msat_term>(expression.getElseExpression()->accept(*this, data));
-
-        // MathSAT does not allow ite with boolean arguments, so we have to encode it ourselves.
-        if (expression.getThenExpression()->hasBooleanType() && expression.getElseExpression()->hasBooleanType()) {
-            return msat_make_and(env, msat_make_or(env, msat_make_not(env, conditionResult), thenResult), msat_make_or(env, conditionResult, elseResult));
-        } else {
-            return msat_make_term_ite(env, conditionResult, thenResult, elseResult);
-        }
-    }
-
-    virtual boost::any visit(storm::expressions::BooleanLiteralExpression const& expression, boost::any const&) override {
-        return expression.getValue() ? msat_make_true(env) : msat_make_false(env);
-    }
-
-    virtual boost::any visit(storm::expressions::RationalLiteralExpression const& expression, boost::any const&) override {
-        std::stringstream fractionStream;
-        fractionStream << expression.getValue();
-        return msat_make_number(env, fractionStream.str().c_str());
-    }
-
-    virtual boost::any visit(storm::expressions::IntegerLiteralExpression const& expression, boost::any const&) override {
-        return msat_make_number(env, std::to_string(static_cast<int>(expression.getValue())).c_str());
-    }
-
-    virtual boost::any visit(storm::expressions::UnaryBooleanFunctionExpression const& expression, boost::any const& data) override {
-        msat_term childResult = boost::any_cast<msat_term>(expression.getOperand()->accept(*this, data));
-
-        switch (expression.getOperatorType()) {
-            case storm::expressions::UnaryBooleanFunctionExpression::OperatorType::Not:
-                return msat_make_not(env, childResult);
-                break;
-            default:
-                STORM_LOG_THROW(false, storm::exceptions::ExpressionEvaluationException,
-                                "Cannot evaluate expression: unknown boolean unary operator: '" << static_cast<uint_fast64_t>(expression.getOperatorType())
-                                                                                                << "' in expression " << expression << ".");
-        }
-    }
-
-    virtual boost::any visit(storm::expressions::UnaryNumericalFunctionExpression const& expression, boost::any const& data) override {
-        msat_term childResult = boost::any_cast<msat_term>(expression.getOperand()->accept(*this, data));
-
-        switch (expression.getOperatorType()) {
-            case storm::expressions::UnaryNumericalFunctionExpression::OperatorType::Minus:
-                return msat_make_times(env, msat_make_number(env, "-1"), childResult);
-            case storm::expressions::UnaryNumericalFunctionExpression::OperatorType::Floor:
-                return msat_make_floor(env, childResult);
-            case storm::expressions::UnaryNumericalFunctionExpression::OperatorType::Ceil:
-                // Mathsat does not support ceil... but ceil(x) = -floor(-x)  wheeii \o/
-                return msat_make_times(env, msat_make_number(env, "-1"), msat_make_floor(env, msat_make_times(env, msat_make_number(env, "-1"), childResult)));
-            default:
-                STORM_LOG_THROW(false, storm::exceptions::ExpressionEvaluationException,
-                                "Cannot evaluate expression: unknown numerical unary operator: '" << static_cast<uint_fast64_t>(expression.getOperatorType())
-                                                                                                  << "' in expression " << expression << ".");
-        }
-    }
-
-    virtual boost::any visit(storm::expressions::VariableExpression const& expression, boost::any const&) override {
-        return translateExpression(expression.getVariable());
-    }
-
-    storm::expressions::Expression translateExpression(msat_term const& term) {
-        if (msat_term_is_and(env, term)) {
-            return translateExpression(msat_term_get_arg(term, 0)) && translateExpression(msat_term_get_arg(term, 1));
-        } else if (msat_term_is_or(env, term)) {
-            return translateExpression(msat_term_get_arg(term, 0)) || translateExpression(msat_term_get_arg(term, 1));
-        } else if (msat_term_is_iff(env, term)) {
-            return storm::expressions::iff(translateExpression(msat_term_get_arg(term, 0)), translateExpression(msat_term_get_arg(term, 1)));
-        } else if (msat_term_is_not(env, term)) {
-            return !translateExpression(msat_term_get_arg(term, 0));
-        } else if (msat_term_is_plus(env, term)) {
-            return translateExpression(msat_term_get_arg(term, 0)) + translateExpression(msat_term_get_arg(term, 1));
-        } else if (msat_term_is_times(env, term)) {
-            return translateExpression(msat_term_get_arg(term, 0)) * translateExpression(msat_term_get_arg(term, 1));
-        } else if (msat_term_is_equal(env, term)) {
-            return translateExpression(msat_term_get_arg(term, 0)) == translateExpression(msat_term_get_arg(term, 1));
-        } else if (msat_term_is_leq(env, term)) {
-            return translateExpression(msat_term_get_arg(term, 0)) <= translateExpression(msat_term_get_arg(term, 1));
-        } else if (msat_term_is_true(env, term)) {
-            return manager.boolean(true);
-        } else if (msat_term_is_false(env, term)) {
-            return manager.boolean(false);
-        } else if (msat_term_is_constant(env, term)) {
-            char* name = msat_decl_get_name(msat_term_get_decl(term));
-            std::string nameString(name);
-            storm::expressions::Expression result = manager.getVariableExpression(nameString.substr(0, nameString.find('/')));
-            msat_free(name);
-            return result;
-        } else if (msat_term_is_number(env, term)) {
-            char* termAsCString = msat_term_repr(term);
-            std::string termString(termAsCString);
-            msat_free(termAsCString);
-            if (msat_is_integer_type(env, msat_term_get_type(term))) {
-                return manager.integer(std::stoll(msat_term_repr(term)));
-            } else if (msat_is_rational_type(env, msat_term_get_type(term))) {
-                return manager.rational(storm::utility::convertNumber<storm::RationalNumber>(termString));
-            }
-        } else if (msat_term_is_term_ite(env, term)) {
-            return storm::expressions::ite(translateExpression(msat_term_get_arg(term, 0)), translateExpression(msat_term_get_arg(term, 1)),
-                                           translateExpression(msat_term_get_arg(term, 2)));
-        }
-
-        // If all other cases did not apply, we cannot represent the term in our expression framework.
-        char* termAsCString = msat_term_repr(term);
-        std::string termString(termAsCString);
-        msat_free(termAsCString);
-        STORM_LOG_THROW(false, storm::exceptions::ExpressionEvaluationException, "Cannot translate expression: unknown term: '" << termString << "'.");
-    }
+    storm::expressions::Expression translateExpression(msat_term const& term);
 
    private:
     /*!
@@ -340,24 +108,7 @@ class MathsatExpressionAdapter : public storm::expressions::ExpressionVisitor {
      *
      * @param variable The variable for which to create a MathSAT counterpart.
      */
-    msat_decl createVariable(storm::expressions::Variable const& variable) {
-        msat_decl msatDeclaration;
-        if (variable.getType().isBooleanType()) {
-            msatDeclaration = msat_declare_function(env, variable.getName().c_str(), msat_get_bool_type(env));
-        } else if (variable.getType().isIntegerType()) {
-            msatDeclaration = msat_declare_function(env, variable.getName().c_str(), msat_get_integer_type(env));
-        } else if (variable.getType().isBitVectorType()) {
-            msatDeclaration = msat_declare_function(env, variable.getName().c_str(), msat_get_bv_type(env, variable.getType().getWidth()));
-        } else if (variable.getType().isRationalType()) {
-            msatDeclaration = msat_declare_function(env, variable.getName().c_str(), msat_get_rational_type(env));
-        } else {
-            STORM_LOG_THROW(false, storm::exceptions::InvalidTypeException,
-                            "Encountered variable '" << variable.getName() << "' with unknown type while trying to create solver variables.");
-        }
-        variableToDeclarationMapping.insert(std::make_pair(variable, msatDeclaration));
-        declarationToVariableMapping.insert(std::make_pair(msatDeclaration, variable));
-        return msatDeclaration;
-    }
+    msat_decl createVariable(storm::expressions::Variable const& variable);
 
     // The expression manager to use.
     storm::expressions::ExpressionManager& manager;

--- a/src/storm/adapters/RationalFunctionAdapter.cpp
+++ b/src/storm/adapters/RationalFunctionAdapter.cpp
@@ -4,6 +4,14 @@ namespace storm {
 RationalFunctionVariable createRFVariable(std::string const& name) {
     return carl::freshRealVariable(name);
 }
+
+RationalFunctionVariable findRFVariable(std::string const& name) {
+    return carl::VariablePool::getInstance().findVariableWithName(name);
+}
+
+void clearRFVariablePool() {
+    carl::VariablePool::getInstance().clear();
+}
 }  // namespace storm
 
 // Explicit instantiations

--- a/src/storm/adapters/RationalFunctionAdapter.h
+++ b/src/storm/adapters/RationalFunctionAdapter.h
@@ -48,4 +48,18 @@ typedef carl::Relation CompareRelation;
 
 RationalFunctionVariable createRFVariable(std::string const& name);
 
+/*!
+ * Retrieves the (already existing) rational-function variable with the given name.
+ *
+ * @param name Variable name.
+ * @return Variable with the given name or an invalid variable, if no such variable exists.
+ */
+RationalFunctionVariable findRFVariable(std::string const& name);
+
+/*!
+ * Clears the global pool of rational-function variables.
+ * This is mainly used to reset the global state in-between tests.
+ */
+void clearRFVariablePool();
+
 }  // namespace storm

--- a/src/storm/adapters/RationalFunctionForward.h
+++ b/src/storm/adapters/RationalFunctionForward.h
@@ -35,6 +35,12 @@ typedef GmpRationalNumber RationalFunctionCoefficient;
 #error GMP is to be used, but is not available.
 #endif
 
+#if (defined(STORM_USE_CLN_EA) && !defined(STORM_USE_CLN_RF)) || (!defined(STORM_USE_CLN_EA) && defined(STORM_USE_CLN_RF))
+#define STORM_RATIONAL_NUMBER_DIFFERS_FROM_COEFFICIENT 1
+#else
+#define STORM_RATIONAL_NUMBER_DIFFERS_FROM_COEFFICIENT 0
+#endif
+
 typedef carl::MultivariatePolynomial<RationalFunctionCoefficient> RawPolynomial;
 typedef carl::UnivariatePolynomial<RationalFunctionCoefficient> RawUnivariatePolynomial;
 typedef carl::FactorizedPolynomial<RawPolynomial> Polynomial;

--- a/src/storm/adapters/eigen.h
+++ b/src/storm/adapters/eigen.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <iostream>
-// Include these utility headers so we can access utility function from Eigen.
+
+// Include these headers so we can access number functions from Eigen.
+#include "storm/adapters/RationalFunctionForward.h"
 #include "storm/utility/constants.h"
 
 #if defined(__clang__)

--- a/src/storm/builder/DdJaniModelBuilder.cpp
+++ b/src/storm/builder/DdJaniModelBuilder.cpp
@@ -188,7 +188,7 @@ class ParameterCreator<Type, storm::RationalFunction> {
     void create(storm::jani::Model const& model, storm::adapters::AddExpressionAdapter<Type, storm::RationalFunction>& rowExpressionAdapter) {
         for (auto const& constant : model.getConstants()) {
             if (!constant.isDefined()) {
-                storm::RationalFunctionVariable carlVariable = carl::freshRealVariable(constant.getExpressionVariable().getName());
+                storm::RationalFunctionVariable carlVariable = storm::createRFVariable(constant.getExpressionVariable().getName());
                 parameters.insert(carlVariable);
                 auto rf = convertVariableToPolynomial(carlVariable);
                 rowExpressionAdapter.setValue(constant.getExpressionVariable(), rf);

--- a/src/storm/generator/PrismNextStateGenerator.cpp
+++ b/src/storm/generator/PrismNextStateGenerator.cpp
@@ -586,7 +586,7 @@ ValueType evaluateLikelihoodExpression(storm::prism::Update const& update, storm
         if (update.isLikelihoodInterval()) {
             BaseValueType lower = evaluator.asRational(update.getLikelihoodExpressionInterval().first);
             BaseValueType upper = evaluator.asRational(update.getLikelihoodExpressionInterval().second);
-            return ValueType(lower, carl::BoundType::WEAK, upper, carl::BoundType::WEAK);
+            return ValueType(lower, storm::BoundType::WEAK, upper, storm::BoundType::WEAK);
         } else {
             return evaluator.asRational(update.getLikelihoodExpression());
         }

--- a/src/storm/logic/Bound.cpp
+++ b/src/storm/logic/Bound.cpp
@@ -30,15 +30,16 @@ ValueType Bound::evaluateThresholdAs() const {
 }
 
 template bool Bound::isSatisfied(double const& compareValue) const;
-#if defined(STORM_HAVE_CLN)
-template bool Bound::isSatisfied(storm::ClnRationalNumber const& compareValue) const;
-template storm::ClnRationalNumber Bound::evaluateThresholdAs() const;
-#endif
-#if defined(STORM_HAVE_GMP)
-template bool Bound::isSatisfied(storm::GmpRationalNumber const& compareValue) const;
-template storm::GmpRationalNumber Bound::evaluateThresholdAs() const;
-#endif
 template double Bound::evaluateThresholdAs() const;
+
+template bool Bound::isSatisfied(storm::RationalNumber const& compareValue) const;
+template storm::RationalNumber Bound::evaluateThresholdAs() const;
+
+#if STORM_RATIONAL_NUMBER_DIFFERS_FROM_COEFFICIENT
+template bool Bound::isSatisfied(storm::RationalFunctionCoefficient const& compareValue) const;
+template storm::RationalFunctionCoefficient Bound::evaluateThresholdAs() const;
+#endif
+
 template storm::RationalFunction Bound::evaluateThresholdAs() const;
 
 }  // namespace storm::logic

--- a/src/storm/modelchecker/results/ParetoCurveCheckResult.cpp
+++ b/src/storm/modelchecker/results/ParetoCurveCheckResult.cpp
@@ -1,6 +1,7 @@
 #include "storm/modelchecker/results/ParetoCurveCheckResult.h"
 
 #include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/utility/NumberTraits.h"
 #include "storm/utility/vector.h"
 
 namespace storm {

--- a/src/storm/models/symbolic/Model.cpp
+++ b/src/storm/models/symbolic/Model.cpp
@@ -15,6 +15,7 @@
 #include "storm/models/symbolic/Mdp.h"
 #include "storm/models/symbolic/StandardRewardModel.h"
 #include "storm/models/symbolic/StochasticTwoPlayerGame.h"
+#include "storm/utility/NumberTraits.h"
 #include "storm/utility/constants.h"
 #include "storm/utility/dd.h"
 #include "storm/utility/macros.h"

--- a/src/storm/solver/MathsatSmtSolver.cpp
+++ b/src/storm/solver/MathsatSmtSolver.cpp
@@ -1,5 +1,7 @@
 #include "storm/solver/MathsatSmtSolver.h"
 
+#include "storm/exceptions/ExpressionEvaluationException.h"
+#include "storm/exceptions/InvalidArgumentException.h"
 #include "storm/exceptions/InvalidStateException.h"
 #include "storm/exceptions/MissingLibraryException.h"
 #include "storm/exceptions/NotSupportedException.h"

--- a/src/storm/solver/SolveGoal.cpp
+++ b/src/storm/solver/SolveGoal.cpp
@@ -148,11 +148,36 @@ void SolveGoal<ValueType, SolutionType>::setRelevantValues(storm::storage::BitVe
     relevantValueVector = std::move(values);
 }
 
+template<typename ValueType, typename MatrixType, typename SolutionType>
+std::unique_ptr<storm::solver::LinearEquationSolver<ValueType>> configureLinearEquationSolver(
+    Environment const& env, SolveGoal<ValueType, SolutionType>&& goal, storm::solver::LinearEquationSolverFactory<ValueType> const& factory,
+    MatrixType&& matrix) {
+    std::unique_ptr<storm::solver::LinearEquationSolver<ValueType>> solver = factory.create(env, std::forward<MatrixType>(matrix));
+    if constexpr (!std::is_same_v<ValueType, storm::RationalFunction>) {
+        if (goal.isBounded()) {
+            solver->setTerminationCondition(std::make_unique<TerminateIfFilteredExtremumExceedsThreshold<ValueType>>(
+                goal.relevantValues(), goal.boundIsStrict(), goal.thresholdValue(), goal.minimize()));
+        }
+    }
+    return solver;
+}
+
 template class SolveGoal<double>;
 template class SolveGoal<storm::RationalNumber>;
 template class SolveGoal<storm::RationalFunction>;
 template class SolveGoal<storm::Interval, double>;
 template class SolveGoal<storm::RationalInterval, storm::RationalNumber>;
+
+template std::unique_ptr<storm::solver::LinearEquationSolver<double>> configureLinearEquationSolver<double, storm::storage::SparseMatrix<double>, double>(
+    Environment const&, SolveGoal<double, double>&&, storm::solver::LinearEquationSolverFactory<double> const&, storm::storage::SparseMatrix<double>&&);
+template std::unique_ptr<storm::solver::LinearEquationSolver<storm::RationalNumber>>
+configureLinearEquationSolver<storm::RationalNumber, storm::storage::SparseMatrix<storm::RationalNumber>, storm::RationalNumber>(
+    Environment const&, SolveGoal<storm::RationalNumber, storm::RationalNumber>&&, storm::solver::LinearEquationSolverFactory<storm::RationalNumber> const&,
+    storm::storage::SparseMatrix<storm::RationalNumber>&&);
+template std::unique_ptr<storm::solver::LinearEquationSolver<storm::RationalFunction>>
+configureLinearEquationSolver<storm::RationalFunction, storm::storage::SparseMatrix<storm::RationalFunction>, storm::RationalFunction>(
+    Environment const&, SolveGoal<storm::RationalFunction, storm::RationalFunction>&&,
+    storm::solver::LinearEquationSolverFactory<storm::RationalFunction> const&, storm::storage::SparseMatrix<storm::RationalFunction>&&);
 
 }  // namespace solver
 }  // namespace storm

--- a/src/storm/solver/SolveGoal.h
+++ b/src/storm/solver/SolveGoal.h
@@ -131,22 +131,7 @@ std::unique_ptr<storm::solver::MinMaxLinearEquationSolver<ValueType, SolutionTyp
 template<typename ValueType, typename MatrixType, typename SolutionType>
 std::unique_ptr<storm::solver::LinearEquationSolver<ValueType>> configureLinearEquationSolver(
     Environment const& env, SolveGoal<ValueType, SolutionType>&& goal, storm::solver::LinearEquationSolverFactory<ValueType> const& factory,
-    MatrixType&& matrix) {
-    std::unique_ptr<storm::solver::LinearEquationSolver<ValueType>> solver = factory.create(env, std::forward<MatrixType>(matrix));
-    if (goal.isBounded()) {
-        solver->setTerminationCondition(std::make_unique<TerminateIfFilteredExtremumExceedsThreshold<ValueType>>(goal.relevantValues(), goal.boundIsStrict(),
-                                                                                                                 goal.thresholdValue(), goal.minimize()));
-    }
-    return solver;
-}
-
-template<typename MatrixType>
-std::unique_ptr<storm::solver::LinearEquationSolver<storm::RationalFunction>> configureLinearEquationSolver(
-    Environment const& env, SolveGoal<storm::RationalFunction>&&, storm::solver::LinearEquationSolverFactory<storm::RationalFunction> const& factory,
-    MatrixType&& matrix) {
-    std::unique_ptr<storm::solver::LinearEquationSolver<storm::RationalFunction>> solver = factory.create(env, std::forward<MatrixType>(matrix));
-    return solver;
-}
+    MatrixType&& matrix);
 
 }  // namespace solver
 }  // namespace storm

--- a/src/storm/solver/stateelimination/EquationSystemEliminator.cpp
+++ b/src/storm/solver/stateelimination/EquationSystemEliminator.cpp
@@ -1,5 +1,8 @@
 #include "storm/solver/stateelimination/EquationSystemEliminator.h"
 
+#include "storm/adapters/RationalFunctionAdapter.h"
+#include "storm/adapters/RationalNumberAdapter.h"
+
 namespace storm {
 namespace solver {
 namespace stateelimination {

--- a/src/storm/storage/SparseMatrix.cpp
+++ b/src/storm/storage/SparseMatrix.cpp
@@ -2492,10 +2492,10 @@ template std::ostream& operator<<(std::ostream& out, MatrixEntry<typename Sparse
 template class SparseMatrixBuilder<double>;
 template class SparseMatrix<double>;
 template std::ostream& operator<<(std::ostream& out, SparseMatrix<double> const& matrix);
+template bool SparseMatrix<double>::isSubmatrixOf(SparseMatrix<double> const& matrix) const;
 template double SparseMatrix<double>::getPointwiseProductRowSum(storm::storage::SparseMatrix<double> const& otherMatrix,
                                                                 typename SparseMatrix<double>::index_type const& row) const;
 template std::vector<double> SparseMatrix<double>::getPointwiseProductRowSumVector(storm::storage::SparseMatrix<double> const& otherMatrix) const;
-template bool SparseMatrix<double>::isSubmatrixOf(SparseMatrix<double> const& matrix) const;
 
 template class MatrixEntry<uint32_t, double>;
 template std::ostream& operator<<(std::ostream& out, MatrixEntry<uint32_t, double> const& entry);
@@ -2518,32 +2518,16 @@ template std::ostream& operator<<(std::ostream& out, SparseMatrix<storm::storage
 template bool SparseMatrix<int>::isSubmatrixOf(SparseMatrix<storm::storage::sparse::state_type> const& matrix) const;
 
 // Rational Numbers
-
-#if defined(STORM_HAVE_CLN)
-template class MatrixEntry<typename SparseMatrix<ClnRationalNumber>::index_type, ClnRationalNumber>;
-template std::ostream& operator<<(std::ostream& out, MatrixEntry<typename SparseMatrix<ClnRationalNumber>::index_type, ClnRationalNumber> const& entry);
-template class SparseMatrixBuilder<ClnRationalNumber>;
-template class SparseMatrix<ClnRationalNumber>;
-template std::ostream& operator<<(std::ostream& out, SparseMatrix<ClnRationalNumber> const& matrix);
-template storm::ClnRationalNumber SparseMatrix<storm::ClnRationalNumber>::getPointwiseProductRowSum(
-    storm::storage::SparseMatrix<storm::ClnRationalNumber> const& otherMatrix, typename SparseMatrix<storm::ClnRationalNumber>::index_type const& row) const;
-template std::vector<storm::ClnRationalNumber> SparseMatrix<ClnRationalNumber>::getPointwiseProductRowSumVector(
-    storm::storage::SparseMatrix<storm::ClnRationalNumber> const& otherMatrix) const;
-template bool SparseMatrix<storm::ClnRationalNumber>::isSubmatrixOf(SparseMatrix<storm::ClnRationalNumber> const& matrix) const;
-#endif
-
-#if defined(STORM_HAVE_GMP)
-template class MatrixEntry<typename SparseMatrix<GmpRationalNumber>::index_type, GmpRationalNumber>;
-template std::ostream& operator<<(std::ostream& out, MatrixEntry<typename SparseMatrix<GmpRationalNumber>::index_type, GmpRationalNumber> const& entry);
-template class SparseMatrixBuilder<GmpRationalNumber>;
-template class SparseMatrix<GmpRationalNumber>;
-template std::ostream& operator<<(std::ostream& out, SparseMatrix<GmpRationalNumber> const& matrix);
-template storm::GmpRationalNumber SparseMatrix<storm::GmpRationalNumber>::getPointwiseProductRowSum(
-    storm::storage::SparseMatrix<storm::GmpRationalNumber> const& otherMatrix, typename SparseMatrix<storm::GmpRationalNumber>::index_type const& row) const;
-template std::vector<storm::GmpRationalNumber> SparseMatrix<GmpRationalNumber>::getPointwiseProductRowSumVector(
-    storm::storage::SparseMatrix<storm::GmpRationalNumber> const& otherMatrix) const;
-template bool SparseMatrix<storm::GmpRationalNumber>::isSubmatrixOf(SparseMatrix<storm::GmpRationalNumber> const& matrix) const;
-#endif
+template class MatrixEntry<typename SparseMatrix<storm::RationalNumber>::index_type, storm::RationalNumber>;
+template std::ostream& operator<<(std::ostream& out, MatrixEntry<typename SparseMatrix<storm::RationalNumber>::index_type, storm::RationalNumber> const& entry);
+template class SparseMatrixBuilder<storm::RationalNumber>;
+template class SparseMatrix<storm::RationalNumber>;
+template std::ostream& operator<<(std::ostream& out, SparseMatrix<storm::RationalNumber> const& matrix);
+template bool SparseMatrix<storm::RationalNumber>::isSubmatrixOf(SparseMatrix<storm::RationalNumber> const& matrix) const;
+template storm::RationalNumber SparseMatrix<storm::RationalNumber>::getPointwiseProductRowSum(
+    storm::storage::SparseMatrix<storm::RationalNumber> const& otherMatrix, typename SparseMatrix<storm::RationalNumber>::index_type const& row) const;
+template std::vector<storm::RationalNumber> SparseMatrix<storm::RationalNumber>::getPointwiseProductRowSumVector(
+    storm::storage::SparseMatrix<storm::RationalNumber> const& otherMatrix) const;
 
 // Rational Function
 template class MatrixEntry<typename SparseMatrix<RationalFunction>::index_type, RationalFunction>;
@@ -2551,6 +2535,7 @@ template std::ostream& operator<<(std::ostream& out, MatrixEntry<typename Sparse
 template class SparseMatrixBuilder<RationalFunction>;
 template class SparseMatrix<RationalFunction>;
 template std::ostream& operator<<(std::ostream& out, SparseMatrix<RationalFunction> const& matrix);
+template bool SparseMatrix<storm::RationalFunction>::isSubmatrixOf(SparseMatrix<storm::RationalFunction> const& matrix) const;
 template storm::RationalFunction SparseMatrix<storm::RationalFunction>::getPointwiseProductRowSum(
     storm::storage::SparseMatrix<storm::RationalFunction> const& otherMatrix, typename SparseMatrix<storm::RationalFunction>::index_type const& row) const;
 template storm::RationalFunction SparseMatrix<double>::getPointwiseProductRowSum(storm::storage::SparseMatrix<storm::RationalFunction> const& otherMatrix,
@@ -2563,35 +2548,32 @@ template std::vector<storm::RationalFunction> SparseMatrix<double>::getPointwise
     storm::storage::SparseMatrix<storm::RationalFunction> const& otherMatrix) const;
 template std::vector<storm::RationalFunction> SparseMatrix<int>::getPointwiseProductRowSumVector(
     storm::storage::SparseMatrix<storm::RationalFunction> const& otherMatrix) const;
-template bool SparseMatrix<storm::RationalFunction>::isSubmatrixOf(SparseMatrix<storm::RationalFunction> const& matrix) const;
 
 // Intervals
-template std::vector<storm::Interval> SparseMatrix<double>::getPointwiseProductRowSumVector(
-    storm::storage::SparseMatrix<storm::Interval> const& otherMatrix) const;
 template class MatrixEntry<typename SparseMatrix<Interval>::index_type, Interval>;
 template std::ostream& operator<<(std::ostream& out, MatrixEntry<typename SparseMatrix<Interval>::index_type, Interval> const& entry);
 template class SparseMatrixBuilder<Interval>;
 template class SparseMatrix<Interval>;
 template std::ostream& operator<<(std::ostream& out, SparseMatrix<Interval> const& matrix);
+template bool SparseMatrix<storm::Interval>::isSubmatrixOf(SparseMatrix<storm::Interval> const& matrix) const;
+template bool SparseMatrix<storm::Interval>::isSubmatrixOf(SparseMatrix<double> const& matrix) const;
 template std::vector<storm::Interval> SparseMatrix<Interval>::getPointwiseProductRowSumVector(
     storm::storage::SparseMatrix<storm::Interval> const& otherMatrix) const;
-template bool SparseMatrix<storm::Interval>::isSubmatrixOf(SparseMatrix<storm::Interval> const& matrix) const;
-
-template bool SparseMatrix<storm::Interval>::isSubmatrixOf(SparseMatrix<double> const& matrix) const;
+template std::vector<storm::Interval> SparseMatrix<double>::getPointwiseProductRowSumVector(
+    storm::storage::SparseMatrix<storm::Interval> const& otherMatrix) const;
 
 // Rational Intervals
-template std::vector<storm::RationalInterval> SparseMatrix<storm::RationalNumber>::getPointwiseProductRowSumVector(
-    storm::storage::SparseMatrix<storm::RationalInterval> const& otherMatrix) const;
 template class MatrixEntry<typename SparseMatrix<RationalInterval>::index_type, RationalInterval>;
 template std::ostream& operator<<(std::ostream& out, MatrixEntry<typename SparseMatrix<RationalInterval>::index_type, RationalInterval> const& entry);
 template class SparseMatrixBuilder<RationalInterval>;
 template class SparseMatrix<RationalInterval>;
 template std::ostream& operator<<(std::ostream& out, SparseMatrix<RationalInterval> const& matrix);
+template bool SparseMatrix<storm::RationalInterval>::isSubmatrixOf(SparseMatrix<storm::RationalInterval> const& matrix) const;
+template bool SparseMatrix<storm::RationalInterval>::isSubmatrixOf(SparseMatrix<storm::RationalNumber> const& matrix) const;
 template std::vector<storm::RationalInterval> SparseMatrix<RationalInterval>::getPointwiseProductRowSumVector(
     storm::storage::SparseMatrix<storm::RationalInterval> const& otherMatrix) const;
-template bool SparseMatrix<storm::RationalInterval>::isSubmatrixOf(SparseMatrix<storm::RationalInterval> const& matrix) const;
-
-template bool SparseMatrix<storm::RationalInterval>::isSubmatrixOf(SparseMatrix<storm::RationalNumber> const& matrix) const;
+template std::vector<storm::RationalInterval> SparseMatrix<storm::RationalNumber>::getPointwiseProductRowSumVector(
+    storm::storage::SparseMatrix<storm::RationalInterval> const& otherMatrix) const;
 
 }  // namespace storage
 }  // namespace storm

--- a/src/storm/storage/expressions/BinaryNumericalFunctionExpression.cpp
+++ b/src/storm/storage/expressions/BinaryNumericalFunctionExpression.cpp
@@ -224,19 +224,14 @@ std::shared_ptr<BaseExpression const> BinaryNumericalFunctionExpression::simplif
                     newValue = firstOperandEvaluation / secondOperandEvaluation;
                     break;
                 case OperatorType::Power: {
-                    if (carl::isInteger(secondOperandEvaluation)) {
-                        auto exponent = carl::toInt<carl::sint>(secondOperandEvaluation);
-                        if (exponent >= 0) {
-                            newValue = carl::pow(firstOperandEvaluation, exponent);
-                        } else {
-                            storm::RationalNumber power = carl::pow(firstOperandEvaluation, -exponent);
-                            newValue = storm::utility::one<storm::RationalNumber>() / power;
-                        }
+                    if (storm::utility::isInteger(secondOperandEvaluation)) {
+                        auto exponent = storm::utility::convertNumber<int_fast64_t>(secondOperandEvaluation);
+                        newValue = storm::utility::pow(firstOperandEvaluation, exponent);
                     }
                     break;
                 }
                 case OperatorType::Modulo: {
-                    if (carl::isInteger(firstOperandEvaluation) && carl::isInteger(secondOperandEvaluation)) {
+                    if (storm::utility::isInteger(firstOperandEvaluation) && storm::utility::isInteger(secondOperandEvaluation)) {
                         newValue = storm::utility::mod(storm::utility::numerator(firstOperandEvaluation), storm::utility::numerator(secondOperandEvaluation));
                     }
                     break;

--- a/src/storm/storage/expressions/ToRationalFunctionVisitor.cpp
+++ b/src/storm/storage/expressions/ToRationalFunctionVisitor.cpp
@@ -50,7 +50,7 @@ boost::any ToRationalFunctionVisitor<RationalFunctionType>::visit(BinaryNumerica
         case BinaryNumericalFunctionExpression::OperatorType::Power: {
             STORM_LOG_THROW(storm::utility::isInteger(secondOperandAsRationalFunction), storm::exceptions::InvalidArgumentException,
                             "Exponent of power operator must be an integer but is " << secondOperandAsRationalFunction << ".");
-            auto exponentAsInteger = storm::utility::convertNumber<carl::sint>(secondOperandAsRationalFunction);
+            auto exponentAsInteger = storm::utility::convertNumber<int_fast64_t>(secondOperandAsRationalFunction);
             return storm::utility::pow(firstOperandAsRationalFunction, exponentAsInteger);
         }
         default:

--- a/src/storm/storage/expressions/ToRationalNumberVisitor.cpp
+++ b/src/storm/storage/expressions/ToRationalNumberVisitor.cpp
@@ -135,7 +135,7 @@ boost::any ToRationalNumberVisitor<RationalNumberType>::visit(BooleanLiteralExpr
 
 template<typename RationalNumberType>
 boost::any ToRationalNumberVisitor<RationalNumberType>::visit(IntegerLiteralExpression const& expression, boost::any const&) {
-    return RationalNumberType(carl::rationalize<storm::RationalNumber>(static_cast<carl::sint>(expression.getValue())));
+    return RationalNumberType(storm::utility::convertNumber<storm::RationalNumber>(static_cast<int_fast64_t>(expression.getValue())));
 }
 
 template<typename RationalNumberType>

--- a/src/storm/storage/geometry/nativepolytopeconversion/HyperplaneCollector.h
+++ b/src/storm/storage/geometry/nativepolytopeconversion/HyperplaneCollector.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/functional/hash.hpp>
 #include <unordered_map>
 
 #include "storm/adapters/EigenAdapter.h"
@@ -42,7 +43,7 @@ class HyperplaneCollector {
        public:
         std::size_t operator()(NormalOffset const& ns) const {
             std::size_t seed = std::hash<EigenVector>()(ns.first);
-            carl::hash_add(seed, std::hash<ValueType>()(ns.second));
+            boost::hash_combine(seed, std::hash<ValueType>()(ns.second));
             return seed;
         }
     };

--- a/src/storm/storage/jani/visitor/JSONExporter.cpp
+++ b/src/storm/storage/jani/visitor/JSONExporter.cpp
@@ -816,8 +816,10 @@ boost::any ExpressionToJson::visit(storm::expressions::RationalLiteralExpression
 
     if (!storm::isJsonNumberExportAccurate(val)) {
         // Try if exact export is possible as fraction of two literals
-        auto [num, den] = storm::utility::asFraction(expression.getValue());
+        auto const& value = expression.getValue();
+        storm::RationalNumber den = storm::utility::convertNumber<storm::RationalNumber>(storm::utility::denominator(value));
         if (!storm::utility::isOne(den)) {
+            storm::RationalNumber num = storm::utility::convertNumber<storm::RationalNumber>(storm::utility::numerator(value));
             ExportJsonType numJson(num), denJson(den);
             if (isJsonNumberExportAccurate(numJson) && isJsonNumberExportAccurate(denJson)) {
                 val = ExportJsonType();

--- a/src/storm/utility/Extremum.cpp
+++ b/src/storm/utility/Extremum.cpp
@@ -1,5 +1,6 @@
 #include "storm/utility/Extremum.h"
 
+#include "storm/adapters/RationalFunctionForward.h"
 #include "storm/adapters/RationalNumberAdapter.h"
 #include "storm/utility/macros.h"
 
@@ -134,13 +135,12 @@ void Extremum<Dir, ValueType>::reset() {
 template class Extremum<storm::OptimizationDirection::Minimize, double>;
 template class Extremum<storm::OptimizationDirection::Maximize, double>;
 
-#if defined(STORM_HAVE_CLN)
-template class Extremum<storm::OptimizationDirection::Minimize, storm::ClnRationalNumber>;
-template class Extremum<storm::OptimizationDirection::Maximize, storm::ClnRationalNumber>;
-#endif
-#if defined(STORM_HAVE_GMP)
-template class Extremum<storm::OptimizationDirection::Minimize, storm::GmpRationalNumber>;
-template class Extremum<storm::OptimizationDirection::Maximize, storm::GmpRationalNumber>;
+template class Extremum<storm::OptimizationDirection::Minimize, storm::RationalNumber>;
+template class Extremum<storm::OptimizationDirection::Maximize, storm::RationalNumber>;
+
+#if STORM_RATIONAL_NUMBER_DIFFERS_FROM_COEFFICIENT
+template class Extremum<storm::OptimizationDirection::Minimize, storm::RationalFunctionCoefficient>;
+template class Extremum<storm::OptimizationDirection::Maximize, storm::RationalFunctionCoefficient>;
 #endif
 
 }  // namespace storm::utility

--- a/src/storm/utility/RationalApproximation.cpp
+++ b/src/storm/utility/RationalApproximation.cpp
@@ -2,6 +2,7 @@
 #include "storm/utility/RationalApproximation.h"
 
 #include "storm/adapters/RationalNumberAdapter.h"
+#include "storm/utility/NumberTraits.h"
 #include "storm/utility/constants.h"
 #include "storm/utility/macros.h"
 

--- a/src/storm/utility/constants.cpp
+++ b/src/storm/utility/constants.cpp
@@ -1,5 +1,6 @@
 #include "storm/utility/constants.h"
 
+#include <cmath>
 #include <numeric>
 
 #include "storm/adapters/IntervalAdapter.h"

--- a/src/storm/utility/constants.cpp
+++ b/src/storm/utility/constants.cpp
@@ -479,9 +479,14 @@ double convertNumber(ClnRationalNumber const& number) {
 }
 
 template<>
+bool tryParseNumber(std::string const& input, ClnRationalNumber& result) {
+    return carl::try_parse<ClnRationalNumber>(input, result);
+}
+
+template<>
 ClnRationalNumber convertNumber(std::string const& number) {
     ClnRationalNumber result;
-    if (carl::try_parse<ClnRationalNumber>(number, result)) {
+    if (tryParseNumber(number, result)) {
         return result;
     }
     STORM_LOG_THROW(false, storm::exceptions::InvalidArgumentException, "Unable to parse '" << number << "' as a rational number.");
@@ -712,9 +717,14 @@ double convertNumber(GmpRationalNumber const& number) {
 }
 
 template<>
+bool tryParseNumber(std::string const& input, GmpRationalNumber& result) {
+    return carl::try_parse<GmpRationalNumber>(input, result);
+}
+
+template<>
 GmpRationalNumber convertNumber(std::string const& number) {
     GmpRationalNumber result;
-    if (carl::try_parse<GmpRationalNumber>(number, result)) {
+    if (tryParseNumber(number, result)) {
         return result;
     }
     STORM_LOG_THROW(false, storm::exceptions::InvalidArgumentException, "Unable to parse '" << number << "' as a rational number.");

--- a/src/storm/utility/constants.cpp
+++ b/src/storm/utility/constants.cpp
@@ -1,6 +1,6 @@
 #include "storm/utility/constants.h"
 
-#include <cmath>
+#include <numeric>
 
 #include "storm/adapters/IntervalAdapter.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
@@ -350,6 +350,16 @@ std::pair<IntegerType, IntegerType> divide(IntegerType const& dividend, IntegerT
     return std::make_pair(dividend / divisor, mod(dividend, divisor));
 }
 
+template<typename IntegerType>
+IntegerType gcd(IntegerType const& first, IntegerType const& second) {
+    return std::gcd(first, second);
+}
+
+template<typename IntegerType>
+IntegerType lcm(IntegerType const& first, IntegerType const& second) {
+    return std::lcm(first, second);
+}
+
 template<typename ValueType>
 std::string to_string(ValueType const& value) {
     std::stringstream ss;
@@ -478,11 +488,6 @@ ClnRationalNumber convertNumber(std::string const& number) {
 }
 
 template<>
-std::pair<ClnRationalNumber, ClnRationalNumber> asFraction(ClnRationalNumber const& number) {
-    return std::make_pair(carl::getNum(number), carl::getDenom(number));
-}
-
-template<>
 ClnRationalNumber sqrt(ClnRationalNumber const& number) {
     return carl::sqrt(number);
 }
@@ -539,6 +544,18 @@ std::pair<typename NumberTraits<ClnRationalNumber>::IntegerType, typename Number
     std::pair<typename NumberTraits<ClnRationalNumber>::IntegerType, typename NumberTraits<ClnRationalNumber>::IntegerType> result;
     carl::divide(dividend, divisor, result.first, result.second);
     return result;
+}
+
+template<>
+typename NumberTraits<ClnRationalNumber>::IntegerType gcd(typename NumberTraits<ClnRationalNumber>::IntegerType const& first,
+                                                          typename NumberTraits<ClnRationalNumber>::IntegerType const& second) {
+    return carl::gcd(first, second);
+}
+
+template<>
+typename NumberTraits<ClnRationalNumber>::IntegerType lcm(typename NumberTraits<ClnRationalNumber>::IntegerType const& first,
+                                                          typename NumberTraits<ClnRationalNumber>::IntegerType const& second) {
+    return carl::lcm(first, second);
 }
 
 template<>
@@ -704,11 +721,6 @@ GmpRationalNumber convertNumber(std::string const& number) {
 }
 
 template<>
-std::pair<GmpRationalNumber, GmpRationalNumber> asFraction(GmpRationalNumber const& number) {
-    return std::make_pair(carl::getNum(number), carl::getDenom(number));
-}
-
-template<>
 GmpRationalNumber sqrt(GmpRationalNumber const& number) {
     return carl::sqrt(number);
 }
@@ -766,6 +778,18 @@ std::pair<typename NumberTraits<GmpRationalNumber>::IntegerType, typename Number
     std::pair<typename NumberTraits<GmpRationalNumber>::IntegerType, typename NumberTraits<GmpRationalNumber>::IntegerType> result;
     carl::divide(dividend, divisor, result.first, result.second);
     return result;
+}
+
+template<>
+typename NumberTraits<GmpRationalNumber>::IntegerType gcd(typename NumberTraits<GmpRationalNumber>::IntegerType const& first,
+                                                          typename NumberTraits<GmpRationalNumber>::IntegerType const& second) {
+    return carl::gcd(first, second);
+}
+
+template<>
+typename NumberTraits<GmpRationalNumber>::IntegerType lcm(typename NumberTraits<GmpRationalNumber>::IntegerType const& first,
+                                                          typename NumberTraits<GmpRationalNumber>::IntegerType const& second) {
+    return carl::lcm(first, second);
 }
 
 template<>

--- a/src/storm/utility/constants.cpp
+++ b/src/storm/utility/constants.cpp
@@ -1147,6 +1147,15 @@ storm::Interval abs(storm::Interval const& interval) {
 }
 
 template<>
+storm::Interval pow(storm::Interval const& value, int_fast64_t exponent) {
+    if (exponent >= 0) {
+        return value.pow(exponent);
+    } else {
+        return storm::utility::one<storm::Interval>() / value.pow(-exponent);
+    }
+}
+
+template<>
 bool isApproxEqual(storm::Interval const& a, storm::Interval const& b, storm::Interval const& precision, bool relative) {
     STORM_LOG_ASSERT(precision.isPointInterval(), "Precision must be a point interval.");
     return isApproxEqual<double>(a.lower(), b.lower(), precision.center(), relative) &&
@@ -1163,6 +1172,15 @@ bool isApproxEqual(storm::RationalInterval const& a, storm::RationalInterval con
 template<>
 storm::RationalInterval abs(storm::RationalInterval const& interval) {
     return interval.abs();
+}
+
+template<>
+storm::RationalInterval pow(storm::RationalInterval const& value, int_fast64_t exponent) {
+    if (exponent >= 0) {
+        return value.pow(exponent);
+    } else {
+        return storm::utility::one<storm::RationalInterval>() / value.pow(-exponent);
+    }
 }
 
 // Explicit instantiations.

--- a/src/storm/utility/constants.h
+++ b/src/storm/utility/constants.h
@@ -120,9 +120,6 @@ template<typename TargetType, typename SourceType>
 TargetType convertNumber(SourceType const& number);
 
 template<typename ValueType>
-std::pair<ValueType, ValueType> asFraction(ValueType const& number);
-
-template<typename ValueType>
 ValueType simplify(ValueType value);
 
 template<typename IndexType, typename ValueType>
@@ -211,6 +208,12 @@ std::pair<IntegerType, IntegerType> divide(IntegerType const& dividend, IntegerT
 
 template<typename IntegerType>
 IntegerType mod(IntegerType const& first, IntegerType const& second);
+
+template<typename IntegerType>
+IntegerType gcd(IntegerType const& first, IntegerType const& second);
+
+template<typename IntegerType>
+IntegerType lcm(IntegerType const& first, IntegerType const& second);
 
 template<typename ValueType>
 std::string to_string(ValueType const& value);

--- a/src/storm/utility/constants.h
+++ b/src/storm/utility/constants.h
@@ -15,8 +15,6 @@
 #include <map>
 #include <vector>
 
-#include "storm/utility/NumberTraits.h"
-
 namespace storm {
 
 // Forward-declare MatrixEntry class.

--- a/src/storm/utility/constants.h
+++ b/src/storm/utility/constants.h
@@ -119,6 +119,16 @@ bool isInteger(ValueType const& number);
 template<typename TargetType, typename SourceType>
 TargetType convertNumber(SourceType const& number);
 
+/*!
+ * Tries to parse a number from its string representation.
+ *
+ * @param input String representation of the number.
+ * @param result The parsed number (only valid if parsing succeeded).
+ * @return True iff the string could be parsed as a number of the given type.
+ */
+template<typename RationalType>
+bool tryParseNumber(std::string const& input, RationalType& result);
+
 template<typename ValueType>
 ValueType simplify(ValueType value);
 

--- a/src/storm/utility/random.cpp
+++ b/src/storm/utility/random.cpp
@@ -2,6 +2,8 @@
 
 #include <limits>
 
+#include "storm/utility/constants.h"
+
 namespace storm {
 namespace utility {
 RandomProbabilityGenerator<double>::RandomProbabilityGenerator() : distribution(0.0, 1.0) {
@@ -27,7 +29,8 @@ RandomProbabilityGenerator<RationalNumber>::RandomProbabilityGenerator() : distr
 RandomProbabilityGenerator<RationalNumber>::RandomProbabilityGenerator(uint64_t seed) : distribution(0, std::numeric_limits<uint64_t>::max()), engine(seed) {}
 
 RationalNumber RandomProbabilityGenerator<RationalNumber>::random() {
-    return carl::rationalize<RationalNumber>(distribution(engine)) / carl::rationalize<RationalNumber>(std::numeric_limits<uint64_t>::max());
+    return storm::utility::convertNumber<RationalNumber>(distribution(engine)) /
+           storm::utility::convertNumber<RationalNumber>(std::numeric_limits<uint64_t>::max());
 }
 
 uint64_t RandomProbabilityGenerator<RationalNumber>::random_uint(uint64_t min, uint64_t max) {

--- a/src/storm/utility/vector.h
+++ b/src/storm/utility/vector.h
@@ -1018,21 +1018,26 @@ typename std::enable_if<std::is_same<ValueType, storm::RationalNumber>::value, s
     } else if (occurringNonZeroNumbers.size() == 1) {
         factor = *occurringNonZeroNumbers.begin();
     } else {
+        using IntegerType = typename storm::NumberTraits<ValueType>::IntegerType;
         // Obtain the least common multiple of the denominators of the occurring numbers.
         // We can then multiply the numbers with the lcm to obtain integers.
         auto numberIt = occurringNonZeroNumbers.begin();
-        ValueType lcm = storm::utility::asFraction(*numberIt).second;
+        IntegerType lcm = storm::utility::denominator(*numberIt);
         for (++numberIt; numberIt != occurringNonZeroNumbers.end(); ++numberIt) {
-            lcm = carl::lcm(lcm, storm::utility::asFraction(*numberIt).second);
+            lcm = storm::utility::lcm(lcm, storm::utility::denominator(*numberIt));
         }
         // Multiply all values with the lcm. To reduce the range of considered integers, we also obtain the gcd of the results.
         numberIt = occurringNonZeroNumbers.begin();
-        ValueType gcd = *numberIt * lcm;
+        STORM_LOG_ASSERT(storm::utility::denominator(ValueType(*numberIt * lcm)) == storm::utility::one<IntegerType>(),
+                         "Number '" << *numberIt << "' is not integral.");
+        IntegerType gcd = storm::utility::numerator(ValueType(*numberIt * lcm));
         for (++numberIt; numberIt != occurringNonZeroNumbers.end(); ++numberIt) {
-            gcd = carl::gcd(gcd, static_cast<ValueType>(*numberIt * lcm));
+            STORM_LOG_ASSERT(storm::utility::denominator(ValueType(*numberIt * lcm)) == storm::utility::one<IntegerType>(),
+                             "Number '" << *numberIt << "' is not integral.");
+            gcd = storm::utility::gcd(gcd, storm::utility::numerator(ValueType(*numberIt * lcm)));
         }
 
-        factor = gcd / lcm;
+        factor = storm::utility::convertNumber<ValueType>(gcd) / storm::utility::convertNumber<ValueType>(lcm);
     }
 
     // Build the result

--- a/src/test/storm-dft/transformations/DftInstantiatorTest.cpp
+++ b/src/test/storm-dft/transformations/DftInstantiatorTest.cpp
@@ -8,7 +8,7 @@
 namespace {
 
 TEST(DftInstantiatorTest, InstantiateSimple) {
-    carl::VariablePool::getInstance().clear();
+    storm::clearRFVariablePool();
 
     std::string file = STORM_TEST_RESOURCES_DIR "/dft/and_param.dft";
     std::shared_ptr<storm::dft::storage::DFT<storm::RationalFunction>> dft = storm::dft::api::loadDFTGalileoFile<storm::RationalFunction>(file);
@@ -18,8 +18,8 @@ TEST(DftInstantiatorTest, InstantiateSimple) {
     storm::dft::transformations::DftInstantiator<storm::RationalFunction, double> instantiator(*dft);
 
     std::map<storm::RationalFunctionVariable, storm::RationalFunctionCoefficient> valuation;
-    storm::RationalFunctionVariable const& x = carl::VariablePool::getInstance().findVariableWithName("x");
-    ASSERT_NE(x, carl::Variable::NO_VARIABLE);
+    storm::RationalFunctionVariable const& x = storm::findRFVariable("x");
+    ASSERT_NE(x, storm::RationalFunctionVariable::NO_VARIABLE);
 
     valuation.insert(std::make_pair(x, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.5)));
     std::shared_ptr<storm::dft::storage::DFT<double>> instDft = instantiator.instantiate(valuation);
@@ -36,7 +36,7 @@ TEST(DftInstantiatorTest, InstantiateSimple) {
 }
 
 TEST(DftInstantiatorTest, InstantiateSymmetry) {
-    carl::VariablePool::getInstance().clear();
+    storm::clearRFVariablePool();
 
     std::string file = STORM_TEST_RESOURCES_DIR "/dft/symmetry_param.dft";
     std::shared_ptr<storm::dft::storage::DFT<storm::RationalFunction>> dft = storm::dft::api::loadDFTGalileoFile<storm::RationalFunction>(file);
@@ -46,10 +46,10 @@ TEST(DftInstantiatorTest, InstantiateSymmetry) {
     storm::dft::transformations::DftInstantiator<storm::RationalFunction, double> instantiator(*dft);
 
     std::map<storm::RationalFunctionVariable, storm::RationalFunctionCoefficient> valuation;
-    storm::RationalFunctionVariable const& x = carl::VariablePool::getInstance().findVariableWithName("x");
-    ASSERT_NE(x, carl::Variable::NO_VARIABLE);
-    storm::RationalFunctionVariable const& y = carl::VariablePool::getInstance().findVariableWithName("y");
-    ASSERT_NE(y, carl::Variable::NO_VARIABLE);
+    storm::RationalFunctionVariable const& x = storm::findRFVariable("x");
+    ASSERT_NE(x, storm::RationalFunctionVariable::NO_VARIABLE);
+    storm::RationalFunctionVariable const& y = storm::findRFVariable("y");
+    ASSERT_NE(y, storm::RationalFunctionVariable::NO_VARIABLE);
 
     valuation.insert(std::make_pair(x, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(5)));
     valuation.insert(std::make_pair(y, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.01)));

--- a/src/test/storm-pars/derivative/GradientDescentInstantiationSearcherTest.cpp
+++ b/src/test/storm-pars/derivative/GradientDescentInstantiationSearcherTest.cpp
@@ -81,10 +81,10 @@ class GradientDescentInstantiationSearcherTest : public ::testing::Test {
 #ifndef STORM_HAVE_Z3
         GTEST_SKIP() << "Z3 not available.";
 #endif
-        carl::VariablePool::getInstance().clear();
+        storm::clearRFVariablePool();
     }
     virtual void TearDown() {
-        carl::VariablePool::getInstance().clear();
+        storm::clearRFVariablePool();
     }
 
    private:
@@ -170,8 +170,8 @@ TYPED_TEST(GradientDescentInstantiationSearcherTest, Crowds) {
     auto doubleInstantiation = adamChecker.gradientDescent();
     auto walk = adamChecker.getVisualizationWalk();
 
-    carl::Variable badCVar;
-    carl::Variable pfVar;
+    storm::RationalFunctionVariable badCVar;
+    storm::RationalFunctionVariable pfVar;
     for (auto parameter : storm::models::sparse::getProbabilityParameters(*dtmc)) {
         if (parameter.name() == "badC") {
             badCVar = parameter;

--- a/src/test/storm-pars/derivative/SparseDerivativeInstantiationModelCheckerTest.cpp
+++ b/src/test/storm-pars/derivative/SparseDerivativeInstantiationModelCheckerTest.cpp
@@ -74,10 +74,10 @@ class SparseDerivativeInstantiationModelCheckerTest : public ::testing::Test {
 #ifndef STORM_HAVE_Z3
         GTEST_SKIP() << "Z3 not available.";
 #endif
-        carl::VariablePool::getInstance().clear();
+        storm::clearRFVariablePool();
     }
     virtual void TearDown() {
-        carl::VariablePool::getInstance().clear();
+        storm::clearRFVariablePool();
     }
     void testModel(std::shared_ptr<storm::models::sparse::Dtmc<storm::RationalFunction>> dtmc,
                    std::vector<std::shared_ptr<const storm::logic::Formula>> formulas, storm::RationalFunction reachabilityFunction);
@@ -178,7 +178,7 @@ TYPED_TEST(SparseDerivativeInstantiationModelCheckerTest, Simple) {
     dtmc = model->as<storm::models::sparse::Dtmc<storm::RationalFunction>>();
 
     // The associated polynomial. In this case, it's p * (1 - p).
-    carl::Variable varP = carl::VariablePool::getInstance().findVariableWithName("p");
+    storm::RationalFunctionVariable varP = storm::findRFVariable("p");
     std::shared_ptr<storm::RawPolynomialCache> cache = std::make_shared<storm::RawPolynomialCache>();
     auto p = storm::RationalFunction(storm::Polynomial(storm::RawPolynomial(varP), cache));
     storm::RationalFunction reachabilityFunction = p * (storm::RationalFunction(1) - p);
@@ -206,8 +206,8 @@ TYPED_TEST(SparseDerivativeInstantiationModelCheckerTest, Simple2) {
     dtmc = model->as<storm::models::sparse::Dtmc<storm::RationalFunction>>();
 
     // The associated polynomial. In this case, it's p * (1 - q).
-    carl::Variable varP = carl::VariablePool::getInstance().findVariableWithName("p");
-    carl::Variable varQ = carl::VariablePool::getInstance().findVariableWithName("q");
+    storm::RationalFunctionVariable varP = storm::findRFVariable("p");
+    storm::RationalFunctionVariable varQ = storm::findRFVariable("q");
     std::shared_ptr<storm::RawPolynomialCache> cache = std::make_shared<storm::RawPolynomialCache>();
     auto p = storm::RationalFunction(storm::Polynomial(storm::RawPolynomial(varP), cache));
     auto q = storm::RationalFunction(storm::Polynomial(storm::RawPolynomial(varQ), cache));
@@ -235,8 +235,8 @@ TYPED_TEST(SparseDerivativeInstantiationModelCheckerTest, Brp162) {
     model = simplifier.getSimplifiedModel();
     dtmc = model->as<storm::models::sparse::Dtmc<storm::RationalFunction>>();
 
-    carl::Variable pLVar = carl::VariablePool::getInstance().findVariableWithName("pL");
-    carl::Variable pKVar = carl::VariablePool::getInstance().findVariableWithName("pK");
+    storm::RationalFunctionVariable pLVar = storm::findRFVariable("pL");
+    storm::RationalFunctionVariable pKVar = storm::findRFVariable("pK");
     std::shared_ptr<storm::RawPolynomialCache> cache = std::make_shared<storm::RawPolynomialCache>();
     auto pL = storm::RationalFunction(storm::Polynomial(storm::RawPolynomial(pLVar), cache));
     auto pK = storm::RationalFunction(storm::Polynomial(storm::RawPolynomial(pKVar), cache));

--- a/src/test/storm-pars/modelchecker/SparseDtmcParameterLiftingMonotonicityTest.cpp
+++ b/src/test/storm-pars/modelchecker/SparseDtmcParameterLiftingMonotonicityTest.cpp
@@ -51,10 +51,10 @@ class SparseDtmcParameterLiftingMonotonicityTest : public ::testing::Test {
 #ifndef STORM_HAVE_Z3
         GTEST_SKIP() << "Z3 not available.";
 #endif
-        carl::VariablePool::getInstance().clear();
+        storm::clearRFVariablePool();
     }
     virtual void TearDown() {
-        carl::VariablePool::getInstance().clear();
+        storm::clearRFVariablePool();
     }
 
    private:

--- a/src/test/storm-pars/modelchecker/SparseDtmcParameterLiftingTest.cpp
+++ b/src/test/storm-pars/modelchecker/SparseDtmcParameterLiftingTest.cpp
@@ -60,10 +60,10 @@ class SparseDtmcParameterLiftingTest : public ::testing::Test {
 #ifndef STORM_HAVE_Z3
         GTEST_SKIP() << "Z3 not available.";
 #endif
-        carl::VariablePool::getInstance().clear();
+        storm::clearRFVariablePool();
     }
     virtual void TearDown() {
-        carl::VariablePool::getInstance().clear();
+        storm::clearRFVariablePool();
     }
 
    private:

--- a/src/test/storm-pars/modelchecker/SparseMdpParameterLiftingTest.cpp
+++ b/src/test/storm-pars/modelchecker/SparseMdpParameterLiftingTest.cpp
@@ -47,10 +47,10 @@ class SparseMdpParameterLiftingTest : public ::testing::Test {
 #ifndef STORM_HAVE_Z3
         GTEST_SKIP() << "Z3 not available.";
 #endif
-        carl::VariablePool::getInstance().clear();
+        storm::clearRFVariablePool();
     }
     virtual void TearDown() {
-        carl::VariablePool::getInstance().clear();
+        storm::clearRFVariablePool();
     }
 
    private:

--- a/src/test/storm-pars/modelchecker/SparseRobustDtmcParameterLiftingTest.cpp
+++ b/src/test/storm-pars/modelchecker/SparseRobustDtmcParameterLiftingTest.cpp
@@ -54,13 +54,13 @@ class SparseRobustDtmcParameterLiftingTest : public ::testing::Test {
         return _graphPreserving;
     }
     virtual void SetUp() {
-        carl::VariablePool::getInstance().clear();
+        storm::clearRFVariablePool();
 #ifndef STORM_HAVE_Z3
         GTEST_SKIP() << "Z3 not available.";
 #endif
     }
     virtual void TearDown() {
-        carl::VariablePool::getInstance().clear();
+        storm::clearRFVariablePool();
     }
 
    private:

--- a/src/test/storm-pars/utility/ModelInstantiatorTest.cpp
+++ b/src/test/storm-pars/utility/ModelInstantiatorTest.cpp
@@ -22,7 +22,7 @@ class ModelInstantiatorTest : public ::testing::Test {
 };
 
 TEST_F(ModelInstantiatorTest, BrpProb) {
-    carl::VariablePool::getInstance().clear();
+    storm::clearRFVariablePool();
 
     std::string programFile = STORM_TEST_RESOURCES_DIR "/pdtmc/brp16_2.pm";
     std::string formulaAsString = "P=? [F s=5 ]";
@@ -43,10 +43,10 @@ TEST_F(ModelInstantiatorTest, BrpProb) {
 
     {
         std::map<storm::RationalFunctionVariable, storm::RationalFunctionCoefficient> valuation;
-        storm::RationalFunctionVariable const& pL = carl::VariablePool::getInstance().findVariableWithName("pL");
-        ASSERT_NE(pL, carl::Variable::NO_VARIABLE);
-        storm::RationalFunctionVariable const& pK = carl::VariablePool::getInstance().findVariableWithName("pK");
-        ASSERT_NE(pK, carl::Variable::NO_VARIABLE);
+        storm::RationalFunctionVariable const& pL = storm::findRFVariable("pL");
+        ASSERT_NE(pL, storm::RationalFunctionVariable::NO_VARIABLE);
+        storm::RationalFunctionVariable const& pK = storm::findRFVariable("pK");
+        ASSERT_NE(pK, storm::RationalFunctionVariable::NO_VARIABLE);
         valuation.insert(std::make_pair(pL, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.8)));
         valuation.insert(std::make_pair(pK, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.9)));
 
@@ -78,10 +78,10 @@ TEST_F(ModelInstantiatorTest, BrpProb) {
 
     {
         std::map<storm::RationalFunctionVariable, storm::RationalFunctionCoefficient> valuation;
-        storm::RationalFunctionVariable const& pL = carl::VariablePool::getInstance().findVariableWithName("pL");
-        ASSERT_NE(pL, carl::Variable::NO_VARIABLE);
-        storm::RationalFunctionVariable const& pK = carl::VariablePool::getInstance().findVariableWithName("pK");
-        ASSERT_NE(pK, carl::Variable::NO_VARIABLE);
+        storm::RationalFunctionVariable const& pL = storm::findRFVariable("pL");
+        ASSERT_NE(pL, storm::RationalFunctionVariable::NO_VARIABLE);
+        storm::RationalFunctionVariable const& pK = storm::findRFVariable("pK");
+        ASSERT_NE(pK, storm::RationalFunctionVariable::NO_VARIABLE);
         valuation.insert(std::make_pair(pL, storm::utility::one<storm::RationalFunctionCoefficient>()));
         valuation.insert(std::make_pair(pK, storm::utility::one<storm::RationalFunctionCoefficient>()));
 
@@ -112,10 +112,10 @@ TEST_F(ModelInstantiatorTest, BrpProb) {
 
     {
         std::map<storm::RationalFunctionVariable, storm::RationalFunctionCoefficient> valuation;
-        storm::RationalFunctionVariable const& pL = carl::VariablePool::getInstance().findVariableWithName("pL");
-        ASSERT_NE(pL, carl::Variable::NO_VARIABLE);
-        storm::RationalFunctionVariable const& pK = carl::VariablePool::getInstance().findVariableWithName("pK");
-        ASSERT_NE(pK, carl::Variable::NO_VARIABLE);
+        storm::RationalFunctionVariable const& pL = storm::findRFVariable("pL");
+        ASSERT_NE(pL, storm::RationalFunctionVariable::NO_VARIABLE);
+        storm::RationalFunctionVariable const& pK = storm::findRFVariable("pK");
+        ASSERT_NE(pK, storm::RationalFunctionVariable::NO_VARIABLE);
         valuation.insert(std::make_pair(pL, storm::utility::one<storm::RationalFunctionCoefficient>()));
         valuation.insert(std::make_pair(pK, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.9)));
 
@@ -147,7 +147,7 @@ TEST_F(ModelInstantiatorTest, BrpProb) {
 }
 
 TEST_F(ModelInstantiatorTest, Brp_Rew) {
-    carl::VariablePool::getInstance().clear();
+    storm::clearRFVariablePool();
 
     std::string programFile = STORM_TEST_RESOURCES_DIR "/pdtmc/brp16_2.pm";
     std::string formulaAsString = "R=? [F ((s=5) | (s=0&srep=3)) ]";
@@ -167,14 +167,14 @@ TEST_F(ModelInstantiatorTest, Brp_Rew) {
 
     {
         std::map<storm::RationalFunctionVariable, storm::RationalFunctionCoefficient> valuation;
-        storm::RationalFunctionVariable const& pL = carl::VariablePool::getInstance().findVariableWithName("pL");
-        ASSERT_NE(pL, carl::Variable::NO_VARIABLE);
-        storm::RationalFunctionVariable const& pK = carl::VariablePool::getInstance().findVariableWithName("pK");
-        ASSERT_NE(pK, carl::Variable::NO_VARIABLE);
-        storm::RationalFunctionVariable const& TOMsg = carl::VariablePool::getInstance().findVariableWithName("TOMsg");
-        ASSERT_NE(pK, carl::Variable::NO_VARIABLE);
-        storm::RationalFunctionVariable const& TOAck = carl::VariablePool::getInstance().findVariableWithName("TOAck");
-        ASSERT_NE(pK, carl::Variable::NO_VARIABLE);
+        storm::RationalFunctionVariable const& pL = storm::findRFVariable("pL");
+        ASSERT_NE(pL, storm::RationalFunctionVariable::NO_VARIABLE);
+        storm::RationalFunctionVariable const& pK = storm::findRFVariable("pK");
+        ASSERT_NE(pK, storm::RationalFunctionVariable::NO_VARIABLE);
+        storm::RationalFunctionVariable const& TOMsg = storm::findRFVariable("TOMsg");
+        ASSERT_NE(pK, storm::RationalFunctionVariable::NO_VARIABLE);
+        storm::RationalFunctionVariable const& TOAck = storm::findRFVariable("TOAck");
+        ASSERT_NE(pK, storm::RationalFunctionVariable::NO_VARIABLE);
         valuation.insert(std::make_pair(pL, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.9)));
         valuation.insert(std::make_pair(pK, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.3)));
         valuation.insert(std::make_pair(TOMsg, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.3)));
@@ -219,7 +219,7 @@ TEST_F(ModelInstantiatorTest, Brp_Rew) {
 }
 
 TEST_F(ModelInstantiatorTest, Consensus) {
-    carl::VariablePool::getInstance().clear();
+    storm::clearRFVariablePool();
 
     std::string programFile = STORM_TEST_RESOURCES_DIR "/pmdp/coin2_2.nm";
     std::string formulaAsString = "Pmin=? [F \"finished\"&\"all_coins_equal_1\" ]";
@@ -238,10 +238,10 @@ TEST_F(ModelInstantiatorTest, Consensus) {
     storm::utility::ModelInstantiator<storm::models::sparse::Mdp<storm::RationalFunction>, storm::models::sparse::Mdp<double>> modelInstantiator(*mdp);
 
     std::map<storm::RationalFunctionVariable, storm::RationalFunctionCoefficient> valuation;
-    storm::RationalFunctionVariable const& p1 = carl::VariablePool::getInstance().findVariableWithName("p1");
-    ASSERT_NE(p1, carl::Variable::NO_VARIABLE);
-    storm::RationalFunctionVariable const& p2 = carl::VariablePool::getInstance().findVariableWithName("p2");
-    ASSERT_NE(p2, carl::Variable::NO_VARIABLE);
+    storm::RationalFunctionVariable const& p1 = storm::findRFVariable("p1");
+    ASSERT_NE(p1, storm::RationalFunctionVariable::NO_VARIABLE);
+    storm::RationalFunctionVariable const& p2 = storm::findRFVariable("p2");
+    ASSERT_NE(p2, storm::RationalFunctionVariable::NO_VARIABLE);
     valuation.insert(std::make_pair(p1, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.51)));
     valuation.insert(std::make_pair(p2, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.49)));
     storm::models::sparse::Mdp<double> const& instantiated(modelInstantiator.instantiate(valuation));

--- a/src/test/storm-pars/utility/ModelInstantiatorTest.cpp
+++ b/src/test/storm-pars/utility/ModelInstantiatorTest.cpp
@@ -172,9 +172,9 @@ TEST_F(ModelInstantiatorTest, Brp_Rew) {
         storm::RationalFunctionVariable const& pK = storm::findRFVariable("pK");
         ASSERT_NE(pK, storm::RationalFunctionVariable::NO_VARIABLE);
         storm::RationalFunctionVariable const& TOMsg = storm::findRFVariable("TOMsg");
-        ASSERT_NE(pK, storm::RationalFunctionVariable::NO_VARIABLE);
+        ASSERT_NE(TOMsg, storm::RationalFunctionVariable::NO_VARIABLE);
         storm::RationalFunctionVariable const& TOAck = storm::findRFVariable("TOAck");
-        ASSERT_NE(pK, storm::RationalFunctionVariable::NO_VARIABLE);
+        ASSERT_NE(TOAck, storm::RationalFunctionVariable::NO_VARIABLE);
         valuation.insert(std::make_pair(pL, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.9)));
         valuation.insert(std::make_pair(pK, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.3)));
         valuation.insert(std::make_pair(TOMsg, storm::utility::convertNumber<storm::RationalFunctionCoefficient>(0.3)));

--- a/src/test/storm-pars/utility/ModelInstantiatorTest.cpp
+++ b/src/test/storm-pars/utility/ModelInstantiatorTest.cpp
@@ -59,7 +59,7 @@ TEST_F(ModelInstantiatorTest, BrpProb) {
                 auto instantiatedEntry = instantiated.getTransitionMatrix().getRow(row).begin();
                 for (auto const& paramEntry : dtmc->getTransitionMatrix().getRow(row)) {
                     EXPECT_EQ(paramEntry.getColumn(), instantiatedEntry->getColumn());
-                    double evaluatedValue = carl::toDouble(paramEntry.getValue().evaluate(valuation));
+                    double evaluatedValue = storm::utility::convertNumber<double>(paramEntry.getValue().evaluate(valuation));
                     EXPECT_EQ(evaluatedValue, instantiatedEntry->getValue());
                     ++instantiatedEntry;
                 }
@@ -94,7 +94,7 @@ TEST_F(ModelInstantiatorTest, BrpProb) {
                 auto instantiatedEntry = instantiated.getTransitionMatrix().getRow(row).begin();
                 for (auto const& paramEntry : dtmc->getTransitionMatrix().getRow(row)) {
                     EXPECT_EQ(paramEntry.getColumn(), instantiatedEntry->getColumn());
-                    double evaluatedValue = carl::toDouble(paramEntry.getValue().evaluate(valuation));
+                    double evaluatedValue = storm::utility::convertNumber<double>(paramEntry.getValue().evaluate(valuation));
                     EXPECT_EQ(evaluatedValue, instantiatedEntry->getValue());
                     ++instantiatedEntry;
                 }
@@ -128,7 +128,7 @@ TEST_F(ModelInstantiatorTest, BrpProb) {
                 auto instantiatedEntry = instantiated.getTransitionMatrix().getRow(row).begin();
                 for (auto const& paramEntry : dtmc->getTransitionMatrix().getRow(row)) {
                     EXPECT_EQ(paramEntry.getColumn(), instantiatedEntry->getColumn());
-                    double evaluatedValue = carl::toDouble(paramEntry.getValue().evaluate(valuation));
+                    double evaluatedValue = storm::utility::convertNumber<double>(paramEntry.getValue().evaluate(valuation));
                     EXPECT_EQ(evaluatedValue, instantiatedEntry->getValue());
                     ++instantiatedEntry;
                 }
@@ -189,7 +189,7 @@ TEST_F(ModelInstantiatorTest, Brp_Rew) {
                 auto instantiatedEntry = instantiated.getTransitionMatrix().getRow(row).begin();
                 for (auto const& paramEntry : dtmc->getTransitionMatrix().getRow(row)) {
                     EXPECT_EQ(paramEntry.getColumn(), instantiatedEntry->getColumn());
-                    double evaluatedValue = carl::toDouble(paramEntry.getValue().evaluate(valuation));
+                    double evaluatedValue = storm::utility::convertNumber<double>(paramEntry.getValue().evaluate(valuation));
                     EXPECT_EQ(evaluatedValue, instantiatedEntry->getValue());
                     ++instantiatedEntry;
                 }
@@ -204,7 +204,7 @@ TEST_F(ModelInstantiatorTest, Brp_Rew) {
         std::size_t stateActionEntries = dtmc->getUniqueRewardModel().getStateActionRewardVector().size();
         ASSERT_EQ(stateActionEntries, instantiated.getUniqueRewardModel().getStateActionRewardVector().size());
         for (std::size_t i = 0; i < stateActionEntries; ++i) {
-            double evaluatedValue = carl::toDouble(dtmc->getUniqueRewardModel().getStateActionRewardVector()[i].evaluate(valuation));
+            double evaluatedValue = storm::utility::convertNumber<double>(dtmc->getUniqueRewardModel().getStateActionRewardVector()[i].evaluate(valuation));
             EXPECT_EQ(evaluatedValue, instantiated.getUniqueRewardModel().getStateActionRewardVector()[i]);
         }
         EXPECT_EQ(dtmc->getStateLabeling(), instantiated.getStateLabeling());
@@ -253,7 +253,7 @@ TEST_F(ModelInstantiatorTest, Consensus) {
             auto instantiatedEntry = instantiated.getTransitionMatrix().getRow(row).begin();
             for (auto const& paramEntry : mdp->getTransitionMatrix().getRow(row)) {
                 EXPECT_EQ(paramEntry.getColumn(), instantiatedEntry->getColumn());
-                double evaluatedValue = carl::toDouble(paramEntry.getValue().evaluate(valuation));
+                double evaluatedValue = storm::utility::convertNumber<double>(paramEntry.getValue().evaluate(valuation));
                 EXPECT_EQ(evaluatedValue, instantiatedEntry->getValue());
                 ++instantiatedEntry;
             }

--- a/src/test/storm/adapter/MathsatExpressionAdapterTest.cpp
+++ b/src/test/storm/adapter/MathsatExpressionAdapterTest.cpp
@@ -5,6 +5,8 @@
 #include <mathsat.h>
 #include "storm/adapters/MathsatExpressionAdapter.h"
 #include "storm/settings/SettingsManager.h"
+#include "storm/storage/expressions/ExpressionManager.h"
+#include "storm/storage/expressions/Expressions.h"
 #include "storm/storage/expressions/OperatorType.h"
 
 TEST(MathsatExpressionAdapter, StormToMathsatBasic) {


### PR DESCRIPTION
The goal is to reduce the direct calls to `carl` in the code and instead go through either an adapter or `constants.h`.

Some notable changes:
- Instantiate via `storm::RationalNumber` and `storm::RationalFunctionCoefficient` instead of `Cln/GmpRationalNumber`, because the type of value (exact or from rational function) is more relevant than the underlying library. Introduced define `STORM_RATIONAL_NUMBER_DIFFERS_FROM_COEFFICIENT` to disable instantiations if both number types coincide.
- Replaced `carl:hash_add` by `boost::hash_combine`. Carl still uses an [older version](https://github.com/stormchecker/carl-storm/blob/master/src/carl/util/hash.h) of the hash which has [issues](https://stackoverflow.com/a/50978188).
- Added `gcd` and `lcm` for Integers and revised `vector::toIntegralVector`. The function now performs the operations on integers instead of rational representations of integers.