### PR TITLE
Upper and lower bounds for more algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ nbproject/
 .idea
 .vscode
 *.out
+.claude/

--- a/src/storm-cli/model-handling-main-cli.h
+++ b/src/storm-cli/model-handling-main-cli.h
@@ -141,19 +141,20 @@ void printFilteredResult(std::unique_ptr<storm::modelchecker::CheckResult> const
                 }
             };
             printValue(aggregate.value);
-            // An aggregate of an enclosure encloses the aggregate, so report it in the same shape as the values do.
+            // An aggregate of an enclosure encloses the aggregate, so report it in the same shape as the values do,
+            // a dash included for a side that is not known.
             if (aggregate.hasLower() || aggregate.hasUpper()) {
                 STORM_PRINT(" [");
                 if (aggregate.hasLower()) {
                     printValue(*aggregate.lower);
                 } else {
-                    STORM_PRINT("-inf");
+                    STORM_PRINT("-");
                 }
                 STORM_PRINT(", ");
                 if (aggregate.hasUpper()) {
                     printValue(*aggregate.upper);
                 } else {
-                    STORM_PRINT("inf");
+                    STORM_PRINT("-");
                 }
                 STORM_PRINT("]");
             }

--- a/src/storm-cli/model-handling-main-cli.h
+++ b/src/storm-cli/model-handling-main-cli.h
@@ -114,19 +114,11 @@ void printFilteredResult(std::unique_ptr<storm::modelchecker::CheckResult> const
         if (ft == storm::modelchecker::FilterType::VALUES) {
             STORM_PRINT(*result);
         } else {
-            storm::utility::ExtendedValueType<ValueType> resultValue;
             switch (ft) {
                 case storm::modelchecker::FilterType::SUM:
-                    resultValue = result->asQuantitativeCheckResult<ValueType>().sum();
-                    break;
                 case storm::modelchecker::FilterType::AVG:
-                    resultValue = result->asQuantitativeCheckResult<ValueType>().average();
-                    break;
                 case storm::modelchecker::FilterType::MIN:
-                    resultValue = result->asQuantitativeCheckResult<ValueType>().getMin();
-                    break;
                 case storm::modelchecker::FilterType::MAX:
-                    resultValue = result->asQuantitativeCheckResult<ValueType>().getMax();
                     break;
                 case storm::modelchecker::FilterType::ARGMIN:
                 case storm::modelchecker::FilterType::ARGMAX:
@@ -138,10 +130,32 @@ void printFilteredResult(std::unique_ptr<storm::modelchecker::CheckResult> const
                 default:
                     STORM_LOG_THROW(false, storm::exceptions::InvalidArgumentException, "Unhandled filter type.");
             }
-            if (storm::NumberTraits<ValueType>::IsExact && storm::utility::isConstant(resultValue)) {
-                STORM_PRINT(resultValue << " (approx. " << storm::utility::convertNumber<double>(resultValue) << ")");
-            } else {
-                STORM_PRINT(resultValue);
+            auto const aggregate = result->asQuantitativeCheckResult<ValueType>().aggregate(ft);
+            auto printValue = [](storm::utility::ExtendedValueType<ValueType> const& value) {
+                if (storm::utility::isInfinity(value)) {
+                    STORM_PRINT("inf");
+                } else if (storm::NumberTraits<ValueType>::IsExact && storm::utility::isConstant(value)) {
+                    STORM_PRINT(value << " (approx. " << storm::utility::convertNumber<double>(value) << ")");
+                } else {
+                    STORM_PRINT(value);
+                }
+            };
+            printValue(aggregate.value);
+            // An aggregate of an enclosure encloses the aggregate, so report it in the same shape as the values do.
+            if (aggregate.hasLower() || aggregate.hasUpper()) {
+                STORM_PRINT(" [");
+                if (aggregate.hasLower()) {
+                    printValue(*aggregate.lower);
+                } else {
+                    STORM_PRINT("-inf");
+                }
+                STORM_PRINT(", ");
+                if (aggregate.hasUpper()) {
+                    printValue(*aggregate.upper);
+                } else {
+                    STORM_PRINT("inf");
+                }
+                STORM_PRINT("]");
             }
         }
     } else {

--- a/src/storm-counterexamples/api/counterexamples.cpp
+++ b/src/storm-counterexamples/api/counterexamples.cpp
@@ -51,7 +51,7 @@ std::shared_ptr<storm::counterexamples::Counterexample> computeKShortestPathCoun
     storm::storage::BitVector phiStates(model->getNumberOfStates(), true);
     auto results = storm::modelchecker::helper::SparseDtmcPrctlHelper<double>::computeUntilProbabilities(
         env, false, model->getTransitionMatrix(), model->getBackwardTransitions(), phiStates, subQualitativeResult.getTruthValuesVector(), true);
-    double reachProb = results.at(initialState);
+    double reachProb = results.values.at(initialState);
     STORM_LOG_THROW((reachProb > threshold) || (strictBound && reachProb >= threshold), storm::exceptions::InvalidArgumentException,
                     "Given probability threshold " << threshold << " cannot be " << (strictBound ? "achieved" : "exceeded")
                                                    << " in model with maximal reachability probability of " << reachProb << ".");

--- a/src/storm-counterexamples/counterexamples/SMTMinimalLabelSetGenerator.h
+++ b/src/storm-counterexamples/counterexamples/SMTMinimalLabelSetGenerator.h
@@ -1668,8 +1668,9 @@ class SMTMinimalLabelSetGenerator {
         if (model.isOfType(storm::models::ModelType::Dtmc)) {
             if (rewardName == boost::none) {
                 results.push_back(storm::utility::zero<T>());
-                allStatesResult = storm::modelchecker::helper::SparseDtmcPrctlHelper<T>::computeUntilProbabilities(
-                    env, false, model.getTransitionMatrix(), model.getBackwardTransitions(), phiStates, psiStates, false);
+                allStatesResult = std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<T>::computeUntilProbabilities(
+                                                env, false, model.getTransitionMatrix(), model.getBackwardTransitions(), phiStates, psiStates, false)
+                                                .values);
                 for (auto state : model.getInitialStates()) {
                     STORM_LOG_TRACE("Found probability " << allStatesResult[state]);
                     results.back() = std::max(results.back(), allStatesResult[state]);

--- a/src/storm-counterexamples/counterexamples/SMTMinimalLabelSetGenerator.h
+++ b/src/storm-counterexamples/counterexamples/SMTMinimalLabelSetGenerator.h
@@ -1679,8 +1679,10 @@ class SMTMinimalLabelSetGenerator {
             } else {
                 for (auto const& rewName : rewardName.get()) {
                     results.push_back(storm::utility::zero<T>());
-                    allStatesResult = storm::modelchecker::helper::SparseDtmcPrctlHelper<T>::computeReachabilityRewards(
-                        env, false, model.getTransitionMatrix(), model.getBackwardTransitions(), model.getRewardModel(rewName), psiStates, false);
+                    allStatesResult =
+                        storm::modelchecker::helper::SparseDtmcPrctlHelper<T>::computeReachabilityRewards(
+                            env, false, model.getTransitionMatrix(), model.getBackwardTransitions(), model.getRewardModel(rewName), psiStates, false)
+                            .values;
                     for (auto state : model.getInitialStates()) {
                         results.back() = std::max(results.back(), allStatesResult[state]);
                     }

--- a/src/storm-dft/modelchecker/DFTModelChecker.cpp
+++ b/src/storm-dft/modelchecker/DFTModelChecker.cpp
@@ -471,7 +471,7 @@ std::vector<typename DFTModelChecker<ValueType>::ExtendedValueType> DFTModelChec
 
         if (result) {
             result->filter(storm::modelchecker::ExplicitQualitativeCheckResult<ValueType>(model->getInitialStates()));
-            results.push_back(result->asExplicitQuantitativeCheckResult<ValueType>().getValueMap().begin()->second);
+            results.push_back(result->asExplicitQuantitativeCheckResult<ValueType>().getValueVector().front());
         } else {
             STORM_LOG_WARN("The property '" << *property << "' could not be checked with the current settings.");
             results.push_back(-storm::utility::one<ExtendedValueType>());

--- a/src/storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.cpp
+++ b/src/storm-gamebased-ar/modelchecker/abstraction/GameBasedMdpModelChecker.cpp
@@ -1286,8 +1286,10 @@ void postProcessStrategies(uint64_t iteration, storm::OptimizationDirection cons
             }
         }
         auto dtmcMatrix = dtmcMatrixBuilder.build();
-        std::vector<ValueType> sanityValues = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
-            Environment(), storm::solver::SolveGoal<ValueType>(), dtmcMatrix, dtmcMatrix.transpose(), constraintStates, targetStates, false);
+        std::vector<ValueType> sanityValues =
+            std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
+                          Environment(), storm::solver::SolveGoal<ValueType>(), dtmcMatrix, dtmcMatrix.transpose(), constraintStates, targetStates, false)
+                          .values);
 
         ValueType maxDiff = storm::utility::zero<ValueType>();
         uint64_t maxState = 0;
@@ -1324,8 +1326,10 @@ void postProcessStrategies(uint64_t iteration, storm::OptimizationDirection cons
             }
         }
         dtmcMatrix = dtmcMatrixBuilder.build();
-        sanityValues = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
-            Environment(), storm::solver::SolveGoal<ValueType>(), dtmcMatrix, dtmcMatrix.transpose(), constraintStates, targetStates, false);
+        sanityValues =
+            std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
+                          Environment(), storm::solver::SolveGoal<ValueType>(), dtmcMatrix, dtmcMatrix.transpose(), constraintStates, targetStates, false)
+                          .values);
 
         maxDiff = storm::utility::zero<ValueType>();
         maxState = 0;

--- a/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
+++ b/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
@@ -109,11 +109,13 @@ std::unique_ptr<CheckResult> SparseCtmcCslModelChecker<SparseCtmcModelType>::com
     std::unique_ptr<CheckResult> rightResultPointer = this->check(env, pathFormula.getRightSubformula());
     ExplicitQualitativeCheckResult<ValueType> const& leftResult = leftResultPointer->template asExplicitQualitativeCheckResult<ValueType>();
     ExplicitQualitativeCheckResult<ValueType> const& rightResult = rightResultPointer->template asExplicitQualitativeCheckResult<ValueType>();
-    std::vector<ValueType> numericResult = storm::modelchecker::helper::SparseCtmcCslHelper::computeUntilProbabilities(
+    auto ret = storm::modelchecker::helper::SparseCtmcCslHelper::computeUntilProbabilities(
         env, storm::solver::SolveGoal<ValueType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
         this->getModel().getBackwardTransitions(), this->getModel().getExitRateVector(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(),
         checkTask.isQualitativeSet());
-    return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<ValueType>(std::move(numericResult)));
+    auto result = std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(std::move(ret.values));
+    result->setBounds(std::move(ret.solutionBounds));
+    return result;
 }
 
 template<typename SparseCtmcModelType>
@@ -194,21 +196,25 @@ std::unique_ptr<CheckResult> SparseCtmcCslModelChecker<SparseCtmcModelType>::com
     std::unique_ptr<CheckResult> subResultPointer = this->check(env, eventuallyFormula.getSubformula());
     ExplicitQualitativeCheckResult<ValueType> const& subResult = subResultPointer->template asExplicitQualitativeCheckResult<ValueType>();
     auto rewardModel = storm::utility::createFilteredRewardModel(this->getModel(), checkTask);
-    std::vector<ExtendedValueType> numericResult = storm::modelchecker::helper::SparseCtmcCslHelper::computeReachabilityRewards(
+    auto ret = storm::modelchecker::helper::SparseCtmcCslHelper::computeReachabilityRewards(
         env, storm::solver::SolveGoal<ValueType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
         this->getModel().getBackwardTransitions(), this->getModel().getExitRateVector(), rewardModel.get(), subResult.getTruthValuesVector(),
         checkTask.isQualitativeSet());
-    return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<ValueType>(std::move(numericResult)));
+    auto result = std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(std::move(ret.values));
+    result->setBounds(std::move(ret.solutionBounds));
+    return result;
 }
 
 template<typename SparseCtmcModelType>
 std::unique_ptr<CheckResult> SparseCtmcCslModelChecker<SparseCtmcModelType>::computeTotalRewards(
     Environment const& env, CheckTask<storm::logic::TotalRewardFormula, ValueType> const& checkTask) {
     auto rewardModel = storm::utility::createFilteredRewardModel(this->getModel(), checkTask);
-    std::vector<ExtendedValueType> numericResult = storm::modelchecker::helper::SparseCtmcCslHelper::computeTotalRewards(
+    auto ret = storm::modelchecker::helper::SparseCtmcCslHelper::computeTotalRewards(
         env, storm::solver::SolveGoal<ValueType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
         this->getModel().getBackwardTransitions(), this->getModel().getExitRateVector(), rewardModel.get(), checkTask.isQualitativeSet());
-    return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<ValueType>(std::move(numericResult)));
+    auto result = std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(std::move(ret.values));
+    result->setBounds(std::move(ret.solutionBounds));
+    return result;
 }
 
 template<typename SparseCtmcModelType>
@@ -244,10 +250,12 @@ std::unique_ptr<CheckResult> SparseCtmcCslModelChecker<SparseCtmcModelType>::com
     std::unique_ptr<CheckResult> subResultPointer = this->check(env, eventuallyFormula.getSubformula());
     ExplicitQualitativeCheckResult<ValueType>& subResult = subResultPointer->template asExplicitQualitativeCheckResult<ValueType>();
 
-    std::vector<ExtendedValueType> numericResult = storm::modelchecker::helper::SparseCtmcCslHelper::computeReachabilityTimes(
+    auto ret = storm::modelchecker::helper::SparseCtmcCslHelper::computeReachabilityTimes(
         env, storm::solver::SolveGoal<ValueType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
         this->getModel().getBackwardTransitions(), this->getModel().getExitRateVector(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet());
-    return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<ValueType>(std::move(numericResult)));
+    auto result = std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(std::move(ret.values));
+    result->setBounds(std::move(ret.solutionBounds));
+    return result;
 }
 
 template<typename SparseCtmcModelType>

--- a/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
+++ b/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
@@ -94,9 +94,11 @@ std::unique_ptr<CheckResult> SparseCtmcCslModelChecker<SparseCtmcModelType>::com
     std::unique_ptr<CheckResult> subResultPointer = this->check(env, pathFormula.getSubformula());
     ExplicitQualitativeCheckResult<ValueType> const& subResult = subResultPointer->template asExplicitQualitativeCheckResult<ValueType>();
     auto probabilisticTransitions = this->getModel().computeProbabilityMatrix();
-    std::vector<ValueType> numericResult = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeGloballyProbabilities(
-        env, storm::solver::SolveGoal<ValueType>(this->getModel(), checkTask), probabilisticTransitions, probabilisticTransitions.transpose(),
-        subResult.getTruthValuesVector(), checkTask.isQualitativeSet());
+    // CTMC results do not carry bounds yet.
+    std::vector<ValueType> numericResult = std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeGloballyProbabilities(
+                                                         env, storm::solver::SolveGoal<ValueType>(this->getModel(), checkTask), probabilisticTransitions,
+                                                         probabilisticTransitions.transpose(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet())
+                                                         .values);
     return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<ValueType>(std::move(numericResult)));
 }
 

--- a/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
+++ b/src/storm/modelchecker/csl/SparseCtmcCslModelChecker.cpp
@@ -94,7 +94,6 @@ std::unique_ptr<CheckResult> SparseCtmcCslModelChecker<SparseCtmcModelType>::com
     std::unique_ptr<CheckResult> subResultPointer = this->check(env, pathFormula.getSubformula());
     ExplicitQualitativeCheckResult<ValueType> const& subResult = subResultPointer->template asExplicitQualitativeCheckResult<ValueType>();
     auto probabilisticTransitions = this->getModel().computeProbabilityMatrix();
-    // CTMC results do not carry bounds yet.
     std::vector<ValueType> numericResult = std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeGloballyProbabilities(
                                                          env, storm::solver::SolveGoal<ValueType>(this->getModel(), checkTask), probabilisticTransitions,
                                                          probabilisticTransitions.transpose(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet())

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
@@ -65,7 +65,9 @@ std::vector<ValueType> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
 
     // If the time bounds are [0, inf], we rather call untimed reachability.
     if (storm::utility::isZero(lowerBound) && !upperBound) {
-        return computeUntilProbabilities(env, std::move(goal), rateMatrix, backwardTransitions, exitRates, phiStates, psiStates, qualitative);
+        // Bounded until does not report bounds on its values, so only the values are taken here. Note that the
+        // remaining cases go through uniformization, which does not produce any.
+        return computeUntilProbabilities(env, std::move(goal), rateMatrix, backwardTransitions, exitRates, phiStates, psiStates, qualitative).values;
     }
 
     // From this point on, we know that we have to solve a more complicated problem [t, t'] with either t != 0
@@ -137,7 +139,8 @@ std::vector<ValueType> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
                     // Start by computing the (unbounded) reachability probabilities of reaching psi states while
                     // staying in phi states.
                     result = computeUntilProbabilities(env, storm::solver::SolveGoal<ValueType>(), rateMatrix, backwardTransitions, exitRates, phiStates,
-                                                       psiStates, qualitative);
+                                                       psiStates, qualitative)
+                                 .values;
 
                     // Determine the set of states that must be considered further.
                     storm::storage::BitVector relevantStates = statesWithProbabilityGreater0 & phiStates;
@@ -253,14 +256,12 @@ std::vector<ValueType> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
 }
 
 template<typename ValueType>
-std::vector<ValueType> SparseCtmcCslHelper::computeUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
-                                                                      storm::storage::SparseMatrix<ValueType> const& rateMatrix,
-                                                                      storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                      std::vector<ValueType> const& exitRateVector, storm::storage::BitVector const& phiStates,
-                                                                      storm::storage::BitVector const& psiStates, bool qualitative) {
-    return std::move(SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(env, std::move(goal), computeProbabilityMatrix(rateMatrix, exitRateVector),
-                                                                                 backwardTransitions, phiStates, psiStates, qualitative)
-                         .values);
+DeterministicSparseModelCheckingHelperReturnType<ValueType> SparseCtmcCslHelper::computeUntilProbabilities(
+    Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
+    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, std::vector<ValueType> const& exitRateVector,
+    storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates, bool qualitative) {
+    return SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(env, std::move(goal), computeProbabilityMatrix(rateMatrix, exitRateVector),
+                                                                       backwardTransitions, phiStates, psiStates, qualitative);
 }
 
 template<typename ValueType>
@@ -410,7 +411,7 @@ std::vector<ValueType> SparseCtmcCslHelper::computeCumulativeRewards(Environment
 }
 
 template<typename ValueType>
-std::vector<storm::utility::ExtendedValueType<ValueType>> SparseCtmcCslHelper::computeReachabilityTimes(
+DeterministicSparseModelCheckingHelperReturnType<storm::utility::ExtendedValueType<ValueType>> SparseCtmcCslHelper::computeReachabilityTimes(
     Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, std::vector<ValueType> const& exitRateVector,
     storm::storage::BitVector const& targetStates, bool qualitative) {
@@ -429,15 +430,12 @@ std::vector<storm::utility::ExtendedValueType<ValueType>> SparseCtmcCslHelper::c
         }
     }
 
-    // TODO: the DTMC helper also reports sound bounds on these values; carrying them through the CTMC helpers
-    // would let reward queries on CTMCs report an enclosure as well.
     return storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeReachabilityRewards(
-               env, std::move(goal), probabilityMatrix, backwardTransitions, totalRewardVector, targetStates, qualitative)
-        .values;
+        env, std::move(goal), probabilityMatrix, backwardTransitions, totalRewardVector, targetStates, qualitative);
 }
 
 template<typename ValueType, typename RewardModelType>
-std::vector<storm::utility::ExtendedValueType<ValueType>> SparseCtmcCslHelper::computeReachabilityRewards(
+DeterministicSparseModelCheckingHelperReturnType<storm::utility::ExtendedValueType<ValueType>> SparseCtmcCslHelper::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, std::vector<ValueType> const& exitRateVector, RewardModelType const& rewardModel,
     storm::storage::BitVector const& targetStates, bool qualitative) {
@@ -468,15 +466,12 @@ std::vector<storm::utility::ExtendedValueType<ValueType>> SparseCtmcCslHelper::c
         totalRewardVector = rewardModel.getStateActionRewardVector();
     }
 
-    // TODO: the DTMC helper also reports sound bounds on these values; carrying them through the CTMC helpers
-    // would let reward queries on CTMCs report an enclosure as well.
     return storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeReachabilityRewards(
-               env, std::move(goal), probabilityMatrix, backwardTransitions, totalRewardVector, targetStates, qualitative)
-        .values;
+        env, std::move(goal), probabilityMatrix, backwardTransitions, totalRewardVector, targetStates, qualitative);
 }
 
 template<typename ValueType, typename RewardModelType>
-std::vector<storm::utility::ExtendedValueType<ValueType>> SparseCtmcCslHelper::computeTotalRewards(
+DeterministicSparseModelCheckingHelperReturnType<storm::utility::ExtendedValueType<ValueType>> SparseCtmcCslHelper::computeTotalRewards(
     Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, std::vector<ValueType> const& exitRateVector, RewardModelType const& rewardModel,
     bool qualitative) {
@@ -509,8 +504,7 @@ std::vector<storm::utility::ExtendedValueType<ValueType>> SparseCtmcCslHelper::c
 
     RewardModelType dtmcRewardModel(std::move(totalRewardVector));
     return storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeTotalRewards(env, std::move(goal), probabilityMatrix, backwardTransitions,
-                                                                                              dtmcRewardModel, qualitative)
-        .values;
+                                                                                              dtmcRewardModel, qualitative);
 }
 
 template<typename ValueType>
@@ -760,12 +754,10 @@ template std::vector<double> SparseCtmcCslHelper::computeBoundedUntilProbabiliti
     storm::storage::SparseMatrix<double> const& backwardTransitions, storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
     std::vector<double> const& exitRates, bool qualitative, double lowerBound, std::optional<double> const& upperBound);
 
-template std::vector<double> SparseCtmcCslHelper::computeUntilProbabilities(Environment const& env, storm::solver::SolveGoal<double>&& goal,
-                                                                            storm::storage::SparseMatrix<double> const& rateMatrix,
-                                                                            storm::storage::SparseMatrix<double> const& backwardTransitions,
-                                                                            std::vector<double> const& exitRateVector,
-                                                                            storm::storage::BitVector const& phiStates,
-                                                                            storm::storage::BitVector const& psiStates, bool qualitative);
+template DeterministicSparseModelCheckingHelperReturnType<double> SparseCtmcCslHelper::computeUntilProbabilities(
+    Environment const& env, storm::solver::SolveGoal<double>&& goal, storm::storage::SparseMatrix<double> const& rateMatrix,
+    storm::storage::SparseMatrix<double> const& backwardTransitions, std::vector<double> const& exitRateVector, storm::storage::BitVector const& phiStates,
+    storm::storage::BitVector const& psiStates, bool qualitative);
 
 template std::vector<double> SparseCtmcCslHelper::computeAllUntilProbabilities(Environment const& env, storm::solver::SolveGoal<double>&& goal,
                                                                                storm::storage::SparseMatrix<double> const& rateMatrix,
@@ -784,17 +776,17 @@ template std::vector<double> SparseCtmcCslHelper::computeInstantaneousRewards(En
                                                                               storm::models::sparse::StandardRewardModel<double> const& rewardModel,
                                                                               double timeBound);
 
-template std::vector<storm::utility::ExtendedValueType<double>> SparseCtmcCslHelper::computeReachabilityTimes(
+template DeterministicSparseModelCheckingHelperReturnType<storm::utility::ExtendedValueType<double>> SparseCtmcCslHelper::computeReachabilityTimes(
     Environment const& env, storm::solver::SolveGoal<double>&& goal, storm::storage::SparseMatrix<double> const& rateMatrix,
     storm::storage::SparseMatrix<double> const& backwardTransitions, std::vector<double> const& exitRateVector, storm::storage::BitVector const& targetStates,
     bool qualitative);
 
-template std::vector<storm::utility::ExtendedValueType<double>> SparseCtmcCslHelper::computeReachabilityRewards(
+template DeterministicSparseModelCheckingHelperReturnType<storm::utility::ExtendedValueType<double>> SparseCtmcCslHelper::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<double>&& goal, storm::storage::SparseMatrix<double> const& rateMatrix,
     storm::storage::SparseMatrix<double> const& backwardTransitions, std::vector<double> const& exitRateVector,
     storm::models::sparse::StandardRewardModel<double> const& rewardModel, storm::storage::BitVector const& targetStates, bool qualitative);
 
-template std::vector<storm::utility::ExtendedValueType<double>> SparseCtmcCslHelper::computeTotalRewards(
+template DeterministicSparseModelCheckingHelperReturnType<storm::utility::ExtendedValueType<double>> SparseCtmcCslHelper::computeTotalRewards(
     Environment const& env, storm::solver::SolveGoal<double>&& goal, storm::storage::SparseMatrix<double> const& rateMatrix,
     storm::storage::SparseMatrix<double> const& backwardTransitions, std::vector<double> const& exitRateVector,
     storm::models::sparse::StandardRewardModel<double> const& rewardModel, bool qualitative);
@@ -818,11 +810,11 @@ template std::vector<double> SparseCtmcCslHelper::computeTransientProbabilities(
                                                                                 std::vector<double> const* addVector, double timeBound,
                                                                                 double uniformizationRate, std::vector<double> values, double epsilon);
 
-template std::vector<storm::RationalNumber> SparseCtmcCslHelper::computeUntilProbabilities(
+template DeterministicSparseModelCheckingHelperReturnType<storm::RationalNumber> SparseCtmcCslHelper::computeUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& rateMatrix,
     storm::storage::SparseMatrix<storm::RationalNumber> const& backwardTransitions, std::vector<storm::RationalNumber> const& exitRateVector,
     storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates, bool qualitative);
-template std::vector<storm::RationalFunction> SparseCtmcCslHelper::computeUntilProbabilities(
+template DeterministicSparseModelCheckingHelperReturnType<storm::RationalFunction> SparseCtmcCslHelper::computeUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<storm::RationalFunction>&& goal, storm::storage::SparseMatrix<storm::RationalFunction> const& rateMatrix,
     storm::storage::SparseMatrix<storm::RationalFunction> const& backwardTransitions, std::vector<storm::RationalFunction> const& exitRateVector,
     storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates, bool qualitative);
@@ -844,29 +836,29 @@ template std::vector<storm::RationalFunction> SparseCtmcCslHelper::computeNextPr
     Environment const& env, storm::storage::SparseMatrix<storm::RationalFunction> const& rateMatrix, std::vector<storm::RationalFunction> const& exitRateVector,
     storm::storage::BitVector const& nextStates);
 
-template std::vector<storm::ExtendedRationalNumber> SparseCtmcCslHelper::computeReachabilityTimes(
+template DeterministicSparseModelCheckingHelperReturnType<storm::ExtendedRationalNumber> SparseCtmcCslHelper::computeReachabilityTimes(
     Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& rateMatrix,
     storm::storage::SparseMatrix<storm::RationalNumber> const& backwardTransitions, std::vector<storm::RationalNumber> const& exitRateVector,
     storm::storage::BitVector const& targetStates, bool qualitative);
-template std::vector<storm::ExtendedRationalFunction> SparseCtmcCslHelper::computeReachabilityTimes(
+template DeterministicSparseModelCheckingHelperReturnType<storm::ExtendedRationalFunction> SparseCtmcCslHelper::computeReachabilityTimes(
     Environment const& env, storm::solver::SolveGoal<storm::RationalFunction>&& goal, storm::storage::SparseMatrix<storm::RationalFunction> const& rateMatrix,
     storm::storage::SparseMatrix<storm::RationalFunction> const& backwardTransitions, std::vector<storm::RationalFunction> const& exitRateVector,
     storm::storage::BitVector const& targetStates, bool qualitative);
 
-template std::vector<storm::ExtendedRationalNumber> SparseCtmcCslHelper::computeReachabilityRewards(
+template DeterministicSparseModelCheckingHelperReturnType<storm::ExtendedRationalNumber> SparseCtmcCslHelper::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& rateMatrix,
     storm::storage::SparseMatrix<storm::RationalNumber> const& backwardTransitions, std::vector<storm::RationalNumber> const& exitRateVector,
     storm::models::sparse::StandardRewardModel<storm::RationalNumber> const& rewardModel, storm::storage::BitVector const& targetStates, bool qualitative);
-template std::vector<storm::ExtendedRationalFunction> SparseCtmcCslHelper::computeReachabilityRewards(
+template DeterministicSparseModelCheckingHelperReturnType<storm::ExtendedRationalFunction> SparseCtmcCslHelper::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<storm::RationalFunction>&& goal, storm::storage::SparseMatrix<storm::RationalFunction> const& rateMatrix,
     storm::storage::SparseMatrix<storm::RationalFunction> const& backwardTransitions, std::vector<storm::RationalFunction> const& exitRateVector,
     storm::models::sparse::StandardRewardModel<storm::RationalFunction> const& rewardModel, storm::storage::BitVector const& targetStates, bool qualitative);
 
-template std::vector<storm::ExtendedRationalNumber> SparseCtmcCslHelper::computeTotalRewards(
+template DeterministicSparseModelCheckingHelperReturnType<storm::ExtendedRationalNumber> SparseCtmcCslHelper::computeTotalRewards(
     Environment const& env, storm::solver::SolveGoal<storm::RationalNumber>&& goal, storm::storage::SparseMatrix<storm::RationalNumber> const& rateMatrix,
     storm::storage::SparseMatrix<storm::RationalNumber> const& backwardTransitions, std::vector<storm::RationalNumber> const& exitRateVector,
     storm::models::sparse::StandardRewardModel<storm::RationalNumber> const& rewardModel, bool qualitative);
-template std::vector<storm::ExtendedRationalFunction> SparseCtmcCslHelper::computeTotalRewards(
+template DeterministicSparseModelCheckingHelperReturnType<storm::ExtendedRationalFunction> SparseCtmcCslHelper::computeTotalRewards(
     Environment const& env, storm::solver::SolveGoal<storm::RationalFunction>&& goal, storm::storage::SparseMatrix<storm::RationalFunction> const& rateMatrix,
     storm::storage::SparseMatrix<storm::RationalFunction> const& backwardTransitions, std::vector<storm::RationalFunction> const& exitRateVector,
     storm::models::sparse::StandardRewardModel<storm::RationalFunction> const& rewardModel, bool qualitative);

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
@@ -429,8 +429,11 @@ std::vector<storm::utility::ExtendedValueType<ValueType>> SparseCtmcCslHelper::c
         }
     }
 
+    // TODO: the DTMC helper also reports sound bounds on these values; carrying them through the CTMC helpers
+    // would let reward queries on CTMCs report an enclosure as well.
     return storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeReachabilityRewards(
-        env, std::move(goal), probabilityMatrix, backwardTransitions, totalRewardVector, targetStates, qualitative);
+               env, std::move(goal), probabilityMatrix, backwardTransitions, totalRewardVector, targetStates, qualitative)
+        .values;
 }
 
 template<typename ValueType, typename RewardModelType>
@@ -465,8 +468,11 @@ std::vector<storm::utility::ExtendedValueType<ValueType>> SparseCtmcCslHelper::c
         totalRewardVector = rewardModel.getStateActionRewardVector();
     }
 
+    // TODO: the DTMC helper also reports sound bounds on these values; carrying them through the CTMC helpers
+    // would let reward queries on CTMCs report an enclosure as well.
     return storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeReachabilityRewards(
-        env, std::move(goal), probabilityMatrix, backwardTransitions, totalRewardVector, targetStates, qualitative);
+               env, std::move(goal), probabilityMatrix, backwardTransitions, totalRewardVector, targetStates, qualitative)
+        .values;
 }
 
 template<typename ValueType, typename RewardModelType>
@@ -503,7 +509,8 @@ std::vector<storm::utility::ExtendedValueType<ValueType>> SparseCtmcCslHelper::c
 
     RewardModelType dtmcRewardModel(std::move(totalRewardVector));
     return storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeTotalRewards(env, std::move(goal), probabilityMatrix, backwardTransitions,
-                                                                                              dtmcRewardModel, qualitative);
+                                                                                              dtmcRewardModel, qualitative)
+        .values;
 }
 
 template<typename ValueType>

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
@@ -258,7 +258,6 @@ std::vector<ValueType> SparseCtmcCslHelper::computeUntilProbabilities(Environmen
                                                                       storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                       std::vector<ValueType> const& exitRateVector, storm::storage::BitVector const& phiStates,
                                                                       storm::storage::BitVector const& psiStates, bool qualitative) {
-    // The CTMC helper does not expose bounds to its callers yet.
     return std::move(SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(env, std::move(goal), computeProbabilityMatrix(rateMatrix, exitRateVector),
                                                                                  backwardTransitions, phiStates, psiStates, qualitative)
                          .values);

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
@@ -258,8 +258,10 @@ std::vector<ValueType> SparseCtmcCslHelper::computeUntilProbabilities(Environmen
                                                                       storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                       std::vector<ValueType> const& exitRateVector, storm::storage::BitVector const& phiStates,
                                                                       storm::storage::BitVector const& psiStates, bool qualitative) {
-    return SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(env, std::move(goal), computeProbabilityMatrix(rateMatrix, exitRateVector),
-                                                                       backwardTransitions, phiStates, psiStates, qualitative);
+    // The CTMC helper does not expose bounds to its callers yet.
+    return std::move(SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(env, std::move(goal), computeProbabilityMatrix(rateMatrix, exitRateVector),
+                                                                                 backwardTransitions, phiStates, psiStates, qualitative)
+                         .values);
 }
 
 template<typename ValueType>

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.cpp
@@ -65,8 +65,6 @@ std::vector<ValueType> SparseCtmcCslHelper::computeBoundedUntilProbabilities(
 
     // If the time bounds are [0, inf], we rather call untimed reachability.
     if (storm::utility::isZero(lowerBound) && !upperBound) {
-        // Bounded until does not report bounds on its values, so only the values are taken here. Note that the
-        // remaining cases go through uniformization, which does not produce any.
         return computeUntilProbabilities(env, std::move(goal), rateMatrix, backwardTransitions, exitRates, phiStates, psiStates, qualitative).values;
     }
 

--- a/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.h
+++ b/src/storm/modelchecker/csl/helper/SparseCtmcCslHelper.h
@@ -5,6 +5,7 @@
 #include "storm/storage/BitVector.h"
 
 #include "storm/logic/OperatorFormula.h"
+#include "storm/modelchecker/prctl/helper/DeterministicModelCheckingHelperReturnType.h"
 #include "storm/solver/LinearEquationSolver.h"
 #include "storm/solver/SolveGoal.h"
 #include "storm/utility/ExtendedNumber.h"
@@ -30,11 +31,10 @@ class SparseCtmcCslHelper {
                                                                    std::optional<ValueType> const& upperBound);
 
     template<typename ValueType>
-    static std::vector<ValueType> computeUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
-                                                            storm::storage::SparseMatrix<ValueType> const& rateMatrix,
-                                                            storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                            std::vector<ValueType> const& exitRateVector, storm::storage::BitVector const& phiStates,
-                                                            storm::storage::BitVector const& psiStates, bool qualitative);
+    static DeterministicSparseModelCheckingHelperReturnType<ValueType> computeUntilProbabilities(
+        Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
+        storm::storage::SparseMatrix<ValueType> const& backwardTransitions, std::vector<ValueType> const& exitRateVector,
+        storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates, bool qualitative);
 
     template<typename ValueType>
     static std::vector<ValueType> computeAllUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
@@ -61,20 +61,19 @@ class SparseCtmcCslHelper {
                                                            ValueType timeBound);
 
     template<typename ValueType, typename RewardModelType>
-    static std::vector<storm::utility::ExtendedValueType<ValueType>> computeReachabilityRewards(
+    static DeterministicSparseModelCheckingHelperReturnType<storm::utility::ExtendedValueType<ValueType>> computeReachabilityRewards(
         Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
         storm::storage::SparseMatrix<ValueType> const& backwardTransitions, std::vector<ValueType> const& exitRateVector, RewardModelType const& rewardModel,
         storm::storage::BitVector const& targetStates, bool qualitative);
 
     template<typename ValueType, typename RewardModelType>
-    static std::vector<storm::utility::ExtendedValueType<ValueType>> computeTotalRewards(Environment const& env, storm::solver::SolveGoal<ValueType>&& goal,
-                                                                                         storm::storage::SparseMatrix<ValueType> const& rateMatrix,
-                                                                                         storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                                         std::vector<ValueType> const& exitRateVector,
-                                                                                         RewardModelType const& rewardModel, bool qualitative);
+    static DeterministicSparseModelCheckingHelperReturnType<storm::utility::ExtendedValueType<ValueType>> computeTotalRewards(
+        Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
+        storm::storage::SparseMatrix<ValueType> const& backwardTransitions, std::vector<ValueType> const& exitRateVector, RewardModelType const& rewardModel,
+        bool qualitative);
 
     template<typename ValueType>
-    static std::vector<storm::utility::ExtendedValueType<ValueType>> computeReachabilityTimes(
+    static DeterministicSparseModelCheckingHelperReturnType<storm::utility::ExtendedValueType<ValueType>> computeReachabilityTimes(
         Environment const& env, storm::solver::SolveGoal<ValueType>&& goal, storm::storage::SparseMatrix<ValueType> const& rateMatrix,
         storm::storage::SparseMatrix<ValueType> const& backwardTransitions, std::vector<ValueType> const& exitRateVector,
         storm::storage::BitVector const& targetStates, bool qualitative);

--- a/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
+++ b/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
@@ -314,9 +314,11 @@ std::vector<ValueType> SparseLTLHelper<ValueType, Nondeterministic>::computeDAPr
         }
 
     } else {
-        prodNumericResult = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
-            env, std::move(solveGoalProduct), product->getProductModel().getTransitionMatrix(), product->getProductModel().getBackwardTransitions(), bvTrue,
-            acceptingStates, this->isQualitativeSet());
+        // Any bounds would have to be projected back to the original model alongside the values, which is not done yet.
+        prodNumericResult = std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
+                                          env, std::move(solveGoalProduct), product->getProductModel().getTransitionMatrix(),
+                                          product->getProductModel().getBackwardTransitions(), bvTrue, acceptingStates, this->isQualitativeSet())
+                                          .values);
     }
 
     std::vector<ValueType> numericResult = product->projectToOriginalModel(this->_transitionMatrix.getRowGroupCount(), prodNumericResult);

--- a/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
+++ b/src/storm/modelchecker/helper/ltl/SparseLTLHelper.cpp
@@ -314,7 +314,6 @@ std::vector<ValueType> SparseLTLHelper<ValueType, Nondeterministic>::computeDAPr
         }
 
     } else {
-        // Any bounds would have to be projected back to the original model alongside the values, which is not done yet.
         prodNumericResult = std::move(storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType>::computeUntilProbabilities(
                                           env, std::move(solveGoalProduct), product->getProductModel().getTransitionMatrix(),
                                           product->getProductModel().getBackwardTransitions(), bvTrue, acceptingStates, this->isQualitativeSet())

--- a/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
@@ -151,12 +151,17 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
     std::unique_ptr<CheckResult> rightResultPointer = this->check(env, pathFormula.getRightSubformula());
     ExplicitQualitativeCheckResult<SolutionType> const& leftResult = leftResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
     ExplicitQualitativeCheckResult<SolutionType> const& rightResult = rightResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
+    storm::solver::SolutionBounds<SolutionType> solutionBounds;
     std::vector<SolutionType> numericResult =
         storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
             env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
             this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
-            checkTask.getHint());
-    return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+            checkTask.getHint(), &solutionBounds);
+    auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(numericResult));
+    if (solutionBounds) {
+        result->setBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+    }
+    return result;
 }
 
 template<typename SparseDtmcModelType>
@@ -168,11 +173,16 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
         storm::logic::GloballyFormula const& pathFormula = checkTask.getFormula();
         std::unique_ptr<CheckResult> subResultPointer = this->check(env, pathFormula.getSubformula());
         ExplicitQualitativeCheckResult<SolutionType> const& subResult = subResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
+        storm::solver::SolutionBounds<SolutionType> solutionBounds;
         std::vector<SolutionType> numericResult =
             storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
                 env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
-                this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet());
-        return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+                this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), &solutionBounds);
+        auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(numericResult));
+        if (solutionBounds) {
+            result->setBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+        }
+        return result;
     }
 }
 

--- a/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
@@ -98,7 +98,7 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
         auto formula = std::make_shared<storm::logic::ProbabilityOperatorFormula>(checkTask.getFormula().asSharedPointer(), opInfo);
         auto numericResult = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeRewardBoundedValues(
             env, this->getModel(), formula);
-        return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+        return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(this->getModel().getInitialStates(), std::move(numericResult)));
     } else {
         STORM_LOG_THROW(pathFormula.hasUpperBound(), storm::exceptions::InvalidPropertyException, "Formula needs to have (a single) upper step bound.");
         STORM_LOG_THROW(pathFormula.hasIntegerLowerBound(), storm::exceptions::InvalidPropertyException, "Formula lower step bound must be discrete/integral.");
@@ -156,7 +156,7 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
         this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
         checkTask.getHint());
     auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(ret.values));
-    setBounds(*result, ret.solutionBounds);
+    result->setBounds(std::move(ret.solutionBounds));
     return result;
 }
 
@@ -173,7 +173,7 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
             env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
             this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet());
         auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(ret.values));
-        setBounds(*result, ret.solutionBounds);
+        result->setBounds(std::move(ret.solutionBounds));
         return result;
     }
 }
@@ -238,7 +238,7 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
             auto formula = std::make_shared<storm::logic::RewardOperatorFormula>(checkTask.getFormula().asSharedPointer(), checkTask.getRewardModel(), opInfo);
             auto numericResult = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeRewardBoundedValues(
                 env, this->getModel(), formula);
-            return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<ValueType>(std::move(numericResult)));
+            return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<ValueType>(this->getModel().getInitialStates(), std::move(numericResult)));
         } else {
             STORM_LOG_THROW(rewardPathFormula.hasIntegerBound(), storm::exceptions::InvalidPropertyException, "Formula needs to have a discrete time bound.");
             auto rewardModel = storm::utility::createFilteredRewardModel(this->getModel(), checkTask);

--- a/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
@@ -151,16 +151,12 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
     std::unique_ptr<CheckResult> rightResultPointer = this->check(env, pathFormula.getRightSubformula());
     ExplicitQualitativeCheckResult<SolutionType> const& leftResult = leftResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
     ExplicitQualitativeCheckResult<SolutionType> const& rightResult = rightResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
-    storm::solver::SolutionBounds<SolutionType> solutionBounds;
-    std::vector<SolutionType> numericResult =
-        storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
-            env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
-            this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
-            checkTask.getHint(), &solutionBounds);
-    auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(numericResult));
-    if (solutionBounds) {
-        result->setBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
-    }
+    auto ret = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
+        env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
+        this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
+        checkTask.getHint());
+    auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(ret.values));
+    setBounds(*result, ret.solutionBounds);
     return result;
 }
 
@@ -173,15 +169,11 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
         storm::logic::GloballyFormula const& pathFormula = checkTask.getFormula();
         std::unique_ptr<CheckResult> subResultPointer = this->check(env, pathFormula.getSubformula());
         ExplicitQualitativeCheckResult<SolutionType> const& subResult = subResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
-        storm::solver::SolutionBounds<SolutionType> solutionBounds;
-        std::vector<SolutionType> numericResult =
-            storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
-                env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
-                this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), &solutionBounds);
-        auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(numericResult));
-        if (solutionBounds) {
-            result->setBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
-        }
+        auto ret = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
+            env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
+            this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet());
+        auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(ret.values));
+        setBounds(*result, ret.solutionBounds);
         return result;
     }
 }

--- a/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.cpp
@@ -308,11 +308,12 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
     std::unique_ptr<CheckResult> subResultPointer = this->check(env, eventuallyFormula.getSubformula());
     ExplicitQualitativeCheckResult<SolutionType> const& subResult = subResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
     auto rewardModel = storm::utility::createFilteredRewardModel(this->getModel(), checkTask);
-    std::vector<ExtendedSolutionType> numericResult =
-        storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabilityRewards(
-            env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
-            this->getModel().getBackwardTransitions(), rewardModel.get(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), checkTask.getHint());
-    return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+    auto ret = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabilityRewards(
+        env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
+        this->getModel().getBackwardTransitions(), rewardModel.get(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), checkTask.getHint());
+    auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(ret.values));
+    result->setBounds(std::move(ret.solutionBounds));
+    return result;
 }
 
 template<typename SparseDtmcModelType>
@@ -324,11 +325,12 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
         storm::logic::EventuallyFormula const& eventuallyFormula = checkTask.getFormula();
         std::unique_ptr<CheckResult> subResultPointer = this->check(env, eventuallyFormula.getSubformula());
         ExplicitQualitativeCheckResult<SolutionType> const& subResult = subResultPointer->template asExplicitQualitativeCheckResult<SolutionType>();
-        std::vector<ExtendedSolutionType> numericResult =
-            storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabilityTimes(
-                env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
-                this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), checkTask.getHint());
-        return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+        auto ret = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabilityTimes(
+            env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
+            this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), checkTask.getHint());
+        auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(ret.values));
+        result->setBounds(std::move(ret.solutionBounds));
+        return result;
     }
 }
 
@@ -339,11 +341,12 @@ std::unique_ptr<CheckResult> SparseDtmcPrctlModelChecker<SparseDtmcModelType>::c
         STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "We have not yet implemented total rewards with intervals.");
     } else {
         auto rewardModel = storm::utility::createFilteredRewardModel(this->getModel(), checkTask);
-        std::vector<ExtendedSolutionType> numericResult =
-            storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeTotalRewards(
-                env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
-                this->getModel().getBackwardTransitions(), rewardModel.get(), checkTask.isQualitativeSet(), checkTask.getHint());
-        return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+        auto ret = storm::modelchecker::helper::SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeTotalRewards(
+            env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
+            this->getModel().getBackwardTransitions(), rewardModel.get(), checkTask.isQualitativeSet(), checkTask.getHint());
+        auto result = std::make_unique<ExplicitQuantitativeCheckResult<SolutionType>>(std::move(ret.values));
+        result->setBounds(std::move(ret.solutionBounds));
+        return result;
     }
 }
 

--- a/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
@@ -182,6 +182,9 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
         checkTask.isProduceSchedulersSet(), checkTask.getHint());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
+    if (ret.solutionBounds) {
+        result->asExplicitQuantitativeCheckResult<SolutionType>().setBounds(std::move(ret.solutionBounds->first), std::move(ret.solutionBounds->second));
+    }
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }

--- a/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
@@ -182,9 +182,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
         checkTask.isProduceSchedulersSet(), checkTask.getHint());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
-    if (ret.solutionBounds) {
-        result->asExplicitQuantitativeCheckResult<SolutionType>().setBounds(std::move(ret.solutionBounds->first), std::move(ret.solutionBounds->second));
-    }
+    setBounds(result->asExplicitQuantitativeCheckResult<SolutionType>(), ret.solutionBounds);
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }
@@ -203,6 +201,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
         this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), checkTask.isProduceSchedulersSet());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
+    setBounds(result->asExplicitQuantitativeCheckResult<SolutionType>(), ret.solutionBounds);
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }

--- a/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
@@ -134,7 +134,8 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
             helper::rewardbounded::MultiDimensionalRewardUnfolding<ValueType, true> rewardUnfolding(this->getModel(), formula);
             auto numericResult = storm::modelchecker::helper::SparseMdpPrctlHelper<ValueType, SolutionType>::computeRewardBoundedValues(
                 env, checkTask.getOptimizationDirection(), rewardUnfolding, this->getModel().getInitialStates());
-            return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+            return std::unique_ptr<CheckResult>(
+                new ExplicitQuantitativeCheckResult<SolutionType>(this->getModel().getInitialStates(), std::move(numericResult)));
         }
     } else {
         STORM_LOG_THROW(pathFormula.hasUpperBound(), storm::exceptions::InvalidPropertyException, "Formula needs to have (a single) upper step bound.");
@@ -182,7 +183,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         this->getModel().getBackwardTransitions(), leftResult.getTruthValuesVector(), rightResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
         checkTask.isProduceSchedulersSet(), checkTask.getHint());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
-    setBounds(result->asExplicitQuantitativeCheckResult<SolutionType>(), ret.solutionBounds);
+    result->asExplicitQuantitativeCheckResult<SolutionType>().setBounds(std::move(ret.solutionBounds));
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }
@@ -201,7 +202,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
         this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), checkTask.isProduceSchedulersSet());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
-    setBounds(result->asExplicitQuantitativeCheckResult<SolutionType>(), ret.solutionBounds);
+    result->asExplicitQuantitativeCheckResult<SolutionType>().setBounds(std::move(ret.solutionBounds));
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }
@@ -316,7 +317,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         helper::rewardbounded::MultiDimensionalRewardUnfolding<ValueType, true> rewardUnfolding(this->getModel(), formula);
         auto numericResult = storm::modelchecker::helper::SparseMdpPrctlHelper<ValueType, SolutionType>::computeRewardBoundedValues(
             env, checkTask.getOptimizationDirection(), rewardUnfolding, this->getModel().getInitialStates());
-        return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(numericResult)));
+        return std::unique_ptr<CheckResult>(new ExplicitQuantitativeCheckResult<SolutionType>(this->getModel().getInitialStates(), std::move(numericResult)));
     } else {
         STORM_LOG_THROW(rewardPathFormula.hasIntegerBound(), storm::exceptions::InvalidPropertyException, "Formula needs to have a discrete time bound.");
         auto rewardModel = storm::utility::createFilteredRewardModel(this->getModel(), checkTask);

--- a/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
+++ b/src/storm/modelchecker/prctl/SparseMdpPrctlModelChecker.cpp
@@ -382,6 +382,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         this->getModel().getBackwardTransitions(), rewardModel.get(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(),
         checkTask.isProduceSchedulersSet(), checkTask.getHint());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
+    result->asExplicitQuantitativeCheckResult<SolutionType>().setBounds(std::move(ret.solutionBounds));
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }
@@ -401,6 +402,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         this->getModel().getBackwardTransitions(), subResult.getTruthValuesVector(), checkTask.isQualitativeSet(), checkTask.isProduceSchedulersSet(),
         checkTask.getHint());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
+    result->asExplicitQuantitativeCheckResult<SolutionType>().setBounds(std::move(ret.solutionBounds));
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }
@@ -417,6 +419,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         env, storm::solver::SolveGoal<ValueType, SolutionType>(this->getModel(), checkTask), this->getModel().getTransitionMatrix(),
         this->getModel().getBackwardTransitions(), rewardModel.get(), checkTask.isQualitativeSet(), checkTask.isProduceSchedulersSet(), checkTask.getHint());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
+    result->asExplicitQuantitativeCheckResult<SolutionType>().setBounds(std::move(ret.solutionBounds));
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }
@@ -448,6 +451,7 @@ std::unique_ptr<CheckResult> SparseMdpPrctlModelChecker<SparseMdpModelType>::com
         this->getModel().getBackwardTransitions(), rewardModel.get(), checkTask.isQualitativeSet(), checkTask.isProduceSchedulersSet(), discountFactor,
         checkTask.getHint());
     std::unique_ptr<CheckResult> result(new ExplicitQuantitativeCheckResult<SolutionType>(std::move(ret.values)));
+    result->asExplicitQuantitativeCheckResult<SolutionType>().setBounds(std::move(ret.solutionBounds));
     if (checkTask.isProduceSchedulersSet() && ret.scheduler) {
         result->asExplicitQuantitativeCheckResult<SolutionType>().setScheduler(std::move(ret.scheduler));
     }

--- a/src/storm/modelchecker/prctl/helper/DTMCModelCheckingHelperReturnType.h
+++ b/src/storm/modelchecker/prctl/helper/DTMCModelCheckingHelperReturnType.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "storm/solver/SolutionBounds.h"
+
+namespace storm {
+namespace modelchecker {
+namespace helper {
+
+/*!
+ * The outcome of a quantitative model checking query on a sparse DTMC. Unlike its MDP counterpart it carries no
+ * scheduler, as a DTMC has no nondeterminism to resolve.
+ */
+template<typename ValueType>
+struct DTMCSparseModelCheckingHelperReturnType {
+    DTMCSparseModelCheckingHelperReturnType(DTMCSparseModelCheckingHelperReturnType const&) = delete;
+    DTMCSparseModelCheckingHelperReturnType(DTMCSparseModelCheckingHelperReturnType&&) = default;
+    DTMCSparseModelCheckingHelperReturnType& operator=(DTMCSparseModelCheckingHelperReturnType&&) = default;
+
+    explicit DTMCSparseModelCheckingHelperReturnType(std::vector<ValueType>&& values) : values(std::move(values)) {
+        // Intentionally left empty.
+    }
+
+    virtual ~DTMCSparseModelCheckingHelperReturnType() {
+        // Intentionally left empty.
+    }
+
+    // The values computed for the states.
+    std::vector<ValueType> values;
+
+    // Sound bounds on the values, if the algorithm that computed them provided any.
+    storm::solver::SolutionBounds<ValueType> solutionBounds;
+};
+
+}  // namespace helper
+}  // namespace modelchecker
+}  // namespace storm

--- a/src/storm/modelchecker/prctl/helper/DTMCModelCheckingHelperReturnType.h
+++ b/src/storm/modelchecker/prctl/helper/DTMCModelCheckingHelperReturnType.h
@@ -30,7 +30,6 @@ struct DTMCSparseModelCheckingHelperReturnType {
     // The values computed for the states.
     std::vector<ValueType> values;
 
-    // Sound bounds on the values, if the algorithm that computed them provided any.
     storm::solver::SolutionBounds<ValueType> solutionBounds;
 };
 

--- a/src/storm/modelchecker/prctl/helper/DeterministicModelCheckingHelperReturnType.h
+++ b/src/storm/modelchecker/prctl/helper/DeterministicModelCheckingHelperReturnType.h
@@ -30,7 +30,6 @@ struct DeterministicSparseModelCheckingHelperReturnType {
     // The values computed for the states.
     std::vector<ValueType> values;
 
-    // Sound bounds on the values, if the algorithm that computed them provided any.
     storm::solver::SolutionBounds<ValueType> solutionBounds;
 };
 

--- a/src/storm/modelchecker/prctl/helper/DeterministicModelCheckingHelperReturnType.h
+++ b/src/storm/modelchecker/prctl/helper/DeterministicModelCheckingHelperReturnType.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "storm/solver/SolutionBounds.h"
+
+namespace storm {
+namespace modelchecker {
+namespace helper {
+
+/*!
+ * The outcome of a quantitative model checking query on a sparse deterministic model, i.e. a DTMC or a CTMC.
+ * Unlike its MDP counterpart it carries no scheduler, as such a model has no nondeterminism to resolve.
+ */
+template<typename ValueType>
+struct DeterministicSparseModelCheckingHelperReturnType {
+    DeterministicSparseModelCheckingHelperReturnType(DeterministicSparseModelCheckingHelperReturnType const&) = delete;
+    DeterministicSparseModelCheckingHelperReturnType(DeterministicSparseModelCheckingHelperReturnType&&) = default;
+    DeterministicSparseModelCheckingHelperReturnType& operator=(DeterministicSparseModelCheckingHelperReturnType&&) = default;
+
+    explicit DeterministicSparseModelCheckingHelperReturnType(std::vector<ValueType>&& values) : values(std::move(values)) {
+        // Intentionally left empty.
+    }
+
+    virtual ~DeterministicSparseModelCheckingHelperReturnType() {
+        // Intentionally left empty.
+    }
+
+    // The values computed for the states.
+    std::vector<ValueType> values;
+
+    // Sound bounds on the values, if the algorithm that computed them provided any.
+    storm::solver::SolutionBounds<ValueType> solutionBounds;
+};
+
+}  // namespace helper
+}  // namespace modelchecker
+}  // namespace storm

--- a/src/storm/modelchecker/prctl/helper/MDPModelCheckingHelperReturnType.h
+++ b/src/storm/modelchecker/prctl/helper/MDPModelCheckingHelperReturnType.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+#include "storm/solver/SolutionBounds.h"
 #include "storm/storage/Scheduler.h"
 
 namespace storm {
@@ -30,6 +31,11 @@ struct MDPSparseModelCheckingHelperReturnType {
 
     // A scheduler, if it was computed.
     std::unique_ptr<storm::storage::Scheduler<ValueType>> scheduler;
+
+    // Sound bounds on the values, if the algorithm that computed them provided any. These are bounds on the
+    // values, so they are expressed in the same type as those: a bound on a reward that may be infinite has to
+    // be able to say so.
+    storm::solver::SolutionBounds<ValuesType> solutionBounds;
 };
 }  // namespace helper
 

--- a/src/storm/modelchecker/prctl/helper/MDPModelCheckingHelperReturnType.h
+++ b/src/storm/modelchecker/prctl/helper/MDPModelCheckingHelperReturnType.h
@@ -32,9 +32,6 @@ struct MDPSparseModelCheckingHelperReturnType {
     // A scheduler, if it was computed.
     std::unique_ptr<storm::storage::Scheduler<ValueType>> scheduler;
 
-    // Sound bounds on the values, if the algorithm that computed them provided any. These are bounds on the
-    // values, so they are expressed in the same type as those: a bound on a reward that may be infinite has to
-    // be able to say so.
     storm::solver::SolutionBounds<ValuesType> solutionBounds;
 };
 }  // namespace helper

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -163,8 +163,7 @@ std::vector<SolutionType> computeRobustValuesForMaybeStates(Environment const& e
     // Solve the corresponding system of equations.
     solver->solveEquations(env, x, b);
 
-    // This goes through the same MinMax solvers the MDP helper uses, so it gets the same bounds out of them. Note
-    // that the solver may well know only one of the two, e.g. value iteration that certified a single direction.
+    // This goes through the same MinMax solvers the MDP helper uses, so it gets the same bounds out of them.
     if (solver->hasSolutionLowerBounds()) {
         solutionBounds.lower = solver->getSolutionLowerBounds();
     }
@@ -304,8 +303,7 @@ DeterministicSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHe
             }
         }
     }
-    // Where the graph analysis settled every state there was no equation system to solve, so the values are
-    // exactly the ones it determined and each of them bounds itself from either side.
+    // With no maybe states nothing was solved, so the values are exact and bound themselves.
     if (maybeStates.empty()) {
         solutionBounds.lower = result;
         solutionBounds.upper = result;
@@ -685,8 +683,7 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabi
                 storm::solver::SolutionBounds<SolutionType> boundsForMaybeStates;
                 std::vector<SolutionType> x = computeRobustValuesForMaybeStates(env, std::move(goal), std::move(submatrix), b, true, boundsForMaybeStates);
 
-                // Outside of the maybe states the reward is exactly zero or exactly infinity, so the entries that
-                // result already holds bound those states from both sides.
+                // The copy of result supplies the exact values outside the maybe states.
                 auto embedBound = [&result, &maybeStates](std::vector<SolutionType> const& boundForMaybeStates) {
                     std::vector<ExtendedSolutionType> bound(result);
                     storm::utility::vector::setVectorValues(bound, maybeStates, boundForMaybeStates);
@@ -753,9 +750,7 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabi
                 // Now solve the resulting equation system.
                 solver->solveEquations(env, x, b);
 
-                // Outside of the maybe states the reward is exactly zero or exactly infinity, so the entries that
-                // result already holds bound those states from both sides. Note that the solver may well know
-                // only one of the two bounds, e.g. optimistic value iteration that did not converge.
+                // The copy of result supplies the exact values outside the maybe states.
                 auto embedBound = [&result, &maybeStates](std::vector<ValueType> const& boundForMaybeStates) {
                     std::vector<ExtendedSolutionType> bound(result);
                     storm::utility::vector::setVectorValues(bound, maybeStates, boundForMaybeStates);
@@ -773,8 +768,7 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabi
             }
         }
     }
-    // Where the graph analysis settled every state there was no equation system to solve, so the values are
-    // exactly the ones it determined and each of them bounds itself from either side.
+    // With no maybe states nothing was solved, so the values are exact and bound themselves.
     if (maybeStates.empty()) {
         solutionBounds.lower = result;
         solutionBounds.upper = result;
@@ -1017,8 +1011,6 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeConditio
                     newRelevantValues = transformedModel.getNewRelevantStates();
                 }
                 goal.setRelevantValues(std::move(newRelevantValues));
-                // The Baier transformation rewrites the model, so any bounds the solver produced are bounds on the
-                // transformed states. Carrying them back is not implemented, so only the values are taken here.
                 std::vector<ExtendedSolutionType> conditionalRewards =
                     computeReachabilityRewards(env, std::move(goal), newTransitionMatrix, newTransitionMatrix.transpose(), transformedModel.stateRewards.get(),
                                                transformedModel.targetStates.get(), qualitative)

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -133,7 +133,7 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
 template<typename ValueType, typename SolutionType>
 std::vector<SolutionType> computeRobustValuesForMaybeStates(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                             storm::storage::SparseMatrix<ValueType>&& submatrix, std::vector<ValueType> const& b,
-                                                            bool computeReward) {
+                                                            bool computeReward, storm::solver::SolutionBounds<SolutionType>& solutionBounds) {
     // Initialize the solution vector.
     std::vector<SolutionType> x = std::vector<SolutionType>(submatrix.getRowGroupCount(), storm::utility::zero<SolutionType>());
 
@@ -162,6 +162,15 @@ std::vector<SolutionType> computeRobustValuesForMaybeStates(Environment const& e
 
     // Solve the corresponding system of equations.
     solver->solveEquations(env, x, b);
+
+    // This goes through the same MinMax solvers the MDP helper uses, so it gets the same bounds out of them. Note
+    // that the solver may well know only one of the two, e.g. value iteration that certified a single direction.
+    if (solver->hasSolutionLowerBounds()) {
+        solutionBounds.lower = solver->getSolutionLowerBounds();
+    }
+    if (solver->hasSolutionUpperBounds()) {
+        solutionBounds.upper = solver->getSolutionUpperBounds();
+    }
 
     return x;
 }
@@ -235,7 +244,8 @@ DeterministicSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHe
                 // the accumulated probability of going from state i to some state that has probability 1.
                 storm::utility::vector::setAllValues(b, transitionMatrix.getRowFilter(statesWithProbability1));
 
-                std::vector<SolutionType> resultForMaybeStates = computeRobustValuesForMaybeStates(env, std::move(goal), std::move(submatrix), b, false);
+                std::vector<SolutionType> resultForMaybeStates =
+                    computeRobustValuesForMaybeStates(env, std::move(goal), std::move(submatrix), b, false, solutionBounds);
 
                 // For interval models, the result for maybe states indeed also holds values for all qualitative states.
                 STORM_LOG_ASSERT(resultForMaybeStates.size() == transitionMatrix.getColumnCount(), "Dimensions do not match.");
@@ -672,7 +682,22 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabi
                 std::vector<ValueType> b = totalStateRewardVectorGetter(submatrix.getRowCount(), transitionMatrix, maybeStates);
 
                 // Compute values for maybe states.
-                std::vector<SolutionType> x = computeRobustValuesForMaybeStates(env, std::move(goal), std::move(submatrix), b, true);
+                storm::solver::SolutionBounds<SolutionType> boundsForMaybeStates;
+                std::vector<SolutionType> x = computeRobustValuesForMaybeStates(env, std::move(goal), std::move(submatrix), b, true, boundsForMaybeStates);
+
+                // Outside of the maybe states the reward is exactly zero or exactly infinity, so the entries that
+                // result already holds bound those states from both sides.
+                auto embedBound = [&result, &maybeStates](std::vector<SolutionType> const& boundForMaybeStates) {
+                    std::vector<ExtendedSolutionType> bound(result);
+                    storm::utility::vector::setVectorValues(bound, maybeStates, boundForMaybeStates);
+                    return bound;
+                };
+                if (boundsForMaybeStates.hasLower()) {
+                    solutionBounds.lower = embedBound(*boundsForMaybeStates.lower);
+                }
+                if (boundsForMaybeStates.hasUpper()) {
+                    solutionBounds.upper = embedBound(*boundsForMaybeStates.upper);
+                }
 
                 // Set values of resulting vector according to result.
                 storm::utility::vector::setVectorValues(result, maybeStates, x);

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -167,7 +167,7 @@ std::vector<SolutionType> computeRobustValuesForMaybeStates(Environment const& e
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-DTMCSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
+DeterministicSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
     bool qualitative, ModelCheckerHint const& hint) {
@@ -294,7 +294,7 @@ DTMCSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<Valu
             }
         }
     }
-    DTMCSparseModelCheckingHelperReturnType<SolutionType> returnValue(std::move(result));
+    DeterministicSparseModelCheckingHelperReturnType<SolutionType> returnValue(std::move(result));
     returnValue.solutionBounds = std::move(solutionBounds);
     return returnValue;
 }
@@ -367,14 +367,14 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-DTMCSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
+DeterministicSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& psiStates, bool qualitative) {
     if constexpr (storm::IsIntervalType<ValueType>) {
         STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "We do not support computing globally probabilities with interval models.");
     } else {
         goal.oneMinus();
-        DTMCSparseModelCheckingHelperReturnType<SolutionType> returnValue =
+        DeterministicSparseModelCheckingHelperReturnType<SolutionType> returnValue =
             computeUntilProbabilities(env, std::move(goal), transitionMatrix, backwardTransitions,
                                       storm::storage::BitVector(transitionMatrix.getRowCount(), true), ~psiStates, qualitative);
         for (auto& entry : returnValue.values) {
@@ -455,7 +455,7 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-DTMCSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
+DeterministicSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
 SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeTotalRewards(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel, bool qualitative, ModelCheckerHint const& hint) {
@@ -538,7 +538,7 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-DTMCSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
+DeterministicSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
 SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel, storm::storage::BitVector const& targetStates,
@@ -552,7 +552,7 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabi
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-DTMCSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
+DeterministicSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
 SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, std::vector<ValueType> const& totalStateRewardVector,
@@ -568,7 +568,7 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabi
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-DTMCSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
+DeterministicSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
 SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabilityTimes(Environment const& env,
                                                                                           storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                                           storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
@@ -608,7 +608,7 @@ std::vector<storm::RationalFunction> computeUpperRewardBounds(storm::storage::Sp
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-DTMCSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
+DeterministicSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
 SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
@@ -742,7 +742,7 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabi
             }
         }
     }
-    DTMCSparseModelCheckingHelperReturnType<ExtendedSolutionType> returnValue(std::move(result));
+    DeterministicSparseModelCheckingHelperReturnType<ExtendedSolutionType> returnValue(std::move(result));
     returnValue.solutionBounds = std::move(solutionBounds);
     return returnValue;
 }

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -294,6 +294,12 @@ DeterministicSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHe
             }
         }
     }
+    // Where the graph analysis settled every state there was no equation system to solve, so the values are
+    // exactly the ones it determined and each of them bounds itself from either side.
+    if (maybeStates.empty()) {
+        solutionBounds.lower = result;
+        solutionBounds.upper = result;
+    }
     DeterministicSparseModelCheckingHelperReturnType<SolutionType> returnValue(std::move(result));
     returnValue.solutionBounds = std::move(solutionBounds);
     return returnValue;
@@ -741,6 +747,12 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabi
                 storm::utility::vector::setVectorValues(result, maybeStates, x);
             }
         }
+    }
+    // Where the graph analysis settled every state there was no equation system to solve, so the values are
+    // exactly the ones it determined and each of them bounds itself from either side.
+    if (maybeStates.empty()) {
+        solutionBounds.lower = result;
+        solutionBounds.upper = result;
     }
     DeterministicSparseModelCheckingHelperReturnType<ExtendedSolutionType> returnValue(std::move(result));
     returnValue.solutionBounds = std::move(solutionBounds);

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -276,9 +276,7 @@ DTMCSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<Valu
                 solver->setBounds(storm::utility::zero<ValueType>(), storm::utility::one<ValueType>());
                 solver->solveEquations(env, x, b);
 
-                // Outside of the maybe states the probability is exactly zero or one, so the entries that
-                // result already holds bound those states from both sides. Note that the solver may well know
-                // only one of the two bounds, e.g. optimistic value iteration that did not converge.
+                // The copy of result supplies the exact values outside the maybe states.
                 auto embedBound = [&result, &maybeStates](std::vector<SolutionType> const& boundForMaybeStates) {
                     std::vector<SolutionType> bound(result);
                     storm::utility::vector::setVectorValues<SolutionType>(bound, maybeStates, boundForMaybeStates);
@@ -382,8 +380,7 @@ DTMCSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<Valu
         for (auto& entry : returnValue.values) {
             entry = storm::utility::one<SolutionType>() - entry;
         }
-        // One minus is antitone, so the complement of the lower bound bounds the result from above and vice
-        // versa. In particular, knowing only one side before means knowing only the other side afterwards.
+        // Inverse the bounds, lb = 1 - ub and ub = 1 - lb.
         auto& bounds = returnValue.solutionBounds;
         for (auto* bound : {&bounds.lower, &bounds.upper}) {
             if (*bound) {

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -166,10 +166,11 @@ std::vector<SolutionType> computeRobustValuesForMaybeStates(Environment const& e
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
+DTMCSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-    bool qualitative, ModelCheckerHint const& hint, storm::solver::SolutionBounds<SolutionType>* solutionBounds) {
+    bool qualitative, ModelCheckerHint const& hint) {
+    storm::solver::SolutionBounds<SolutionType> solutionBounds;
     std::vector<SolutionType> result(transitionMatrix.getRowCount(), storm::utility::zero<SolutionType>());
 
     // We need to identify the maybe states (states which have a probability for satisfying the until formula
@@ -274,13 +275,19 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
                 solver->setBounds(storm::utility::zero<ValueType>(), storm::utility::one<ValueType>());
                 solver->solveEquations(env, x, b);
 
-                if (solutionBounds != nullptr && solver->hasSolutionBounds()) {
-                    // Outside of the maybe states the probability is exactly zero or one, so the entries that
-                    // result already holds bound those states from both sides.
-                    std::vector<SolutionType> lower(result), upper(result);
-                    storm::utility::vector::setVectorValues<SolutionType>(lower, maybeStates, solver->getSolutionLowerBounds());
-                    storm::utility::vector::setVectorValues<SolutionType>(upper, maybeStates, solver->getSolutionUpperBounds());
-                    *solutionBounds = std::make_pair(std::move(lower), std::move(upper));
+                // Outside of the maybe states the probability is exactly zero or one, so the entries that
+                // result already holds bound those states from both sides. Note that the solver may well know
+                // only one of the two bounds, e.g. optimistic value iteration that did not converge.
+                auto embedBound = [&result, &maybeStates](std::vector<SolutionType> const& boundForMaybeStates) {
+                    std::vector<SolutionType> bound(result);
+                    storm::utility::vector::setVectorValues<SolutionType>(bound, maybeStates, boundForMaybeStates);
+                    return bound;
+                };
+                if (solver->hasSolutionLowerBounds()) {
+                    solutionBounds.lower = embedBound(solver->getSolutionLowerBounds());
+                }
+                if (solver->hasSolutionUpperBounds()) {
+                    solutionBounds.upper = embedBound(solver->getSolutionUpperBounds());
                 }
 
                 // Set values of resulting vector according to result.
@@ -288,7 +295,9 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
             }
         }
     }
-    return result;
+    DTMCSparseModelCheckingHelperReturnType<SolutionType> returnValue(std::move(result));
+    returnValue.solutionBounds = std::move(solutionBounds);
+    return returnValue;
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
@@ -359,32 +368,31 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
+DTMCSparseModelCheckingHelperReturnType<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& psiStates, bool qualitative,
-    storm::solver::SolutionBounds<SolutionType>* solutionBounds) {
+    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& psiStates, bool qualitative) {
     if constexpr (storm::IsIntervalType<ValueType>) {
         STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "We do not support computing globally probabilities with interval models.");
     } else {
         goal.oneMinus();
-        std::vector<SolutionType> result = computeUntilProbabilities(env, std::move(goal), transitionMatrix, backwardTransitions,
-                                                                     storm::storage::BitVector(transitionMatrix.getRowCount(), true), ~psiStates, qualitative,
-                                                                     ModelCheckerHint(), solutionBounds);
-        for (auto& entry : result) {
+        DTMCSparseModelCheckingHelperReturnType<SolutionType> returnValue =
+            computeUntilProbabilities(env, std::move(goal), transitionMatrix, backwardTransitions,
+                                      storm::storage::BitVector(transitionMatrix.getRowCount(), true), ~psiStates, qualitative);
+        for (auto& entry : returnValue.values) {
             entry = storm::utility::one<SolutionType>() - entry;
         }
-        if (solutionBounds != nullptr && *solutionBounds) {
-            // One minus is antitone, so the complement of the lower bound bounds the result from above.
-            auto& bounds = **solutionBounds;
-            for (auto& entry : bounds.first) {
-                entry = storm::utility::one<SolutionType>() - entry;
+        // One minus is antitone, so the complement of the lower bound bounds the result from above and vice
+        // versa. In particular, knowing only one side before means knowing only the other side afterwards.
+        auto& bounds = returnValue.solutionBounds;
+        for (auto* bound : {&bounds.lower, &bounds.upper}) {
+            if (*bound) {
+                for (auto& entry : **bound) {
+                    entry = storm::utility::one<SolutionType>() - entry;
+                }
             }
-            for (auto& entry : bounds.second) {
-                entry = storm::utility::one<SolutionType>() - entry;
-            }
-            std::swap(bounds.first, bounds.second);
         }
-        return result;
+        std::swap(bounds.lower, bounds.upper);
+        return returnValue;
     }
 }
 
@@ -738,8 +746,9 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeBaierTra
 
         // Start by computing all 'before' states, i.e. the states for which the conditional probability is defined.
         std::vector<ValueType> probabilitiesToReachConditionStates =
-            computeUntilProbabilities(env, storm::solver::SolveGoal<ValueType>(), transitionMatrix, backwardTransitions,
-                                      storm::storage::BitVector(transitionMatrix.getRowCount(), true), conditionStates, false);
+            std::move(computeUntilProbabilities(env, storm::solver::SolveGoal<ValueType>(), transitionMatrix, backwardTransitions,
+                                                storm::storage::BitVector(transitionMatrix.getRowCount(), true), conditionStates, false)
+                          .values);
 
         result.beforeStates = storm::storage::BitVector(targetStates.size(), true);
         uint_fast64_t state = 0;
@@ -909,9 +918,11 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeConditio
                     newRelevantValues = transformedModel.getNewRelevantStates();
                 }
                 goal.setRelevantValues(std::move(newRelevantValues));
-                std::vector<ValueType> conditionalProbabilities = computeUntilProbabilities(
-                    env, std::move(goal), newTransitionMatrix, newTransitionMatrix.transpose(),
-                    storm::storage::BitVector(newTransitionMatrix.getRowCount(), true), transformedModel.targetStates.get(), qualitative);
+                std::vector<ValueType> conditionalProbabilities =
+                    std::move(computeUntilProbabilities(env, std::move(goal), newTransitionMatrix, newTransitionMatrix.transpose(),
+                                                        storm::storage::BitVector(newTransitionMatrix.getRowCount(), true), transformedModel.targetStates.get(),
+                                                        qualitative)
+                                  .values);
 
                 storm::utility::vector::setVectorValues(result, transformedModel.beforeStates, conditionalProbabilities);
             }

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -455,7 +455,7 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-std::vector<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
+DTMCSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
 SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeTotalRewards(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel, bool qualitative, ModelCheckerHint const& hint) {
@@ -538,7 +538,7 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-std::vector<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
+DTMCSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
 SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel, storm::storage::BitVector const& targetStates,
@@ -552,7 +552,7 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabi
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-std::vector<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
+DTMCSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
 SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, std::vector<ValueType> const& totalStateRewardVector,
@@ -568,7 +568,7 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabi
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-std::vector<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
+DTMCSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
 SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabilityTimes(Environment const& env,
                                                                                           storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                                           storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
@@ -608,7 +608,7 @@ std::vector<storm::RationalFunction> computeUpperRewardBounds(storm::storage::Sp
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-std::vector<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
+DTMCSparseModelCheckingHelperReturnType<typename SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::ExtendedSolutionType>
 SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabilityRewards(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
@@ -617,6 +617,7 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabi
     storm::storage::BitVector const& targetStates, bool qualitative, std::function<storm::storage::BitVector()> const& zeroRewardStatesGetter,
     ModelCheckerHint const& hint) {
     std::vector<ExtendedSolutionType> result(transitionMatrix.getRowCount(), storm::utility::zero<ExtendedSolutionType>());
+    storm::solver::SolutionBounds<ExtendedSolutionType> solutionBounds;
 
     // Determine which states have reward zero
     storm::storage::BitVector rew0States;
@@ -721,12 +722,29 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeReachabi
                 // Now solve the resulting equation system.
                 solver->solveEquations(env, x, b);
 
+                // Outside of the maybe states the reward is exactly zero or exactly infinity, so the entries that
+                // result already holds bound those states from both sides. Note that the solver may well know
+                // only one of the two bounds, e.g. optimistic value iteration that did not converge.
+                auto embedBound = [&result, &maybeStates](std::vector<ValueType> const& boundForMaybeStates) {
+                    std::vector<ExtendedSolutionType> bound(result);
+                    storm::utility::vector::setVectorValues(bound, maybeStates, boundForMaybeStates);
+                    return bound;
+                };
+                if (solver->hasSolutionLowerBounds()) {
+                    solutionBounds.lower = embedBound(solver->getSolutionLowerBounds());
+                }
+                if (solver->hasSolutionUpperBounds()) {
+                    solutionBounds.upper = embedBound(solver->getSolutionUpperBounds());
+                }
+
                 // Set values of resulting vector according to result.
                 storm::utility::vector::setVectorValues(result, maybeStates, x);
             }
         }
     }
-    return result;
+    DTMCSparseModelCheckingHelperReturnType<ExtendedSolutionType> returnValue(std::move(result));
+    returnValue.solutionBounds = std::move(solutionBounds);
+    return returnValue;
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
@@ -962,9 +980,12 @@ SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeConditio
                     newRelevantValues = transformedModel.getNewRelevantStates();
                 }
                 goal.setRelevantValues(std::move(newRelevantValues));
+                // The Baier transformation rewrites the model, so any bounds the solver produced are bounds on the
+                // transformed states. Carrying them back is not implemented, so only the values are taken here.
                 std::vector<ExtendedSolutionType> conditionalRewards =
                     computeReachabilityRewards(env, std::move(goal), newTransitionMatrix, newTransitionMatrix.transpose(), transformedModel.stateRewards.get(),
-                                               transformedModel.targetStates.get(), qualitative);
+                                               transformedModel.targetStates.get(), qualitative)
+                        .values;
                 storm::utility::vector::setVectorValues(result, transformedModel.beforeStates, conditionalRewards);
             }
         }

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -169,7 +169,7 @@ template<typename ValueType, typename RewardModelType, typename SolutionType>
 std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeUntilProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
     storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-    bool qualitative, ModelCheckerHint const& hint) {
+    bool qualitative, ModelCheckerHint const& hint, storm::solver::SolutionBounds<SolutionType>* solutionBounds) {
     std::vector<SolutionType> result(transitionMatrix.getRowCount(), storm::utility::zero<SolutionType>());
 
     // We need to identify the maybe states (states which have a probability for satisfying the until formula
@@ -274,6 +274,15 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
                 solver->setBounds(storm::utility::zero<ValueType>(), storm::utility::one<ValueType>());
                 solver->solveEquations(env, x, b);
 
+                if (solutionBounds != nullptr && solver->hasSolutionBounds()) {
+                    // Outside of the maybe states the probability is exactly zero or one, so the entries that
+                    // result already holds bound those states from both sides.
+                    std::vector<SolutionType> lower(result), upper(result);
+                    storm::utility::vector::setVectorValues<SolutionType>(lower, maybeStates, solver->getSolutionLowerBounds());
+                    storm::utility::vector::setVectorValues<SolutionType>(upper, maybeStates, solver->getSolutionUpperBounds());
+                    *solutionBounds = std::make_pair(std::move(lower), std::move(upper));
+                }
+
                 // Set values of resulting vector according to result.
                 storm::utility::vector::setVectorValues(result, maybeStates, x);
             }
@@ -352,15 +361,28 @@ std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, Solu
 template<typename ValueType, typename RewardModelType, typename SolutionType>
 std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeGloballyProbabilities(
     Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& psiStates, bool qualitative) {
+    storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& psiStates, bool qualitative,
+    storm::solver::SolutionBounds<SolutionType>* solutionBounds) {
     if constexpr (storm::IsIntervalType<ValueType>) {
         STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "We do not support computing globally probabilities with interval models.");
     } else {
         goal.oneMinus();
         std::vector<SolutionType> result = computeUntilProbabilities(env, std::move(goal), transitionMatrix, backwardTransitions,
-                                                                     storm::storage::BitVector(transitionMatrix.getRowCount(), true), ~psiStates, qualitative);
+                                                                     storm::storage::BitVector(transitionMatrix.getRowCount(), true), ~psiStates, qualitative,
+                                                                     ModelCheckerHint(), solutionBounds);
         for (auto& entry : result) {
             entry = storm::utility::one<SolutionType>() - entry;
+        }
+        if (solutionBounds != nullptr && *solutionBounds) {
+            // One minus is antitone, so the complement of the lower bound bounds the result from above.
+            auto& bounds = **solutionBounds;
+            for (auto& entry : bounds.first) {
+                entry = storm::utility::one<SolutionType>() - entry;
+            }
+            for (auto& entry : bounds.second) {
+                entry = storm::utility::one<SolutionType>() - entry;
+            }
+            std::swap(bounds.first, bounds.second);
         }
         return result;
     }

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp
@@ -31,15 +31,15 @@ namespace modelchecker {
 namespace helper {
 
 template<>
-std::map<storm::storage::sparse::state_type, storm::RationalFunction> SparseDtmcPrctlHelper<storm::RationalFunction>::computeRewardBoundedValues(
+std::vector<storm::RationalFunction> SparseDtmcPrctlHelper<storm::RationalFunction>::computeRewardBoundedValues(
     Environment const& /*env*/, storm::models::sparse::Dtmc<storm::RationalFunction> const& /*model*/,
     std::shared_ptr<storm::logic::OperatorFormula const> /*rewardBoundedFormula*/) {
     STORM_LOG_THROW(false, storm::exceptions::NotSupportedException, "The specified property is not supported by this value type.");
-    return std::map<storm::storage::sparse::state_type, storm::RationalFunction>();
+    return std::vector<storm::RationalFunction>();
 }
 
 template<typename ValueType, typename RewardModelType, typename SolutionType>
-std::map<storm::storage::sparse::state_type, SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeRewardBoundedValues(
+std::vector<SolutionType> SparseDtmcPrctlHelper<ValueType, RewardModelType, SolutionType>::computeRewardBoundedValues(
     Environment const& env, storm::models::sparse::Dtmc<ValueType> const& model, std::shared_ptr<storm::logic::OperatorFormula const> rewardBoundedFormula) {
     if constexpr (storm::IsIntervalType<ValueType>) {
         STORM_LOG_THROW(false, storm::exceptions::NotImplementedException, "We do not support computing reward bounded values with interval models.");
@@ -100,9 +100,10 @@ std::map<storm::storage::sparse::state_type, SolutionType> SparseDtmcPrctlHelper
             }
         }
 
-        std::map<storm::storage::sparse::state_type, ValueType> result;
+        std::vector<ValueType> result;
+        result.reserve(model.getInitialStates().getNumberOfSetBits());
         for (auto initState : model.getInitialStates()) {
-            result[initState] = rewardUnfolding.getInitialStateResult(initEpoch, initState);
+            result.push_back(rewardUnfolding.getInitialStateResult(initEpoch, initState));
         }
 
         swAll.stop();

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
@@ -67,11 +67,12 @@ class SparseDtmcPrctlHelper {
                                                                  storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                  RewardModelType const& rewardModel, uint_fast64_t stepCount);
 
-    static std::vector<ExtendedSolutionType> computeTotalRewards(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
-                                                                 storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                                 storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                 RewardModelType const& rewardModel, bool qualitative,
-                                                                 ModelCheckerHint const& hint = ModelCheckerHint());
+    static DTMCSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeTotalRewards(Environment const& env,
+                                                                                             storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
+                                                                                             storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+                                                                                             storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
+                                                                                             RewardModelType const& rewardModel, bool qualitative,
+                                                                                             ModelCheckerHint const& hint = ModelCheckerHint());
 
     static std::vector<SolutionType> computeDiscountedCumulativeRewards(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                         storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
@@ -83,24 +84,20 @@ class SparseDtmcPrctlHelper {
                                                                    RewardModelType const& rewardModel, bool qualitative, ValueType discountFactor,
                                                                    ModelCheckerHint const& hint = ModelCheckerHint());
 
-    static std::vector<ExtendedSolutionType> computeReachabilityRewards(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
-                                                                        storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                                        storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                        RewardModelType const& rewardModel, storm::storage::BitVector const& targetStates,
-                                                                        bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint());
+    static DTMCSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeReachabilityRewards(
+        Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+        storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel, storm::storage::BitVector const& targetStates,
+        bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint());
 
-    static std::vector<ExtendedSolutionType> computeReachabilityRewards(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
-                                                                        storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                                        storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                        std::vector<ValueType> const& totalStateRewardVector,
-                                                                        storm::storage::BitVector const& targetStates, bool qualitative,
-                                                                        ModelCheckerHint const& hint = ModelCheckerHint());
+    static DTMCSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeReachabilityRewards(
+        Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+        storm::storage::SparseMatrix<ValueType> const& backwardTransitions, std::vector<ValueType> const& totalStateRewardVector,
+        storm::storage::BitVector const& targetStates, bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint());
 
-    static std::vector<ExtendedSolutionType> computeReachabilityTimes(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
-                                                                      storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                                      storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                      storm::storage::BitVector const& targetStates, bool qualitative,
-                                                                      ModelCheckerHint const& hint = ModelCheckerHint());
+    static DTMCSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeReachabilityTimes(
+        Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+        storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& targetStates, bool qualitative,
+        ModelCheckerHint const& hint = ModelCheckerHint());
 
     static std::vector<ExtendedSolutionType> computeConditionalProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                              storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
@@ -115,7 +112,7 @@ class SparseDtmcPrctlHelper {
                                                                        storm::storage::BitVector const& conditionStates, bool qualitative);
 
    private:
-    static std::vector<ExtendedSolutionType> computeReachabilityRewards(
+    static DTMCSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeReachabilityRewards(
         Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
         storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
         std::function<std::vector<ValueType>(uint_fast64_t, storm::storage::SparseMatrix<ValueType> const&, storm::storage::BitVector const&)> const&

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
@@ -30,8 +30,11 @@ class SparseDtmcPrctlHelper {
    public:
     using ExtendedSolutionType = storm::utility::ExtendedValueType<SolutionType>;
 
-    static std::map<storm::storage::sparse::state_type, SolutionType> computeRewardBoundedValues(
-        Environment const& env, storm::models::sparse::Dtmc<ValueType> const& model, std::shared_ptr<storm::logic::OperatorFormula const> rewardBoundedFormula);
+    /*!
+     * @return One value per initial state of the given model, in the order of those states.
+     */
+    static std::vector<SolutionType> computeRewardBoundedValues(Environment const& env, storm::models::sparse::Dtmc<ValueType> const& model,
+                                                                std::shared_ptr<storm::logic::OperatorFormula const> rewardBoundedFormula);
 
     static std::vector<SolutionType> computeNextProbabilities(Environment const& env, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                               storm::storage::BitVector const& nextStates);

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
@@ -5,7 +5,7 @@
 #include <boost/optional.hpp>
 
 #include "storm/modelchecker/hints/ModelCheckerHint.h"
-#include "storm/modelchecker/prctl/helper/DTMCModelCheckingHelperReturnType.h"
+#include "storm/modelchecker/prctl/helper/DeterministicModelCheckingHelperReturnType.h"
 #include "storm/models/sparse/Dtmc.h"
 #include "storm/models/sparse/StandardRewardModel.h"
 
@@ -42,7 +42,7 @@ class SparseDtmcPrctlHelper {
     /*!
      * @return The probabilities, together with sound bounds on them if the equation solver provided any.
      */
-    static DTMCSparseModelCheckingHelperReturnType<SolutionType> computeUntilProbabilities(
+    static DeterministicSparseModelCheckingHelperReturnType<SolutionType> computeUntilProbabilities(
         Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
         storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& phiStates,
         storm::storage::BitVector const& psiStates, bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint());
@@ -55,7 +55,7 @@ class SparseDtmcPrctlHelper {
     /*!
      * @return The probabilities, together with sound bounds on them if the equation solver provided any.
      */
-    static DTMCSparseModelCheckingHelperReturnType<SolutionType> computeGloballyProbabilities(
+    static DeterministicSparseModelCheckingHelperReturnType<SolutionType> computeGloballyProbabilities(
         Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
         storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& psiStates, bool qualitative);
 
@@ -67,12 +67,10 @@ class SparseDtmcPrctlHelper {
                                                                  storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                  RewardModelType const& rewardModel, uint_fast64_t stepCount);
 
-    static DTMCSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeTotalRewards(Environment const& env,
-                                                                                             storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
-                                                                                             storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                                                             storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                                             RewardModelType const& rewardModel, bool qualitative,
-                                                                                             ModelCheckerHint const& hint = ModelCheckerHint());
+    static DeterministicSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeTotalRewards(
+        Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+        storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel, bool qualitative,
+        ModelCheckerHint const& hint = ModelCheckerHint());
 
     static std::vector<SolutionType> computeDiscountedCumulativeRewards(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                         storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
@@ -84,17 +82,17 @@ class SparseDtmcPrctlHelper {
                                                                    RewardModelType const& rewardModel, bool qualitative, ValueType discountFactor,
                                                                    ModelCheckerHint const& hint = ModelCheckerHint());
 
-    static DTMCSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeReachabilityRewards(
+    static DeterministicSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeReachabilityRewards(
         Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
         storm::storage::SparseMatrix<ValueType> const& backwardTransitions, RewardModelType const& rewardModel, storm::storage::BitVector const& targetStates,
         bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint());
 
-    static DTMCSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeReachabilityRewards(
+    static DeterministicSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeReachabilityRewards(
         Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
         storm::storage::SparseMatrix<ValueType> const& backwardTransitions, std::vector<ValueType> const& totalStateRewardVector,
         storm::storage::BitVector const& targetStates, bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint());
 
-    static DTMCSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeReachabilityTimes(
+    static DeterministicSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeReachabilityTimes(
         Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
         storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& targetStates, bool qualitative,
         ModelCheckerHint const& hint = ModelCheckerHint());
@@ -112,7 +110,7 @@ class SparseDtmcPrctlHelper {
                                                                        storm::storage::BitVector const& conditionStates, bool qualitative);
 
    private:
-    static DTMCSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeReachabilityRewards(
+    static DeterministicSparseModelCheckingHelperReturnType<ExtendedSolutionType> computeReachabilityRewards(
         Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
         storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
         std::function<std::vector<ValueType>(uint_fast64_t, storm::storage::SparseMatrix<ValueType> const&, storm::storage::BitVector const&)> const&

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
@@ -5,6 +5,7 @@
 #include <boost/optional.hpp>
 
 #include "storm/modelchecker/hints/ModelCheckerHint.h"
+#include "storm/modelchecker/prctl/helper/DTMCModelCheckingHelperReturnType.h"
 #include "storm/models/sparse/Dtmc.h"
 #include "storm/models/sparse/StandardRewardModel.h"
 
@@ -36,26 +37,24 @@ class SparseDtmcPrctlHelper {
                                                               storm::storage::BitVector const& nextStates);
 
     /*!
-     * @param solutionBounds If given, receives sound bounds on the computed probabilities, provided that the
-     * equation solver produced any.
+     * @return The probabilities, together with sound bounds on them if the equation solver provided any.
      */
-    static std::vector<SolutionType> computeUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
-                                                               storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                               storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                               storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-                                                               bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint(),
-                                                               storm::solver::SolutionBounds<SolutionType>* solutionBounds = nullptr);
+    static DTMCSparseModelCheckingHelperReturnType<SolutionType> computeUntilProbabilities(
+        Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+        storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& phiStates,
+        storm::storage::BitVector const& psiStates, bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint());
 
     static std::vector<SolutionType> computeAllUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                   storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                   storm::storage::BitVector const& initialStates, storm::storage::BitVector const& phiStates,
                                                                   storm::storage::BitVector const& psiStates);
 
-    static std::vector<SolutionType> computeGloballyProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
-                                                                  storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
-                                                                  storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                  storm::storage::BitVector const& psiStates, bool qualitative,
-                                                                  storm::solver::SolutionBounds<SolutionType>* solutionBounds = nullptr);
+    /*!
+     * @return The probabilities, together with sound bounds on them if the equation solver provided any.
+     */
+    static DTMCSparseModelCheckingHelperReturnType<SolutionType> computeGloballyProbabilities(
+        Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
+        storm::storage::SparseMatrix<ValueType> const& backwardTransitions, storm::storage::BitVector const& psiStates, bool qualitative);
 
     static std::vector<SolutionType> computeCumulativeRewards(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                               storm::storage::SparseMatrix<ValueType> const& transitionMatrix,

--- a/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
+++ b/src/storm/modelchecker/prctl/helper/SparseDtmcPrctlHelper.h
@@ -35,11 +35,16 @@ class SparseDtmcPrctlHelper {
     static std::vector<SolutionType> computeNextProbabilities(Environment const& env, storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                               storm::storage::BitVector const& nextStates);
 
+    /*!
+     * @param solutionBounds If given, receives sound bounds on the computed probabilities, provided that the
+     * equation solver produced any.
+     */
     static std::vector<SolutionType> computeUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
                                                                storm::storage::BitVector const& phiStates, storm::storage::BitVector const& psiStates,
-                                                               bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint());
+                                                               bool qualitative, ModelCheckerHint const& hint = ModelCheckerHint(),
+                                                               storm::solver::SolutionBounds<SolutionType>* solutionBounds = nullptr);
 
     static std::vector<SolutionType> computeAllUntilProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                   storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
@@ -49,7 +54,8 @@ class SparseDtmcPrctlHelper {
     static std::vector<SolutionType> computeGloballyProbabilities(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                                   storm::storage::SparseMatrix<ValueType> const& transitionMatrix,
                                                                   storm::storage::SparseMatrix<ValueType> const& backwardTransitions,
-                                                                  storm::storage::BitVector const& psiStates, bool qualitative);
+                                                                  storm::storage::BitVector const& psiStates, bool qualitative,
+                                                                  storm::solver::SolutionBounds<SolutionType>* solutionBounds = nullptr);
 
     static std::vector<SolutionType> computeCumulativeRewards(Environment const& env, storm::solver::SolveGoal<ValueType, SolutionType>&& goal,
                                                               storm::storage::SparseMatrix<ValueType> const& transitionMatrix,

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -425,7 +425,6 @@ struct MaybeStateResult {
     std::vector<ValueType> values;
     boost::optional<std::vector<uint64_t>> scheduler;
 
-    // Sound bounds on the values, if the solver provided any.
     storm::solver::SolutionBounds<ValueType> solutionBounds;
 };
 
@@ -488,8 +487,6 @@ MaybeStateResult<SolutionType> computeValuesForMaybeStates(Environment const& en
 
     // Create result.
     MaybeStateResult<SolutionType> result(std::move(x));
-    // Note that the solver may well know only one of the two bounds, e.g. optimistic value iteration that did
-    // not converge.
     if (solver->hasSolutionLowerBounds()) {
         result.solutionBounds.lower = solver->getSolutionLowerBounds();
     }
@@ -702,7 +699,6 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
     // Prepare resulting vector.
     std::vector<SolutionType> result(transitionMatrix.getRowGroupCount(), storm::utility::zero<SolutionType>());
 
-    // Sound bounds on the result, if the solver provides any.
     storm::solver::SolutionBounds<SolutionType> resultBounds;
 
     // We need to identify the maybe states (states which have a probability for satisfying the until formula
@@ -780,8 +776,7 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
                 // Set values of resulting vector according to result.
                 if constexpr (!storm::IsIntervalType<ValueType>) {
                     // For non-interval models, we only operated on the maybe states, and we must recover the qualitative values for the other state.
-                    // Outside of the maybe states the probability is exactly zero or one, so the entries that
-                    // result already holds bound those states from both sides.
+                    // The copy of result supplies the exact values outside the maybe states.
                     auto embedBound = [&result, &qualitativeStateSets](std::vector<SolutionType> const& boundForMaybeStates) {
                         std::vector<SolutionType> bound(result);
                         storm::utility::vector::setVectorValues<SolutionType>(bound, qualitativeStateSets.maybeStates, boundForMaybeStates);
@@ -849,8 +844,7 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
         for (auto& element : result.values) {
             element = storm::utility::one<SolutionType>() - element;
         }
-        // One minus is antitone, so the complement of the lower bound bounds the result from above and vice
-        // versa. In particular, knowing only one side before means knowing only the other side afterwards.
+        // Inverse the bounds, lb = 1 - ub and ub = 1 - lb.
         auto& bounds = result.solutionBounds;
         for (auto* bound : {&bounds.lower, &bounds.upper}) {
             if (*bound) {

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -423,6 +423,9 @@ struct MaybeStateResult {
 
     std::vector<ValueType> values;
     boost::optional<std::vector<uint64_t>> scheduler;
+
+    // Sound bounds on the values, if the solver provided any.
+    storm::solver::SolutionBounds<ValueType> solutionBounds;
 };
 
 template<typename ValueType, typename SolutionType>
@@ -484,6 +487,9 @@ MaybeStateResult<SolutionType> computeValuesForMaybeStates(Environment const& en
 
     // Create result.
     MaybeStateResult<SolutionType> result(std::move(x));
+    if (solver->hasSolutionBounds()) {
+        result.solutionBounds = std::make_pair(solver->getSolutionLowerBounds(), solver->getSolutionUpperBounds());
+    }
 
     // If requested, return the requested scheduler.
     if (produceScheduler) {
@@ -690,6 +696,9 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
     // Prepare resulting vector.
     std::vector<SolutionType> result(transitionMatrix.getRowGroupCount(), storm::utility::zero<SolutionType>());
 
+    // Sound bounds on the result, if the solver provides any.
+    storm::solver::SolutionBounds<SolutionType> resultBounds;
+
     // We need to identify the maybe states (states which have a probability for satisfying the until formula
     // that is strictly between 0 and 1) and the states that satisfy the formula with probablity 1 and 0, respectively.
     QualitativeStateSetsUntilProbabilities qualitativeStateSets =
@@ -765,7 +774,17 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
                 // Set values of resulting vector according to result.
                 if constexpr (!storm::IsIntervalType<ValueType>) {
                     // For non-interval models, we only operated on the maybe states, and we must recover the qualitative values for the other state.
-                    storm::utility::vector::setVectorValues(result, qualitativeStateSets.maybeStates, resultForMaybeStates.getValues());
+                    if (resultForMaybeStates.solutionBounds) {
+                        // Outside of the maybe states the probability is exactly zero or one, so the entries
+                        // that result already holds bound those states from both sides.
+                        std::vector<SolutionType> lower(result), upper(result);
+                        storm::utility::vector::setVectorValues<SolutionType>(lower, qualitativeStateSets.maybeStates,
+                                                                              resultForMaybeStates.solutionBounds->first);
+                        storm::utility::vector::setVectorValues<SolutionType>(upper, qualitativeStateSets.maybeStates,
+                                                                              resultForMaybeStates.solutionBounds->second);
+                        resultBounds = std::make_pair(std::move(lower), std::move(upper));
+                    }
+                    storm::utility::vector::setVectorValues<SolutionType>(result, qualitativeStateSets.maybeStates, resultForMaybeStates.getValues());
                 } else {
                     // For interval models, the result for maybe states indeed also holds values for all qualitative states.
                     STORM_LOG_ASSERT(resultForMaybeStates.getValues().size() == transitionMatrix.getColumnCount(), "Dimensions do not match.");
@@ -791,7 +810,9 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
     STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isMemorylessScheduler(), "Expected a memoryless scheduler.");
 
     // Return result.
-    return MDPSparseModelCheckingHelperReturnType<SolutionType>(std::move(result), std::move(scheduler));
+    MDPSparseModelCheckingHelperReturnType<SolutionType> returnValue(std::move(result), std::move(scheduler));
+    returnValue.solutionBounds = std::move(resultBounds);
+    return returnValue;
 }
 
 template<typename ValueType, typename SolutionType>

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -487,8 +487,13 @@ MaybeStateResult<SolutionType> computeValuesForMaybeStates(Environment const& en
 
     // Create result.
     MaybeStateResult<SolutionType> result(std::move(x));
-    if (solver->hasSolutionBounds()) {
-        result.solutionBounds = std::make_pair(solver->getSolutionLowerBounds(), solver->getSolutionUpperBounds());
+    // Note that the solver may well know only one of the two bounds, e.g. optimistic value iteration that did
+    // not converge.
+    if (solver->hasSolutionLowerBounds()) {
+        result.solutionBounds.lower = solver->getSolutionLowerBounds();
+    }
+    if (solver->hasSolutionUpperBounds()) {
+        result.solutionBounds.upper = solver->getSolutionUpperBounds();
     }
 
     // If requested, return the requested scheduler.
@@ -774,15 +779,18 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
                 // Set values of resulting vector according to result.
                 if constexpr (!storm::IsIntervalType<ValueType>) {
                     // For non-interval models, we only operated on the maybe states, and we must recover the qualitative values for the other state.
-                    if (resultForMaybeStates.solutionBounds) {
-                        // Outside of the maybe states the probability is exactly zero or one, so the entries
-                        // that result already holds bound those states from both sides.
-                        std::vector<SolutionType> lower(result), upper(result);
-                        storm::utility::vector::setVectorValues<SolutionType>(lower, qualitativeStateSets.maybeStates,
-                                                                              resultForMaybeStates.solutionBounds->first);
-                        storm::utility::vector::setVectorValues<SolutionType>(upper, qualitativeStateSets.maybeStates,
-                                                                              resultForMaybeStates.solutionBounds->second);
-                        resultBounds = std::make_pair(std::move(lower), std::move(upper));
+                    // Outside of the maybe states the probability is exactly zero or one, so the entries that
+                    // result already holds bound those states from both sides.
+                    auto embedBound = [&result, &qualitativeStateSets](std::vector<SolutionType> const& boundForMaybeStates) {
+                        std::vector<SolutionType> bound(result);
+                        storm::utility::vector::setVectorValues<SolutionType>(bound, qualitativeStateSets.maybeStates, boundForMaybeStates);
+                        return bound;
+                    };
+                    if (resultForMaybeStates.solutionBounds.hasLower()) {
+                        resultBounds.lower = embedBound(*resultForMaybeStates.solutionBounds.lower);
+                    }
+                    if (resultForMaybeStates.solutionBounds.hasUpper()) {
+                        resultBounds.upper = embedBound(*resultForMaybeStates.solutionBounds.upper);
                     }
                     storm::utility::vector::setVectorValues<SolutionType>(result, qualitativeStateSets.maybeStates, resultForMaybeStates.getValues());
                 } else {
@@ -840,6 +848,17 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
         for (auto& element : result.values) {
             element = storm::utility::one<SolutionType>() - element;
         }
+        // One minus is antitone, so the complement of the lower bound bounds the result from above and vice
+        // versa. In particular, knowing only one side before means knowing only the other side afterwards.
+        auto& bounds = result.solutionBounds;
+        for (auto* bound : {&bounds.lower, &bounds.upper}) {
+            if (*bound) {
+                for (auto& entry : **bound) {
+                    entry = storm::utility::one<SolutionType>() - entry;
+                }
+            }
+        }
+        std::swap(bounds.lower, bounds.upper);
         return result;
     }
 }

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -37,7 +37,7 @@ namespace modelchecker {
 namespace helper {
 
 template<typename ValueType, typename SolutionType>
-std::map<storm::storage::sparse::state_type, SolutionType> SparseMdpPrctlHelper<ValueType, SolutionType>::computeRewardBoundedValues(
+std::vector<SolutionType> SparseMdpPrctlHelper<ValueType, SolutionType>::computeRewardBoundedValues(
     Environment const& env, OptimizationDirection dir, rewardbounded::MultiDimensionalRewardUnfolding<ValueType, true>& rewardUnfolding,
     storm::storage::BitVector const& initialStates) {
     if constexpr (storm::IsIntervalType<ValueType>) {
@@ -93,9 +93,10 @@ std::map<storm::storage::sparse::state_type, SolutionType> SparseMdpPrctlHelper<
             }
         }
 
-        std::map<storm::storage::sparse::state_type, ValueType> result;
+        std::vector<ValueType> result;
+        result.reserve(initialStates.getNumberOfSetBits());
         for (uint64_t initState : initialStates) {
-            result[initState] = rewardUnfolding.getInitialStateResult(initEpoch, initState);
+            result.push_back(rewardUnfolding.getInitialStateResult(initEpoch, initState));
         }
 
         swAll.stop();

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -813,6 +813,13 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
     STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isDeterministicScheduler(), "Expected a deterministic scheduler.");
     STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isMemorylessScheduler(), "Expected a memoryless scheduler.");
 
+    // Where the graph analysis settled every state there was no equation system to solve, so the values are
+    // exactly the ones it determined and each of them bounds itself from either side.
+    if (qualitativeStateSets.maybeStates.empty()) {
+        resultBounds.lower = result;
+        resultBounds.upper = result;
+    }
+
     // Return result.
     MDPSparseModelCheckingHelperReturnType<SolutionType> returnValue(std::move(result), std::move(scheduler));
     returnValue.solutionBounds = std::move(resultBounds);
@@ -1531,6 +1538,13 @@ typename SparseMdpPrctlHelper<ValueType, SolutionType>::ExtendedReturnType Spars
     STORM_LOG_ASSERT((!produceScheduler && !scheduler) || !scheduler->isPartialScheduler(), "Expected a fully defined scheduler.");
     STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isDeterministicScheduler(), "Expected a deterministic scheduler.");
     STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isMemorylessScheduler(), "Expected a memoryless scheduler.");
+
+    // Where the graph analysis settled every state there was no equation system to solve, so the values are
+    // exactly the ones it determined and each of them bounds itself from either side.
+    if (qualitativeStateSets.maybeStates.empty()) {
+        resultBounds.lower = result;
+        resultBounds.upper = result;
+    }
 
     if constexpr (storm::IsIntervalType<ValueType>) {
         ExtendedReturnType returnValue(std::move(result));

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -996,9 +996,21 @@ typename SparseMdpPrctlHelper<ValueType, SolutionType>::ExtendedReturnType Spars
                     return newChoicesWithoutReward;
                 });
 
-            std::vector<ExtendedSolutionType> resultInEcQuotient = std::move(result.values);
-            result.values.resize(ecElimResult.oldToNewStateMapping.size());
-            storm::utility::vector::selectVectorValues(result.values, ecElimResult.oldToNewStateMapping, resultInEcQuotient);
+            // Map the values, and any bounds on them, from the quotient back to the original states. All states of
+            // an eliminated end component share the value of the quotient state, so a bound on the latter bounds
+            // each of them.
+            auto liftFromEcQuotient = [&ecElimResult](std::vector<ExtendedSolutionType>& valuesInEcQuotient) {
+                std::vector<ExtendedSolutionType> lifted(ecElimResult.oldToNewStateMapping.size());
+                storm::utility::vector::selectVectorValues(lifted, ecElimResult.oldToNewStateMapping, valuesInEcQuotient);
+                return lifted;
+            };
+            if (result.solutionBounds.hasLower()) {
+                result.solutionBounds.lower = liftFromEcQuotient(*result.solutionBounds.lower);
+            }
+            if (result.solutionBounds.hasUpper()) {
+                result.solutionBounds.upper = liftFromEcQuotient(*result.solutionBounds.upper);
+            }
+            result.values = liftFromEcQuotient(result.values);
             return result;
         }
     }
@@ -1387,6 +1399,7 @@ typename SparseMdpPrctlHelper<ValueType, SolutionType>::ExtendedReturnType Spars
     ModelCheckerHint const& hint) {
     // Prepare resulting vector.
     std::vector<ExtendedSolutionType> result(transitionMatrix.getRowGroupCount(), storm::utility::zero<ExtendedSolutionType>());
+    storm::solver::SolutionBounds<ExtendedSolutionType> resultBounds;
 
     // Determine which states have a reward that is infinity or less than infinity.
     QualitativeStateSetsReachabilityRewards qualitativeStateSets = getQualitativeStateSetsReachabilityRewards(
@@ -1484,6 +1497,20 @@ typename SparseMdpPrctlHelper<ValueType, SolutionType>::ExtendedReturnType Spars
                     }
                 }
             } else {
+                // We only operated on the maybe states, and we must recover the qualitative values for the other
+                // states. Outside of the maybe states the reward is exactly zero or exactly infinity, so the
+                // entries that result already holds bound those states from both sides.
+                auto embedBound = [&result, &qualitativeStateSets](std::vector<SolutionType> const& boundForMaybeStates) {
+                    std::vector<ExtendedSolutionType> bound(result);
+                    storm::utility::vector::setVectorValues(bound, qualitativeStateSets.maybeStates, boundForMaybeStates);
+                    return bound;
+                };
+                if (resultForMaybeStates.solutionBounds.hasLower()) {
+                    resultBounds.lower = embedBound(*resultForMaybeStates.solutionBounds.lower);
+                }
+                if (resultForMaybeStates.solutionBounds.hasUpper()) {
+                    resultBounds.upper = embedBound(*resultForMaybeStates.solutionBounds.upper);
+                }
                 // Set values of resulting vector according to result.
                 storm::utility::vector::setVectorValues(result, qualitativeStateSets.maybeStates, resultForMaybeStates.getValues());
                 if (produceScheduler) {
@@ -1506,9 +1533,13 @@ typename SparseMdpPrctlHelper<ValueType, SolutionType>::ExtendedReturnType Spars
     STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isMemorylessScheduler(), "Expected a memoryless scheduler.");
 
     if constexpr (storm::IsIntervalType<ValueType>) {
-        return ExtendedReturnType(std::move(result));
+        ExtendedReturnType returnValue(std::move(result));
+        returnValue.solutionBounds = std::move(resultBounds);
+        return returnValue;
     } else {
-        return ExtendedReturnType(std::move(result), std::move(scheduler));
+        ExtendedReturnType returnValue(std::move(result), std::move(scheduler));
+        returnValue.solutionBounds = std::move(resultBounds);
+        return returnValue;
     }
 }
 

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.cpp
@@ -813,8 +813,7 @@ MDPSparseModelCheckingHelperReturnType<SolutionType> SparseMdpPrctlHelper<ValueT
     STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isDeterministicScheduler(), "Expected a deterministic scheduler.");
     STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isMemorylessScheduler(), "Expected a memoryless scheduler.");
 
-    // Where the graph analysis settled every state there was no equation system to solve, so the values are
-    // exactly the ones it determined and each of them bounds itself from either side.
+    // With no maybe states nothing was solved, so the values are exact and bound themselves.
     if (qualitativeStateSets.maybeStates.empty()) {
         resultBounds.lower = result;
         resultBounds.upper = result;
@@ -1003,9 +1002,8 @@ typename SparseMdpPrctlHelper<ValueType, SolutionType>::ExtendedReturnType Spars
                     return newChoicesWithoutReward;
                 });
 
-            // Map the values, and any bounds on them, from the quotient back to the original states. All states of
-            // an eliminated end component share the value of the quotient state, so a bound on the latter bounds
-            // each of them.
+            // All states of an eliminated end component share the value of their quotient state, so a bound on
+            // the latter bounds each of them.
             auto liftFromEcQuotient = [&ecElimResult](std::vector<ExtendedSolutionType>& valuesInEcQuotient) {
                 std::vector<ExtendedSolutionType> lifted(ecElimResult.oldToNewStateMapping.size());
                 storm::utility::vector::selectVectorValues(lifted, ecElimResult.oldToNewStateMapping, valuesInEcQuotient);
@@ -1504,9 +1502,7 @@ typename SparseMdpPrctlHelper<ValueType, SolutionType>::ExtendedReturnType Spars
                     }
                 }
             } else {
-                // We only operated on the maybe states, and we must recover the qualitative values for the other
-                // states. Outside of the maybe states the reward is exactly zero or exactly infinity, so the
-                // entries that result already holds bound those states from both sides.
+                // The copy of result supplies the exact values outside the maybe states.
                 auto embedBound = [&result, &qualitativeStateSets](std::vector<SolutionType> const& boundForMaybeStates) {
                     std::vector<ExtendedSolutionType> bound(result);
                     storm::utility::vector::setVectorValues(bound, qualitativeStateSets.maybeStates, boundForMaybeStates);
@@ -1539,8 +1535,7 @@ typename SparseMdpPrctlHelper<ValueType, SolutionType>::ExtendedReturnType Spars
     STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isDeterministicScheduler(), "Expected a deterministic scheduler.");
     STORM_LOG_ASSERT((!produceScheduler && !scheduler) || scheduler->isMemorylessScheduler(), "Expected a memoryless scheduler.");
 
-    // Where the graph analysis settled every state there was no equation system to solve, so the values are
-    // exactly the ones it determined and each of them bounds itself from either side.
+    // With no maybe states nothing was solved, so the values are exact and bound themselves.
     if (qualitativeStateSets.maybeStates.empty()) {
         resultBounds.lower = result;
         resultBounds.upper = result;

--- a/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.h
+++ b/src/storm/modelchecker/prctl/helper/SparseMdpPrctlHelper.h
@@ -38,9 +38,12 @@ class SparseMdpPrctlHelper {
     using ExtendedSolutionType = storm::utility::ExtendedValueType<SolutionType>;
     using ExtendedReturnType = MDPSparseModelCheckingHelperReturnType<SolutionType, ExtendedSolutionType>;
 
-    static std::map<storm::storage::sparse::state_type, SolutionType> computeRewardBoundedValues(
-        Environment const& env, OptimizationDirection dir, rewardbounded::MultiDimensionalRewardUnfolding<ValueType, true>& rewardUnfolding,
-        storm::storage::BitVector const& initialStates);
+    /*!
+     * @return One value per given initial state, in the order of those states.
+     */
+    static std::vector<SolutionType> computeRewardBoundedValues(Environment const& env, OptimizationDirection dir,
+                                                                rewardbounded::MultiDimensionalRewardUnfolding<ValueType, true>& rewardUnfolding,
+                                                                storm::storage::BitVector const& initialStates);
 
     static std::vector<SolutionType> computeNextProbabilities(Environment const& env, OptimizationDirection dir,
                                                               UncertaintyResolutionMode uncertaintyResolutionMode,

--- a/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
+++ b/src/storm/modelchecker/reachability/SparseDtmcEliminationModelChecker.cpp
@@ -512,11 +512,9 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
     if (computeForInitialStatesOnly) {
         // If we computed the results for the initial (and prob 0 and prob1) states only, we need to filter the
         // result to only communicate these results.
-        std::unique_ptr<ExplicitQuantitativeCheckResult<ValueType>> checkResult = std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>();
-        for (uint64_t state : ~maybeStates | initialStates) {
-            (*checkResult)[state] = result[state];
-        }
-        return std::move(checkResult);  // move() required by, e.g., clang 3.8
+        storm::storage::BitVector relevantStates = ~maybeStates | initialStates;
+        std::vector<ValueType> relevantValues = storm::utility::vector::filterVector(result, relevantStates);
+        return std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(std::move(relevantStates), std::move(relevantValues));
     }
     return std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(result);
 }
@@ -621,11 +619,9 @@ std::unique_ptr<CheckResult> SparseDtmcEliminationModelChecker<SparseDtmcModelTy
     if (computeForInitialStatesOnly) {
         // If we computed the results for the initial (and inf) states only, we need to filter the result to
         // only communicate these results.
-        std::unique_ptr<ExplicitQuantitativeCheckResult<ValueType>> checkResult = std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>();
-        for (uint64_t state : ~maybeStates | initialStates) {
-            (*checkResult)[state] = result[state];
-        }
-        return std::move(checkResult);  // move() required by, e.g., clang 3.8
+        storm::storage::BitVector relevantStates = ~maybeStates | initialStates;
+        auto relevantValues = storm::utility::vector::filterVector(result, relevantStates);
+        return std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(std::move(relevantStates), std::move(relevantValues));
     }
     return std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(result);
 }

--- a/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
@@ -4,6 +4,8 @@
 
 #include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
 
+#include <algorithm>
+
 #include "storm/adapters/JsonAdapter.h"
 #include "storm/exceptions/InvalidOperationException.h"
 #include "storm/utility/macros.h"
@@ -12,52 +14,35 @@ namespace storm {
 namespace modelchecker {
 
 template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult() : truthValues(map_type()) {
-    // Intentionally left empty.
+ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(storm::storage::sparse::state_type state, bool value)
+    : states(storm::storage::BitVector(state + 1)), truthValues(1, value) {
+    states->set(state);
 }
 
 template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(map_type const& map) : truthValues(map) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(map_type&& map) : truthValues(map) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(storm::storage::sparse::state_type state, bool value) : truthValues(map_type()) {
-    boost::get<map_type>(truthValues)[state] = value;
-}
-
-template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(storm::storage::BitVector const& truthValues) : truthValues(truthValues) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(storm::storage::BitVector&& truthValues) : truthValues(std::move(truthValues)) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(boost::variant<vector_type, map_type> const& truthValues,
+ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(vector_type const& truthValues,
                                                                           std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
     : truthValues(truthValues), scheduler(scheduler) {
     // Intentionally left empty.
 }
 
 template<typename ValueType>
-ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(boost::variant<vector_type, map_type>&& truthValues,
+ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(vector_type&& truthValues,
                                                                           std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
     : truthValues(std::move(truthValues)), scheduler(scheduler) {
     // Intentionally left empty.
 }
 
 template<typename ValueType>
+ExplicitQualitativeCheckResult<ValueType>::ExplicitQualitativeCheckResult(storm::storage::BitVector states, vector_type&& truthValues,
+                                                                          std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
+    : states(std::move(states)), truthValues(std::move(truthValues)), scheduler(scheduler) {
+    STORM_LOG_ASSERT(this->states->getNumberOfSetBits() == this->truthValues.size(), "Expected one truth value per selected state.");
+}
+
+template<typename ValueType>
 std::unique_ptr<CheckResult> ExplicitQualitativeCheckResult<ValueType>::clone() const {
-    return std::make_unique<ExplicitQualitativeCheckResult<ValueType>>(this->truthValues);
+    return std::make_unique<ExplicitQualitativeCheckResult<ValueType>>(*this);
 }
 
 template<typename ValueType>
@@ -65,34 +50,13 @@ void ExplicitQualitativeCheckResult<ValueType>::performLogicalOperation(Explicit
                                                                         bool logicalAnd) {
     STORM_LOG_THROW(second.isExplicitQualitativeCheckResult(), storm::exceptions::InvalidOperationException,
                     "Cannot perform logical 'and' on check results of incompatible type.");
-    STORM_LOG_THROW(first.isResultForAllStates() == second.isResultForAllStates(), storm::exceptions::InvalidOperationException,
-                    "Cannot perform logical 'and' on check results of incompatible type.");
     ExplicitQualitativeCheckResult<ValueType> const& secondCheckResult = static_cast<ExplicitQualitativeCheckResult<ValueType> const&>(second);
-    if (first.isResultForAllStates()) {
-        if (logicalAnd) {
-            boost::get<vector_type>(first.truthValues) &= boost::get<vector_type>(secondCheckResult.truthValues);
-        } else {
-            boost::get<vector_type>(first.truthValues) |= boost::get<vector_type>(secondCheckResult.truthValues);
-        }
+    STORM_LOG_THROW(first.states == secondCheckResult.states && first.truthValues.size() == secondCheckResult.truthValues.size(),
+                    storm::exceptions::InvalidOperationException, "Cannot perform logical 'and' on check results of incompatible type.");
+    if (logicalAnd) {
+        first.truthValues &= secondCheckResult.truthValues;
     } else {
-        std::function<bool(bool, bool)> function = logicalAnd ? std::function<bool(bool, bool)>([](bool a, bool b) { return a && b; })
-                                                              : std::function<bool(bool, bool)>([](bool a, bool b) { return a || b; });
-
-        map_type& map1 = boost::get<map_type>(first.truthValues);
-        map_type const& map2 = boost::get<map_type>(secondCheckResult.truthValues);
-        for (auto& element1 : map1) {
-            auto const& keyValuePair = map2.find(element1.first);
-            STORM_LOG_THROW(keyValuePair != map2.end(), storm::exceptions::InvalidOperationException,
-                            "Cannot perform logical 'and' on check results of incompatible type.");
-            element1.second = function(element1.second, keyValuePair->second);
-        }
-
-        // Double-check that there are no entries in map2 that the current result does not have.
-        for (auto const& element2 : map2) {
-            auto const& keyValuePair = map1.find(element2.first);
-            STORM_LOG_THROW(keyValuePair != map1.end(), storm::exceptions::InvalidOperationException,
-                            "Cannot perform logical 'and' on check results of incompatible type.");
-        }
+        first.truthValues |= secondCheckResult.truthValues;
     }
 }
 
@@ -110,78 +74,53 @@ QualitativeCheckResult& ExplicitQualitativeCheckResult<ValueType>::operator|=(Qu
 
 template<typename ValueType>
 bool ExplicitQualitativeCheckResult<ValueType>::existsTrue() const {
-    if (this->isResultForAllStates()) {
-        return !boost::get<vector_type>(truthValues).empty();
-    } else {
-        for (auto& element : boost::get<map_type>(truthValues)) {
-            if (element.second) {
-                return true;
-            }
-        }
-        return false;
-    }
+    return !truthValues.empty();
 }
 
 template<typename ValueType>
 bool ExplicitQualitativeCheckResult<ValueType>::forallTrue() const {
-    if (this->isResultForAllStates()) {
-        return boost::get<vector_type>(truthValues).full();
-    } else {
-        for (auto& element : boost::get<map_type>(truthValues)) {
-            if (!element.second) {
-                return false;
-            }
-        }
-        return true;
-    }
+    return truthValues.full();
 }
 
 template<typename ValueType>
 uint64_t ExplicitQualitativeCheckResult<ValueType>::count() const {
-    if (this->isResultForAllStates()) {
-        return boost::get<vector_type>(truthValues).getNumberOfSetBits();
-    } else {
-        uint64_t result = 0;
-        for (auto& element : boost::get<map_type>(truthValues)) {
-            if (element.second) {
-                ++result;
-            }
-        }
-        return result;
+    return truthValues.getNumberOfSetBits();
+}
+
+template<typename ValueType>
+bool ExplicitQualitativeCheckResult<ValueType>::hasValueForState(storm::storage::sparse::state_type state) const {
+    if (states) {
+        return state < states->size() && states->get(state);
     }
+    return state < truthValues.size();
+}
+
+template<typename ValueType>
+uint64_t ExplicitQualitativeCheckResult<ValueType>::getOffset(storm::storage::sparse::state_type state) const {
+    STORM_LOG_THROW(this->hasValueForState(state), storm::exceptions::InvalidOperationException, "Unknown key '" << state << "'.");
+    return states ? states->getNumberOfSetBitsBeforeIndex(state) : state;
 }
 
 template<typename ValueType>
 bool ExplicitQualitativeCheckResult<ValueType>::operator[](storm::storage::sparse::state_type state) const {
-    if (this->isResultForAllStates()) {
-        return boost::get<vector_type>(truthValues).get(state);
-    } else {
-        map_type const& map = boost::get<map_type>(truthValues);
-        auto const& keyValuePair = map.find(state);
-        STORM_LOG_THROW(keyValuePair != map.end(), storm::exceptions::InvalidOperationException, "Unknown key '" << state << "'.");
-        return keyValuePair->second;
-    }
+    return truthValues.get(this->getOffset(state));
+}
+
+template<typename ValueType>
+storm::storage::BitVector const& ExplicitQualitativeCheckResult<ValueType>::getStates() const {
+    STORM_LOG_THROW(!this->isResultForAllStates(), storm::exceptions::InvalidOperationException,
+                    "Unable to retrieve the states of a result that is for all states.");
+    return *states;
 }
 
 template<typename ValueType>
 typename ExplicitQualitativeCheckResult<ValueType>::vector_type const& ExplicitQualitativeCheckResult<ValueType>::getTruthValuesVector() const {
-    return boost::get<vector_type>(truthValues);
-}
-
-template<typename ValueType>
-typename ExplicitQualitativeCheckResult<ValueType>::map_type const& ExplicitQualitativeCheckResult<ValueType>::getTruthValuesMap() const {
-    return boost::get<map_type>(truthValues);
+    return truthValues;
 }
 
 template<typename ValueType>
 void ExplicitQualitativeCheckResult<ValueType>::complement() {
-    if (this->isResultForAllStates()) {
-        boost::get<vector_type>(truthValues).complement();
-    } else {
-        for (auto& element : boost::get<map_type>(truthValues)) {
-            element.second = !element.second;
-        }
-    }
+    truthValues.complement();
 }
 
 template<typename ValueType>
@@ -191,7 +130,7 @@ bool ExplicitQualitativeCheckResult<ValueType>::isExplicit() const {
 
 template<typename ValueType>
 bool ExplicitQualitativeCheckResult<ValueType>::isResultForAllStates() const {
-    return truthValues.which() == 0;
+    return !states.has_value();
 }
 
 template<typename ValueType>
@@ -201,44 +140,16 @@ bool ExplicitQualitativeCheckResult<ValueType>::isExplicitQualitativeCheckResult
 
 template<typename ValueType>
 std::ostream& ExplicitQualitativeCheckResult<ValueType>::writeToStream(std::ostream& out) const {
-    if (this->isResultForAllStates()) {
-        vector_type const& vector = boost::get<vector_type>(truthValues);
-        bool allTrue = vector.full();
-        bool allFalse = !allTrue && vector.empty();
-        if (allTrue) {
-            out << "{true}";
-        } else if (allFalse) {
-            out << "{false}";
-        } else {
-            out << "{true, false}";
-        }
+    if (!this->isResultForAllStates() && truthValues.size() == 1) {
+        std::ios::fmtflags oldflags(out.flags());
+        out << std::boolalpha << truthValues.get(0);
+        out.flags(oldflags);
+    } else if (truthValues.full()) {
+        out << "{true}";
+    } else if (truthValues.empty()) {
+        out << "{false}";
     } else {
-        std::ios::fmtflags oldflags(std::cout.flags());
-        out << std::boolalpha;
-
-        map_type const& map = boost::get<map_type>(truthValues);
-        if (map.size() == 1) {
-            out << map.begin()->second;
-        } else {
-            bool allTrue = true;
-            bool allFalse = true;
-            for (auto const& entry : map) {
-                if (entry.second) {
-                    allFalse = false;
-                } else {
-                    allTrue = false;
-                }
-            }
-            if (allTrue) {
-                out << "{true}";
-            } else if (allFalse) {
-                out << "{false}";
-            } else {
-                out << "{true, false}";
-            }
-        }
-
-        std::cout.flags(oldflags);
+        out << "{true, false}";
     }
     return out;
 }
@@ -251,27 +162,20 @@ void ExplicitQualitativeCheckResult<ValueType>::filter(QualitativeCheckResult co
     ExplicitQualitativeCheckResult<ValueType> const& explicitFilter = filter.template asExplicitQualitativeCheckResult<ValueType>();
     vector_type const& filterTruthValues = explicitFilter.getTruthValuesVector();
 
-    if (this->isResultForAllStates()) {
-        map_type newMap;
-        for (auto element : filterTruthValues) {
-            newMap.emplace(element, this->getTruthValuesVector().get(element));
-        }
-        this->truthValues = newMap;
-    } else {
-        map_type const& map = boost::get<map_type>(truthValues);
+    // Line the filter up with the states this result has truth values for. The two need not span the same range
+    // of states, e.g. if this result holds a truth value for a single state only.
+    uint64_t const numStates = std::max(filterTruthValues.size(), states ? states->size() : truthValues.size());
+    storm::storage::BitVector available = states ? *states : storm::storage::BitVector(truthValues.size(), true);
+    available.resize(numStates);
+    storm::storage::BitVector selected(filterTruthValues);
+    selected.resize(numStates);
+    STORM_LOG_THROW(selected.isSubsetOf(available), storm::exceptions::InvalidOperationException,
+                    "The check result fails to contain some results referred to by the filter.");
 
-        map_type newMap;
-        for (auto const& element : map) {
-            if (filterTruthValues.get(element.first)) {
-                newMap.insert(element);
-            }
-        }
-
-        STORM_LOG_THROW(newMap.size() == filterTruthValues.getNumberOfSetBits(), storm::exceptions::InvalidOperationException,
-                        "The check result fails to contain some results referred to by the filter.");
-
-        this->truthValues = newMap;
-    }
+    // Keep the truth values of the selected states. Note that the result is a result for the selected states
+    // even if those happen to be all of them.
+    truthValues = truthValues % (selected % available);
+    states = filterTruthValues;
 }
 
 template<typename ValueType>
@@ -319,17 +223,9 @@ template<typename JsonRationalType>
 storm::json<JsonRationalType> ExplicitQualitativeCheckResult<ValueType>::toJson(std::optional<storm::storage::sparse::Valuations> const& stateValuations,
                                                                                 std::optional<storm::models::sparse::StateLabeling> const& stateLabels) const {
     storm::json<JsonRationalType> result;
-    if (this->isResultForAllStates()) {
-        vector_type const& valuesAsVector = boost::get<vector_type>(truthValues);
-        for (uint64_t state = 0; state < valuesAsVector.size(); ++state) {
-            insertJsonEntry(result, state, valuesAsVector.get(state), stateValuations, stateLabels);
-        }
-    } else {
-        map_type const& valuesAsMap = boost::get<map_type>(truthValues);
-        for (auto const& stateValue : valuesAsMap) {
-            insertJsonEntry(result, stateValue.first, stateValue.second, stateValuations, stateLabels);
-        }
-    }
+    this->forEachState([&](storm::storage::sparse::state_type state, uint64_t offset) {
+        insertJsonEntry(result, state, truthValues.get(offset), stateValuations, stateLabels);
+    });
     return result;
 }
 

--- a/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.cpp
@@ -172,8 +172,6 @@ void ExplicitQualitativeCheckResult<ValueType>::filter(QualitativeCheckResult co
     STORM_LOG_THROW(selected.isSubsetOf(available), storm::exceptions::InvalidOperationException,
                     "The check result fails to contain some results referred to by the filter.");
 
-    // Keep the truth values of the selected states. Note that the result is a result for the selected states
-    // even if those happen to be all of them.
     truthValues = truthValues % (selected % available);
     states = filterTruthValues;
 }

--- a/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQualitativeCheckResult.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <boost/variant.hpp>
-#include <map>
 #include <optional>
 
 #include "storm/adapters/JsonForward.h"
@@ -16,24 +14,38 @@ namespace storm {
 
 namespace modelchecker {
 
+/*!
+ * A qualitative check result over the states of a sparse model.
+ *
+ * The result either covers every state of the model or just a subset of them, e.g. after filtering it to the
+ * initial states. In the latter case the states in question are recorded in a bit vector and the truth values are
+ * stored compressed, i.e. the i-th truth value belongs to the i-th state selected by that bit vector.
+ */
 template<typename ValueType>
 class ExplicitQualitativeCheckResult : public QualitativeCheckResult {
    public:
     typedef storm::storage::BitVector vector_type;
-    typedef std::map<storm::storage::sparse::state_type, bool> map_type;
 
-    ExplicitQualitativeCheckResult();
-    virtual ~ExplicitQualitativeCheckResult() = default;
-    ExplicitQualitativeCheckResult(map_type const& map);
-    ExplicitQualitativeCheckResult(map_type&& map);
+    /*!
+     * Creates a result that holds the given truth value for the given state only.
+     */
     ExplicitQualitativeCheckResult(storm::storage::sparse::state_type state, bool value);
-    ExplicitQualitativeCheckResult(vector_type const& truthValues);
-    ExplicitQualitativeCheckResult(vector_type&& truthValues);
-    ExplicitQualitativeCheckResult(boost::variant<vector_type, map_type> const& truthValues,
-                                   std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
-    ExplicitQualitativeCheckResult(boost::variant<vector_type, map_type>&& truthValues,
+
+    /*!
+     * Creates a result for all states of a model with as many states as the given bit vector has bits.
+     */
+    ExplicitQualitativeCheckResult(vector_type const& truthValues, std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
+    ExplicitQualitativeCheckResult(vector_type&& truthValues, std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
+
+    /*!
+     * Creates a result for the given states only.
+     * @param states The states the result is for.
+     * @param truthValues One truth value per state selected by @p states, in the order of the selected states.
+     */
+    ExplicitQualitativeCheckResult(storm::storage::BitVector states, vector_type&& truthValues,
                                    std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
 
+    virtual ~ExplicitQualitativeCheckResult() = default;
     ExplicitQualitativeCheckResult(ExplicitQualitativeCheckResult const& other) = default;
     ExplicitQualitativeCheckResult& operator=(ExplicitQualitativeCheckResult const& other) = default;
     ExplicitQualitativeCheckResult(ExplicitQualitativeCheckResult&& other) = default;
@@ -41,7 +53,11 @@ class ExplicitQualitativeCheckResult : public QualitativeCheckResult {
 
     virtual std::unique_ptr<CheckResult> clone() const override;
 
-    bool operator[](storm::storage::sparse::state_type index) const;
+    /*!
+     * Retrieves the truth value of the given state.
+     * @pre The result holds a truth value for that state.
+     */
+    bool operator[](storm::storage::sparse::state_type state) const;
 
     virtual bool isExplicit() const override;
     virtual bool isResultForAllStates() const override;
@@ -52,8 +68,22 @@ class ExplicitQualitativeCheckResult : public QualitativeCheckResult {
     virtual QualitativeCheckResult& operator|=(QualitativeCheckResult const& other) override;
     virtual void complement() override;
 
+    /*!
+     * Retrieves whether the result holds a truth value for the given state.
+     */
+    bool hasValueForState(storm::storage::sparse::state_type state) const;
+
+    /*!
+     * Retrieves the states this result holds truth values for.
+     * @pre This is not a result for all states.
+     */
+    storm::storage::BitVector const& getStates() const;
+
+    /*!
+     * Retrieves the truth values, one per state this result is for. If this is not a result for all states, the
+     * i-th truth value belongs to the i-th state selected by getStates().
+     */
     vector_type const& getTruthValuesVector() const;
-    map_type const& getTruthValuesMap() const;
 
     virtual bool existsTrue() const override;
     virtual bool forallTrue() const override;
@@ -79,8 +109,36 @@ class ExplicitQualitativeCheckResult : public QualitativeCheckResult {
 
     static void performLogicalOperation(ExplicitQualitativeCheckResult& first, QualitativeCheckResult const& second, bool logicalAnd);
 
-    // The values of the quantitative check result.
-    boost::variant<vector_type, map_type> truthValues;
+    /*!
+     * Retrieves the index at which the truth value of the given state is stored.
+     * @pre The result holds a truth value for that state.
+     */
+    uint64_t getOffset(storm::storage::sparse::state_type state) const;
+
+    /*!
+     * Invokes the given function with the state and the offset of its truth value, for every state this result is
+     * for.
+     */
+    template<typename Function>
+    void forEachState(Function const& f) const {
+        if (states) {
+            uint64_t offset = 0;
+            for (auto const& state : *states) {
+                f(state, offset);
+                ++offset;
+            }
+        } else {
+            for (uint64_t state = 0; state < truthValues.size(); ++state) {
+                f(state, state);
+            }
+        }
+    }
+
+    // The states this result holds truth values for, or nothing at all if it is a result for all states.
+    std::optional<storm::storage::BitVector> states;
+
+    // The truth values of the qualitative check result, one per state this result is for.
+    vector_type truthValues;
 
     // An optional scheduler that accompanies the values.
     std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler;

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -2,8 +2,6 @@
 
 #include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
 
-#include <algorithm>
-
 #include "storm/adapters/JsonAdapter.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
 #include "storm/exceptions/InvalidOperationException.h"
@@ -270,15 +268,43 @@ typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQ
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQuantitativeCheckResult<ValueType>::average() const {
-    STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Average of empty set is not defined.");
+    return this->sum() / storm::utility::convertNumber<ExtendedValueType, uint64_t>(values.size());
+}
 
-    ExtendedValueType sum = storm::utility::zero<ExtendedValueType>();
-    for (auto const& element : values) {
-        STORM_LOG_THROW(!storm::utility::isInfinity(element), storm::exceptions::InvalidOperationException,
-                        "Cannot compute the average of values containing infinity.");
-        sum += element;
+template<typename ValueType>
+typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQuantitativeCheckResult<ValueType>::aggregateVector(vector_type const& vector,
+                                                                                                                                   FilterType filter) {
+    // A bound has the same shape as the values, so aggregating one is exactly what the methods above do, applied
+    // to a different vector. Wrapping it in a result of its own reuses them rather than repeating them, and keeps
+    // the two kinds of aggregate in step should any of them ever change.
+    ExplicitQuantitativeCheckResult<ValueType> const asResult{vector};
+    switch (filter) {
+        case FilterType::MIN:
+            return asResult.getMin();
+        case FilterType::MAX:
+            return asResult.getMax();
+        case FilterType::SUM:
+            return asResult.sum();
+        case FilterType::AVG:
+            return asResult.average();
+        default:
+            STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "The filter " << toString(filter) << " does not aggregate values.");
     }
-    return sum / storm::utility::convertNumber<ExtendedValueType, uint64_t>(values.size());
+}
+
+template<typename ValueType>
+AggregatedValue<typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType> ExplicitQuantitativeCheckResult<ValueType>::aggregate(
+    FilterType filter) const {
+    // The values go through the base implementation, i.e. through getMin(), sum() and friends, so that the
+    // aggregations keep whatever those promise about them.
+    AggregatedValue<ExtendedValueType> result = QuantitativeCheckResult<ValueType>::aggregate(filter);
+    if (this->hasLowerBounds()) {
+        result.lower = aggregateVector(*bounds.lower, filter);
+    }
+    if (this->hasUpperBounds()) {
+        result.upper = aggregateVector(*bounds.upper, filter);
+    }
+    return result;
 }
 
 template<typename ValueType>

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -2,13 +2,13 @@
 
 #include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
 
+#include <algorithm>
+
 #include "storm/adapters/JsonAdapter.h"
 #include "storm/adapters/RationalFunctionAdapter.h"
-#include "storm/exceptions/InvalidAccessException.h"
 #include "storm/exceptions/InvalidOperationException.h"
 #include "storm/exceptions/NotSupportedException.h"
 #include "storm/modelchecker/results/ExplicitQualitativeCheckResult.h"
-#include "storm/storage/BitVector.h"
 #include "storm/utility/constants.h"
 #include "storm/utility/macros.h"
 #include "storm/utility/vector.h"
@@ -16,93 +16,38 @@
 namespace storm {
 namespace modelchecker {
 
-namespace detail {
-/*!
- * Restricts the given values to the states selected by the filter. Note that the result is always a map, even
- * if the given values are a vector.
- */
-template<typename ValueType>
-boost::variant<std::vector<ValueType>, std::map<storm::storage::sparse::state_type, ValueType>> filterValues(
-    boost::variant<std::vector<ValueType>, std::map<storm::storage::sparse::state_type, ValueType>> const& values,
-    storm::storage::BitVector const& filterTruthValues) {
-    typedef std::vector<ValueType> vector_type;
-    typedef std::map<storm::storage::sparse::state_type, ValueType> map_type;
-
-    map_type newMap;
-    if (values.which() == 0) {
-        vector_type const& valuesAsVector = boost::get<vector_type>(values);
-        for (auto element : filterTruthValues) {
-            STORM_LOG_THROW(element < valuesAsVector.size(), storm::exceptions::InvalidAccessException, "Invalid index in results.");
-            newMap.emplace(element, valuesAsVector[element]);
-        }
-    } else {
-        for (auto const& element : boost::get<map_type>(values)) {
-            if (filterTruthValues.get(element.first)) {
-                newMap.insert(element);
-            }
-        }
-        STORM_LOG_THROW(newMap.size() == filterTruthValues.getNumberOfSetBits(), storm::exceptions::InvalidOperationException,
-                        "The check result fails to contain some results referred to by the filter.");
-    }
-    return newMap;
-}
-
-/*!
- * Replaces every value by one minus that value.
- */
-template<typename ValueType>
-void complementValues(boost::variant<std::vector<ValueType>, std::map<storm::storage::sparse::state_type, ValueType>>& values) {
-    typedef std::vector<ValueType> vector_type;
-    typedef std::map<storm::storage::sparse::state_type, ValueType> map_type;
-
-    if (values.which() == 0) {
-        for (auto& element : boost::get<vector_type>(values)) {
-            element = storm::utility::one<ValueType>() - element;
-        }
-    } else {
-        for (auto& element : boost::get<map_type>(values)) {
-            element.second = storm::utility::one<ValueType>() - element.second;
-        }
-    }
-}
-}  // namespace detail
-
-template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult() : values(map_type()) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(map_type const& values) : values(values) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(map_type&& values) : values(std::move(values)) {
-    // Intentionally left empty.
-}
-
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(storm::storage::sparse::state_type const& state, ExtendedValueType const& value)
-    : values(map_type()) {
-    boost::get<map_type>(values).emplace(state, value);
+    : states(storm::storage::BitVector(state + 1)), values({value}) {
+    states->set(state);
 }
 
 template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(vector_type const& values) : values(values) {
+ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(vector_type const& values,
+                                                                            std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
+    : values(values), scheduler(scheduler) {
     // Intentionally left empty.
 }
 
 template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(vector_type&& values) : values(std::move(values)) {
+ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(vector_type&& values,
+                                                                            std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
+    : values(std::move(values)), scheduler(scheduler) {
     // Intentionally left empty.
+}
+
+template<typename ValueType>
+ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(storm::storage::BitVector states, vector_type&& values,
+                                                                            std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
+    : states(std::move(states)), values(std::move(values)), scheduler(scheduler) {
+    STORM_LOG_ASSERT(this->states->getNumberOfSetBits() == this->values.size(), "Expected one value per selected state.");
 }
 
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(std::vector<ValueType> const& values)
     requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
-    : values(map_type()) {
-    this->values = storm::utility::fromSentinel(std::vector<ValueType>(values));
+    : values(storm::utility::fromSentinel(std::vector<ValueType>(values))) {
+    // Intentionally left empty.
 }
 
 template<typename ValueType>
@@ -113,148 +58,153 @@ ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(std:
 }
 
 template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(std::map<storm::storage::sparse::state_type, ValueType> const& values)
+ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(storm::storage::BitVector states, std::vector<ValueType>&& values)
     requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
-    : values(map_type()) {
-    map_type& widened = boost::get<map_type>(this->values);
-    for (auto const& stateValue : values) {
-        widened.emplace(stateValue.first, storm::utility::fromSentinel(stateValue.second));
-    }
-}
-
-template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(boost::variant<vector_type, map_type> const& values,
-                                                                            std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
-    : values(values), scheduler(scheduler) {
-    // Intentionally left empty.
-}
-
-template<typename ValueType>
-ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(boost::variant<vector_type, map_type>&& values,
-                                                                            std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler)
-    : values(std::move(values)), scheduler(scheduler) {
-    // Intentionally left empty.
+    : states(std::move(states)), values(storm::utility::fromSentinel(std::move(values))) {
+    STORM_LOG_ASSERT(this->states->getNumberOfSetBits() == this->values.size(), "Expected one value per selected state.");
 }
 
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(ExplicitQualitativeCheckResult<ValueType> const& other) {
-    if (other.isResultForAllStates()) {
-        storm::storage::BitVector const& bvValues = other.getTruthValuesVector();
+    auto const toValue = [](bool truthValue) { return truthValue ? storm::utility::one<ExtendedValueType>() : storm::utility::zero<ExtendedValueType>(); };
 
-        vector_type newVector;
-        newVector.reserve(bvValues.size());
-        for (std::size_t i = 0, n = bvValues.size(); i < n; i++) {
-            newVector.push_back(bvValues.get(i) ? storm::utility::one<ValueType>() : storm::utility::zero<ValueType>());
-        }
-
-        values = newVector;
-    } else {
-        typename ExplicitQualitativeCheckResult<ValueType>::map_type const& bitMap = other.getTruthValuesMap();
-
-        map_type newMap;
-        for (auto const& e : bitMap) {
-            newMap[e.first] = e.second ? storm::utility::one<ValueType>() : storm::utility::zero<ValueType>();
-        }
-
-        values = newMap;
+    storm::storage::BitVector const& truthValues = other.getTruthValuesVector();
+    values.reserve(truthValues.size());
+    for (std::size_t i = 0, n = truthValues.size(); i < n; i++) {
+        values.push_back(toValue(truthValues.get(i)));
+    }
+    if (!other.isResultForAllStates()) {
+        states = other.getStates();
     }
 }
 
 template<typename ValueType>
 std::unique_ptr<CheckResult> ExplicitQuantitativeCheckResult<ValueType>::clone() const {
-    auto result = std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(this->values, this->scheduler);
-    result->lowerBounds = this->lowerBounds;
-    result->upperBounds = this->upperBounds;
-    return result;
+    return std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(*this);
+}
+
+template<typename ValueType>
+bool ExplicitQuantitativeCheckResult<ValueType>::hasValueForState(storm::storage::sparse::state_type state) const {
+    if (states) {
+        return state < states->size() && states->get(state);
+    }
+    return state < values.size();
+}
+
+template<typename ValueType>
+uint64_t ExplicitQuantitativeCheckResult<ValueType>::getOffset(storm::storage::sparse::state_type state) const {
+    STORM_LOG_THROW(this->hasValueForState(state), storm::exceptions::InvalidOperationException, "Unknown key '" << state << "'.");
+    return states ? states->getNumberOfSetBitsBeforeIndex(state) : state;
+}
+
+template<typename ValueType>
+storm::storage::BitVector const& ExplicitQuantitativeCheckResult<ValueType>::getStates() const {
+    STORM_LOG_THROW(!this->isResultForAllStates(), storm::exceptions::InvalidOperationException,
+                    "Unable to retrieve the states of a result that is for all states.");
+    return *states;
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::vector_type const& ExplicitQuantitativeCheckResult<ValueType>::getValueVector() const {
-    return boost::get<vector_type>(values);
+    return values;
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::vector_type& ExplicitQuantitativeCheckResult<ValueType>::getValueVector() {
-    return boost::get<vector_type>(values);
-}
-
-template<typename ValueType>
-typename ExplicitQuantitativeCheckResult<ValueType>::map_type const& ExplicitQuantitativeCheckResult<ValueType>::getValueMap() const {
-    return boost::get<map_type>(values);
+    return values;
 }
 
 template<typename ValueType>
 std::vector<ValueType> ExplicitQuantitativeCheckResult<ValueType>::getFiniteValueVector() const {
-    return storm::utility::narrowFinite<ValueType>(boost::get<vector_type>(values));
+    return storm::utility::narrowFinite<ValueType>(values);
+}
+
+template<typename ValueType>
+std::vector<ValueType> ExplicitQuantitativeCheckResult<ValueType>::getSentinelValueVector() const {
+    if constexpr (!std::is_same_v<ExtendedValueType, ValueType>) {
+        std::vector<ValueType> result;
+        result.reserve(values.size());
+        for (auto const& value : values) {
+            result.push_back(storm::utility::toSentinel<ValueType>(value));
+        }
+        return result;
+    } else {
+        return values;
+    }
 }
 
 template<typename ValueType>
 bool ExplicitQuantitativeCheckResult<ValueType>::hasLowerBounds() const {
-    return lowerBounds.has_value();
+    return bounds.hasLower();
 }
 
 template<typename ValueType>
 bool ExplicitQuantitativeCheckResult<ValueType>::hasUpperBounds() const {
-    return upperBounds.has_value();
+    return bounds.hasUpper();
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::vector_type const& ExplicitQuantitativeCheckResult<ValueType>::getLowerBoundVector() const {
     STORM_LOG_THROW(this->hasLowerBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown lower bounds.");
-    return boost::get<vector_type>(*lowerBounds);
+    return *bounds.lower;
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::vector_type const& ExplicitQuantitativeCheckResult<ValueType>::getUpperBoundVector() const {
     STORM_LOG_THROW(this->hasUpperBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown upper bounds.");
-    return boost::get<vector_type>(*upperBounds);
+    return *bounds.upper;
 }
 
 template<typename ValueType>
-typename ExplicitQuantitativeCheckResult<ValueType>::map_type const& ExplicitQuantitativeCheckResult<ValueType>::getLowerBoundMap() const {
-    STORM_LOG_THROW(this->hasLowerBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown lower bounds.");
-    return boost::get<map_type>(*lowerBounds);
+storm::solver::SolutionBounds<typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType> const&
+ExplicitQuantitativeCheckResult<ValueType>::getSolutionBounds() const {
+    return bounds;
 }
 
 template<typename ValueType>
-typename ExplicitQuantitativeCheckResult<ValueType>::map_type const& ExplicitQuantitativeCheckResult<ValueType>::getUpperBoundMap() const {
-    STORM_LOG_THROW(this->hasUpperBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown upper bounds.");
-    return boost::get<map_type>(*upperBounds);
+void ExplicitQuantitativeCheckResult<ValueType>::assertBoundsShape([[maybe_unused]] vector_type const& bounds) const {
+    STORM_LOG_ASSERT(bounds.size() == values.size(), "Bounds must have the same size as the values.");
 }
 
 template<typename ValueType>
-void ExplicitQuantitativeCheckResult<ValueType>::assertBoundsShape([[maybe_unused]] boost::variant<vector_type, map_type> const& bounds) const {
-    STORM_LOG_ASSERT(bounds.which() == values.which(), "Bounds must have the same shape as the values.");
-    if (this->isResultForAllStates()) {
-        STORM_LOG_ASSERT(boost::get<vector_type>(bounds).size() == boost::get<vector_type>(values).size(), "Bounds must have the same size as the values.");
-    } else {
-        STORM_LOG_ASSERT(boost::get<map_type>(bounds).size() == boost::get<map_type>(values).size(), "Bounds must have the same size as the values.");
+void ExplicitQuantitativeCheckResult<ValueType>::setLowerBounds(vector_type lowerBounds) {
+    this->assertBoundsShape(lowerBounds);
+    this->bounds.lower = std::move(lowerBounds);
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::setUpperBounds(vector_type upperBounds) {
+    this->assertBoundsShape(upperBounds);
+    this->bounds.upper = std::move(upperBounds);
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::setBounds(storm::solver::SolutionBounds<ExtendedValueType> bounds) {
+    // Each of the two sides is transferred only if the algorithm in question established it; the other side is
+    // left as it is.
+    if (bounds.hasLower()) {
+        this->setLowerBounds(std::move(*bounds.lower));
+    }
+    if (bounds.hasUpper()) {
+        this->setUpperBounds(std::move(*bounds.upper));
     }
 }
 
 template<typename ValueType>
-void ExplicitQuantitativeCheckResult<ValueType>::setLowerBounds(boost::variant<vector_type, map_type> lowerBounds) {
-    this->assertBoundsShape(lowerBounds);
-    this->lowerBounds = std::move(lowerBounds);
-}
-
-template<typename ValueType>
-void ExplicitQuantitativeCheckResult<ValueType>::setUpperBounds(boost::variant<vector_type, map_type> upperBounds) {
-    this->assertBoundsShape(upperBounds);
-    this->upperBounds = std::move(upperBounds);
-}
-
-template<typename ValueType>
-void ExplicitQuantitativeCheckResult<ValueType>::setBounds(boost::variant<vector_type, map_type> lowerBounds,
-                                                           boost::variant<vector_type, map_type> upperBounds) {
-    this->setLowerBounds(std::move(lowerBounds));
-    this->setUpperBounds(std::move(upperBounds));
+void ExplicitQuantitativeCheckResult<ValueType>::setBounds(storm::solver::SolutionBounds<ValueType> bounds)
+    requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
+{
+    if (bounds.hasLower()) {
+        this->setLowerBounds(storm::utility::fromSentinel(std::move(*bounds.lower)));
+    }
+    if (bounds.hasUpper()) {
+        this->setUpperBounds(storm::utility::fromSentinel(std::move(*bounds.upper)));
+    }
 }
 
 template<typename ValueType>
 void ExplicitQuantitativeCheckResult<ValueType>::clearBounds() {
-    lowerBounds = std::nullopt;
-    upperBounds = std::nullopt;
+    bounds.clear();
 }
 
 template<typename ValueType>
@@ -266,62 +216,47 @@ void ExplicitQuantitativeCheckResult<ValueType>::filter(QualitativeCheckResult c
     ExplicitQualitativeCheckResult<ValueType> const& explicitFilter = filter.template asExplicitQualitativeCheckResult<ValueType>();
     typename ExplicitQualitativeCheckResult<ValueType>::vector_type const& filterTruthValues = explicitFilter.getTruthValuesVector();
 
+    // Line the filter up with the states this result has values for. The two need not span the same range of
+    // states, e.g. if this result holds a value for a single state only.
+    uint64_t const numStates = std::max(filterTruthValues.size(), states ? states->size() : values.size());
+    storm::storage::BitVector available = states ? *states : storm::storage::BitVector(values.size(), true);
+    available.resize(numStates);
+    storm::storage::BitVector selected(filterTruthValues);
+    selected.resize(numStates);
+    STORM_LOG_THROW(selected.isSubsetOf(available), storm::exceptions::InvalidOperationException,
+                    "The check result fails to contain some results referred to by the filter.");
+
+    // The entries that survive, in the index space the values are stored in. Note that the result is a result
+    // for the selected states even if those happen to be all of them.
+    storm::storage::BitVector const keep = selected % available;
+
     if (this->hasLowerBounds()) {
-        this->lowerBounds = detail::filterValues<ExtendedValueType>(*this->lowerBounds, filterTruthValues);
+        bounds.lower = storm::utility::vector::filterVector(*bounds.lower, keep);
     }
     if (this->hasUpperBounds()) {
-        this->upperBounds = detail::filterValues<ExtendedValueType>(*this->upperBounds, filterTruthValues);
+        bounds.upper = storm::utility::vector::filterVector(*bounds.upper, keep);
     }
-    this->values = detail::filterValues<ExtendedValueType>(this->values, filterTruthValues);
-}
-
-template<typename ValueType>
-std::vector<ValueType> ExplicitQuantitativeCheckResult<ValueType>::getSentinelValueVector() const {
-    vector_type const& valuesAsVector = boost::get<vector_type>(values);
-    if constexpr (!std::is_same_v<ExtendedValueType, ValueType>) {
-        std::vector<ValueType> result;
-        result.reserve(valuesAsVector.size());
-        for (auto const& value : valuesAsVector) {
-            result.push_back(storm::utility::toSentinel<ValueType>(value));
-        }
-        return result;
-    } else {
-        return valuesAsVector;
-    }
+    values = storm::utility::vector::filterVector(values, keep);
+    states = filterTruthValues;
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQuantitativeCheckResult<ValueType>::getMin() const {
     STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Minimum of empty set is not defined.");
-
-    if (this->isResultForAllStates()) {
-        return storm::utility::minimum(boost::get<vector_type>(values));
-    } else {
-        return storm::utility::minimum(boost::get<map_type>(values));
-    }
+    return storm::utility::minimum(values);
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQuantitativeCheckResult<ValueType>::getMax() const {
-    STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Minimum of empty set is not defined.");
-
-    if (this->isResultForAllStates()) {
-        return storm::utility::maximum(boost::get<vector_type>(values));
-    } else {
-        return storm::utility::maximum(boost::get<map_type>(values));
-    }
+    STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Maximum of empty set is not defined.");
+    return storm::utility::maximum(values);
 }
 
 template<typename ValueType>
 std::pair<typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType, typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType>
 ExplicitQuantitativeCheckResult<ValueType>::getMinMax() const {
     STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Minimum/maximum of empty set is not defined.");
-
-    if (this->isResultForAllStates()) {
-        return storm::utility::minmax(boost::get<vector_type>(values));
-    } else {
-        return storm::utility::minmax(boost::get<map_type>(values));
-    }
+    return storm::utility::minmax(values);
 }
 
 template<typename ValueType>
@@ -329,18 +264,10 @@ typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQ
     STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Sum of empty set is not defined.");
 
     ExtendedValueType sum = storm::utility::zero<ExtendedValueType>();
-    if (this->isResultForAllStates()) {
-        for (auto const& element : boost::get<vector_type>(values)) {
-            STORM_LOG_THROW(!storm::utility::isInfinity(element), storm::exceptions::InvalidOperationException,
-                            "Cannot compute the sum of values containing infinity.");
-            sum += element;
-        }
-    } else {
-        for (auto const& element : boost::get<map_type>(values)) {
-            STORM_LOG_THROW(!storm::utility::isInfinity(element.second), storm::exceptions::InvalidOperationException,
-                            "Cannot compute the sum of values containing infinity.");
-            sum += element.second;
-        }
+    for (auto const& element : values) {
+        STORM_LOG_THROW(!storm::utility::isInfinity(element), storm::exceptions::InvalidOperationException,
+                        "Cannot compute the sum of values containing infinity.");
+        sum += element;
     }
     return sum;
 }
@@ -350,23 +277,12 @@ typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQ
     STORM_LOG_THROW(!values.empty(), storm::exceptions::InvalidOperationException, "Average of empty set is not defined.");
 
     ExtendedValueType sum = storm::utility::zero<ExtendedValueType>();
-    uint64_t count = 0;
-    if (this->isResultForAllStates()) {
-        for (auto const& element : boost::get<vector_type>(values)) {
-            STORM_LOG_THROW(!storm::utility::isInfinity(element), storm::exceptions::InvalidOperationException,
-                            "Cannot compute the average of values containing infinity.");
-            sum += element;
-        }
-        count = boost::get<vector_type>(values).size();
-    } else {
-        for (auto const& element : boost::get<map_type>(values)) {
-            STORM_LOG_THROW(!storm::utility::isInfinity(element.second), storm::exceptions::InvalidOperationException,
-                            "Cannot compute the average of values containing infinity.");
-            sum += element.second;
-        }
-        count = boost::get<map_type>(values).size();
+    for (auto const& element : values) {
+        STORM_LOG_THROW(!storm::utility::isInfinity(element), storm::exceptions::InvalidOperationException,
+                        "Cannot compute the average of values containing infinity.");
+        sum += element;
     }
-    return sum / storm::utility::convertNumber<ExtendedValueType, uint64_t>(count);
+    return sum / storm::utility::convertNumber<ExtendedValueType, uint64_t>(values.size());
 }
 
 template<typename ValueType>
@@ -429,8 +345,8 @@ void printRange(std::ostream& out, ValueType const& min, ValueType const& max) {
 }
 
 template<typename ValueType>
-void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, storm::storage::sparse::state_type state) const {
-    print(out, (*this)[state]);
+void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, uint64_t offset) const {
+    print(out, values[offset]);
     if (!this->hasLowerBounds() && !this->hasUpperBounds()) {
         return;
     }
@@ -438,13 +354,13 @@ void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, s
     // that is printed for large results below.
     out << " [";
     if (this->hasLowerBounds()) {
-        print(out, this->isResultForAllStates() ? this->getLowerBoundVector()[state] : this->getLowerBoundMap().at(state));
+        print(out, this->getLowerBoundVector()[offset]);
     } else {
         out << "-inf";
     }
     out << ", ";
     if (this->hasUpperBounds()) {
-        print(out, this->isResultForAllStates() ? this->getUpperBoundVector()[state] : this->getUpperBoundMap().at(state));
+        print(out, this->getUpperBoundVector()[offset]);
     } else {
         out << "inf";
     }
@@ -454,51 +370,21 @@ void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, s
 template<typename ValueType>
 std::ostream& ExplicitQuantitativeCheckResult<ValueType>::writeToStream(std::ostream& out) const {
     bool minMaxSupported = std::is_same<ValueType, double>::value || std::is_same<ValueType, storm::RationalNumber>::value;
-    bool printAsRange = false;
 
-    if (this->isResultForAllStates()) {
-        vector_type const& valuesAsVector = boost::get<vector_type>(values);
-        if (valuesAsVector.size() >= 10 && minMaxSupported) {
-            printAsRange = true;
-        } else {
-            out << "{";
-            bool first = true;
-            for (uint64_t state = 0; state < valuesAsVector.size(); ++state) {
-                if (!first) {
-                    out << ", ";
-                } else {
-                    first = false;
-                }
-                this->printValue(out, state);
-            }
-            out << "}";
-        }
-    } else {
-        map_type const& valuesAsMap = boost::get<map_type>(values);
-        if (valuesAsMap.size() >= 10 && minMaxSupported) {
-            printAsRange = true;
-        } else {
-            if (valuesAsMap.size() == 1) {
-                this->printValue(out, valuesAsMap.begin()->first);
-            } else {
-                out << "{";
-                bool first = true;
-                for (auto const& element : valuesAsMap) {
-                    if (!first) {
-                        out << ", ";
-                    } else {
-                        first = false;
-                    }
-                    this->printValue(out, element.first);
-                }
-                out << "}";
-            }
-        }
-    }
-
-    if (printAsRange) {
+    if (values.size() >= 10 && minMaxSupported) {
         std::pair<ExtendedValueType, ExtendedValueType> minmax = this->getMinMax();
         printRange(out, minmax.first, minmax.second);
+    } else if (!this->isResultForAllStates() && values.size() == 1) {
+        this->printValue(out, 0);
+    } else {
+        out << "{";
+        for (uint64_t offset = 0; offset < values.size(); ++offset) {
+            if (offset > 0) {
+                out << ", ";
+            }
+            this->printValue(out, offset);
+        }
+        out << "}";
     }
 
     return out;
@@ -507,66 +393,39 @@ std::ostream& ExplicitQuantitativeCheckResult<ValueType>::writeToStream(std::ost
 template<typename ValueType>
 std::unique_ptr<CheckResult> ExplicitQuantitativeCheckResult<ValueType>::compareAgainstBound(storm::logic::ComparisonType comparisonType,
                                                                                              ValueType const& bound) const {
+    auto const compare = [&comparisonType, &bound](ExtendedValueType const& value) {
+        switch (comparisonType) {
+            case logic::ComparisonType::Less:
+                return value < bound;
+            case logic::ComparisonType::LessEqual:
+                return value <= bound;
+            case logic::ComparisonType::Greater:
+                return value > bound;
+            case logic::ComparisonType::GreaterEqual:
+                return value >= bound;
+        }
+        return false;
+    };
+
+    // A comparison is only sound if the bound fall outside the lower and upperbound of te result.
+    if (this->hasLowerBounds() && this->hasUpperBounds()) {
+        for (uint64_t offset = 0; offset < values.size(); ++offset) {
+            STORM_LOG_ASSERT(!((*bounds.lower)[offset] < bound && bound < (*bounds.upper)[offset]),
+                             "The bound " << bound << " lies between the lower bound " << (*bounds.lower)[offset] << " and the upper bound "
+                                          << (*bounds.upper)[offset] << ", so the comparison against it is not decided at state " << offset << ".");
+        }
+    }
+
+    storm::storage::BitVector result(values.size());
+    for (uint64_t offset = 0; offset < values.size(); ++offset) {
+        if (compare(values[offset])) {
+            result.set(offset);
+        }
+    }
     if (this->isResultForAllStates()) {
-        vector_type const& valuesAsVector = boost::get<vector_type>(values);
-        storm::storage::BitVector result(valuesAsVector.size());
-        switch (comparisonType) {
-            case logic::ComparisonType::Less:
-                for (uint_fast64_t index = 0; index < valuesAsVector.size(); ++index) {
-                    if (valuesAsVector[index] < bound) {
-                        result.set(index);
-                    }
-                }
-                break;
-            case logic::ComparisonType::LessEqual:
-                for (uint_fast64_t index = 0; index < valuesAsVector.size(); ++index) {
-                    if (valuesAsVector[index] <= bound) {
-                        result.set(index);
-                    }
-                }
-                break;
-            case logic::ComparisonType::Greater:
-                for (uint_fast64_t index = 0; index < valuesAsVector.size(); ++index) {
-                    if (valuesAsVector[index] > bound) {
-                        result.set(index);
-                    }
-                }
-                break;
-            case logic::ComparisonType::GreaterEqual:
-                for (uint_fast64_t index = 0; index < valuesAsVector.size(); ++index) {
-                    if (valuesAsVector[index] >= bound) {
-                        result.set(index);
-                    }
-                }
-                break;
-        }
-        return std::unique_ptr<CheckResult>(new ExplicitQualitativeCheckResult<ValueType>(std::move(result), std::move(scheduler)));
+        return std::unique_ptr<CheckResult>(new ExplicitQualitativeCheckResult<ValueType>(std::move(result), scheduler));
     } else {
-        map_type const& valuesAsMap = boost::get<map_type>(values);
-        std::map<storm::storage::sparse::state_type, bool> result;
-        switch (comparisonType) {
-            case logic::ComparisonType::Less:
-                for (auto const& element : valuesAsMap) {
-                    result[element.first] = element.second < bound;
-                }
-                break;
-            case logic::ComparisonType::LessEqual:
-                for (auto const& element : valuesAsMap) {
-                    result[element.first] = element.second <= bound;
-                }
-                break;
-            case logic::ComparisonType::Greater:
-                for (auto const& element : valuesAsMap) {
-                    result[element.first] = element.second > bound;
-                }
-                break;
-            case logic::ComparisonType::GreaterEqual:
-                for (auto const& element : valuesAsMap) {
-                    result[element.first] = element.second >= bound;
-                }
-                break;
-        }
-        return std::unique_ptr<CheckResult>(new ExplicitQualitativeCheckResult<ValueType>(std::move(result), std::move(scheduler)));
+        return std::unique_ptr<CheckResult>(new ExplicitQualitativeCheckResult<ValueType>(*states, std::move(result), scheduler));
     }
 }
 
@@ -580,24 +439,13 @@ std::unique_ptr<CheckResult> ExplicitQuantitativeCheckResult<storm::RationalFunc
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType& ExplicitQuantitativeCheckResult<ValueType>::operator[](
     storm::storage::sparse::state_type state) {
-    if (this->isResultForAllStates()) {
-        return boost::get<vector_type>(values)[state];
-    } else {
-        return boost::get<map_type>(values)[state];
-    }
+    return values[this->getOffset(state)];
 }
 
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType const& ExplicitQuantitativeCheckResult<ValueType>::operator[](
     storm::storage::sparse::state_type state) const {
-    if (this->isResultForAllStates()) {
-        return boost::get<vector_type>(values)[state];
-    } else {
-        map_type const& valuesAsMap = boost::get<map_type>(values);
-        auto const& keyValuePair = valuesAsMap.find(state);
-        STORM_LOG_THROW(keyValuePair != valuesAsMap.end(), storm::exceptions::InvalidOperationException, "Unknown key '" << state << "'.");
-        return keyValuePair->second;
-    }
+    return values[this->getOffset(state)];
 }
 
 template<typename ValueType>
@@ -607,7 +455,7 @@ bool ExplicitQuantitativeCheckResult<ValueType>::isExplicit() const {
 
 template<typename ValueType>
 bool ExplicitQuantitativeCheckResult<ValueType>::isResultForAllStates() const {
-    return values.which() == 0;
+    return !states.has_value();
 }
 
 template<typename ValueType>
@@ -617,15 +465,15 @@ bool ExplicitQuantitativeCheckResult<ValueType>::isExplicitQuantitativeCheckResu
 
 template<typename ValueType>
 void ExplicitQuantitativeCheckResult<ValueType>::oneMinus() {
-    detail::complementValues<ExtendedValueType>(values);
+    storm::utility::vector::subtractFromConstantOneVector(values);
     if (this->hasLowerBounds()) {
-        detail::complementValues<ExtendedValueType>(*lowerBounds);
+        storm::utility::vector::subtractFromConstantOneVector(*bounds.lower);
     }
     if (this->hasUpperBounds()) {
-        detail::complementValues<ExtendedValueType>(*upperBounds);
+        storm::utility::vector::subtractFromConstantOneVector(*bounds.upper);
     }
     // One minus is antitone, so what used to bound the values from below now bounds them from above.
-    std::swap(lowerBounds, upperBounds);
+    std::swap(bounds.lower, bounds.upper);
 }
 
 /*!
@@ -674,21 +522,11 @@ template<typename ValueType>
 storm::json<ValueType> ExplicitQuantitativeCheckResult<ValueType>::toJson(std::optional<storm::storage::sparse::Valuations> const& stateValuations,
                                                                           std::optional<storm::models::sparse::StateLabeling> const& stateLabels) const {
     storm::json<ValueType> result;
-    if (this->isResultForAllStates()) {
-        vector_type const& valuesAsVector = boost::get<vector_type>(values);
-        for (uint64_t state = 0; state < valuesAsVector.size(); ++state) {
-            insertJsonEntry(result, state, valuesAsVector[state], stateValuations, stateLabels,
-                            this->hasLowerBounds() ? std::make_optional(this->getLowerBoundVector()[state]) : std::nullopt,
-                            this->hasUpperBounds() ? std::make_optional(this->getUpperBoundVector()[state]) : std::nullopt);
-        }
-    } else {
-        map_type const& valuesAsMap = boost::get<map_type>(values);
-        for (auto const& stateValue : valuesAsMap) {
-            insertJsonEntry(result, stateValue.first, stateValue.second, stateValuations, stateLabels,
-                            this->hasLowerBounds() ? std::make_optional(this->getLowerBoundMap().at(stateValue.first)) : std::nullopt,
-                            this->hasUpperBounds() ? std::make_optional(this->getUpperBoundMap().at(stateValue.first)) : std::nullopt);
-        }
-    }
+    this->forEachState([&](storm::storage::sparse::state_type state, uint64_t offset) {
+        insertJsonEntry(result, state, values[offset], stateValuations, stateLabels,
+                        this->hasLowerBounds() ? std::make_optional(this->getLowerBoundVector()[offset]) : std::nullopt,
+                        this->hasUpperBounds() ? std::make_optional(this->getUpperBoundVector()[offset]) : std::nullopt);
+    });
     return result;
 }
 

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -46,21 +46,21 @@ ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(stor
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(std::vector<ValueType> const& values)
     requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
-    : values(storm::utility::fromSentinel(std::vector<ValueType>(values))) {
+    : values(storm::utility::widen(std::vector<ValueType>(values))) {
     // Intentionally left empty.
 }
 
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(std::vector<ValueType>&& values)
     requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
-    : values(storm::utility::fromSentinel(std::move(values))) {
+    : values(storm::utility::widen(std::move(values))) {
     // Intentionally left empty.
 }
 
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(storm::storage::BitVector states, std::vector<ValueType>&& values)
     requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
-    : states(std::move(states)), values(storm::utility::fromSentinel(std::move(values))) {
+    : states(std::move(states)), values(storm::utility::widen(std::move(values))) {
     STORM_LOG_ASSERT(this->states->getNumberOfSetBits() == this->values.size(), "Expected one value per selected state.");
 }
 

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -274,9 +274,8 @@ typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQ
 template<typename ValueType>
 typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQuantitativeCheckResult<ValueType>::aggregateVector(vector_type const& vector,
                                                                                                                                    FilterType filter) {
-    // A bound has the same shape as the values, so aggregating one is exactly what the methods above do, applied
-    // to a different vector. Wrapping it in a result of its own reuses them rather than repeating them, and keeps
-    // the two kinds of aggregate in step should any of them ever change.
+    // A bound has the same shape as the values, so wrapping it in a result of its own reuses the methods above
+    // rather than repeating them.
     ExplicitQuantitativeCheckResult<ValueType> const asResult{vector};
     switch (filter) {
         case FilterType::MIN:
@@ -295,8 +294,8 @@ typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType ExplicitQ
 template<typename ValueType>
 AggregatedValue<typename ExplicitQuantitativeCheckResult<ValueType>::ExtendedValueType> ExplicitQuantitativeCheckResult<ValueType>::aggregate(
     FilterType filter) const {
-    // The values go through the base implementation, i.e. through getMin(), sum() and friends, so that the
-    // aggregations keep whatever those promise about them.
+    // The values go through the base implementation, so the aggregations keep what getMin(), sum() and friends
+    // promise about them.
     AggregatedValue<ExtendedValueType> result = QuantitativeCheckResult<ValueType>::aggregate(filter);
     if (this->hasLowerBounds()) {
         result.lower = aggregateVector(*bounds.lower, filter);

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -180,8 +180,6 @@ void ExplicitQuantitativeCheckResult<ValueType>::setUpperBounds(vector_type uppe
 
 template<typename ValueType>
 void ExplicitQuantitativeCheckResult<ValueType>::setBounds(storm::solver::SolutionBounds<ExtendedValueType> bounds) {
-    // Each of the two sides is transferred only if the algorithm in question established it; the other side is
-    // left as it is.
     if (bounds.hasLower()) {
         this->setLowerBounds(std::move(*bounds.lower));
     }
@@ -226,8 +224,6 @@ void ExplicitQuantitativeCheckResult<ValueType>::filter(QualitativeCheckResult c
     STORM_LOG_THROW(selected.isSubsetOf(available), storm::exceptions::InvalidOperationException,
                     "The check result fails to contain some results referred to by the filter.");
 
-    // The entries that survive, in the index space the values are stored in. Note that the result is a result
-    // for the selected states even if those happen to be all of them.
     storm::storage::BitVector const keep = selected % available;
 
     if (this->hasLowerBounds()) {
@@ -350,11 +346,8 @@ void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, u
     if (!this->hasLowerBounds() && !this->hasUpperBounds()) {
         return;
     }
-    // The enclosure is printed next to the estimate. Note that this is unrelated to the range over all states
-    // that is printed for large results below.
     out << " [";
-    // A side that is not known is written as a dash rather than as the infinity that would bound anything, so
-    // that "nothing was proven here" cannot be read as "the value may be arbitrarily large".
+    // A side that is not known is written as a dash, so that it cannot be read as an infinite bound.
     if (this->hasLowerBounds()) {
         print(out, this->getLowerBoundVector()[offset]);
     } else {
@@ -409,7 +402,7 @@ std::unique_ptr<CheckResult> ExplicitQuantitativeCheckResult<ValueType>::compare
         return false;
     };
 
-    // A comparison is only sound if the bound fall outside the lower and upperbound of te result.
+    // A comparison is only sound if the bound falls outside the lower and upper bound of the result.
     if (this->hasLowerBounds() && this->hasUpperBounds()) {
         for (uint64_t offset = 0; offset < values.size(); ++offset) {
             STORM_LOG_WARN_COND(!((*bounds.lower)[offset] < bound && bound < (*bounds.upper)[offset]),
@@ -474,7 +467,7 @@ void ExplicitQuantitativeCheckResult<ValueType>::oneMinus() {
     if (this->hasUpperBounds()) {
         storm::utility::vector::subtractFromConstantOneVector(*bounds.upper);
     }
-    // One minus is antitone, so what used to bound the values from below now bounds them from above.
+    // Inverse the bounds, lb = 1 - ub and ub = 1 - lb.
     std::swap(bounds.lower, bounds.upper);
 }
 

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -15,6 +15,58 @@
 
 namespace storm {
 namespace modelchecker {
+
+namespace detail {
+/*!
+ * Restricts the given values to the states selected by the filter. Note that the result is always a map, even
+ * if the given values are a vector.
+ */
+template<typename ValueType>
+boost::variant<std::vector<ValueType>, std::map<storm::storage::sparse::state_type, ValueType>> filterValues(
+    boost::variant<std::vector<ValueType>, std::map<storm::storage::sparse::state_type, ValueType>> const& values,
+    storm::storage::BitVector const& filterTruthValues) {
+    typedef std::vector<ValueType> vector_type;
+    typedef std::map<storm::storage::sparse::state_type, ValueType> map_type;
+
+    map_type newMap;
+    if (values.which() == 0) {
+        vector_type const& valuesAsVector = boost::get<vector_type>(values);
+        for (auto element : filterTruthValues) {
+            STORM_LOG_THROW(element < valuesAsVector.size(), storm::exceptions::InvalidAccessException, "Invalid index in results.");
+            newMap.emplace(element, valuesAsVector[element]);
+        }
+    } else {
+        for (auto const& element : boost::get<map_type>(values)) {
+            if (filterTruthValues.get(element.first)) {
+                newMap.insert(element);
+            }
+        }
+        STORM_LOG_THROW(newMap.size() == filterTruthValues.getNumberOfSetBits(), storm::exceptions::InvalidOperationException,
+                        "The check result fails to contain some results referred to by the filter.");
+    }
+    return newMap;
+}
+
+/*!
+ * Replaces every value by one minus that value.
+ */
+template<typename ValueType>
+void complementValues(boost::variant<std::vector<ValueType>, std::map<storm::storage::sparse::state_type, ValueType>>& values) {
+    typedef std::vector<ValueType> vector_type;
+    typedef std::map<storm::storage::sparse::state_type, ValueType> map_type;
+
+    if (values.which() == 0) {
+        for (auto& element : boost::get<vector_type>(values)) {
+            element = storm::utility::one<ValueType>() - element;
+        }
+    } else {
+        for (auto& element : boost::get<map_type>(values)) {
+            element.second = storm::utility::one<ValueType>() - element.second;
+        }
+    }
+}
+}  // namespace detail
+
 template<typename ValueType>
 ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult() : values(map_type()) {
     // Intentionally left empty.
@@ -110,7 +162,10 @@ ExplicitQuantitativeCheckResult<ValueType>::ExplicitQuantitativeCheckResult(Expl
 
 template<typename ValueType>
 std::unique_ptr<CheckResult> ExplicitQuantitativeCheckResult<ValueType>::clone() const {
-    return std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(this->values, this->scheduler);
+    auto result = std::make_unique<ExplicitQuantitativeCheckResult<ValueType>>(this->values, this->scheduler);
+    result->lowerBounds = this->lowerBounds;
+    result->upperBounds = this->upperBounds;
+    return result;
 }
 
 template<typename ValueType>
@@ -134,6 +189,75 @@ std::vector<ValueType> ExplicitQuantitativeCheckResult<ValueType>::getFiniteValu
 }
 
 template<typename ValueType>
+bool ExplicitQuantitativeCheckResult<ValueType>::hasLowerBounds() const {
+    return lowerBounds.has_value();
+}
+
+template<typename ValueType>
+bool ExplicitQuantitativeCheckResult<ValueType>::hasUpperBounds() const {
+    return upperBounds.has_value();
+}
+
+template<typename ValueType>
+typename ExplicitQuantitativeCheckResult<ValueType>::vector_type const& ExplicitQuantitativeCheckResult<ValueType>::getLowerBoundVector() const {
+    STORM_LOG_THROW(this->hasLowerBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown lower bounds.");
+    return boost::get<vector_type>(*lowerBounds);
+}
+
+template<typename ValueType>
+typename ExplicitQuantitativeCheckResult<ValueType>::vector_type const& ExplicitQuantitativeCheckResult<ValueType>::getUpperBoundVector() const {
+    STORM_LOG_THROW(this->hasUpperBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown upper bounds.");
+    return boost::get<vector_type>(*upperBounds);
+}
+
+template<typename ValueType>
+typename ExplicitQuantitativeCheckResult<ValueType>::map_type const& ExplicitQuantitativeCheckResult<ValueType>::getLowerBoundMap() const {
+    STORM_LOG_THROW(this->hasLowerBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown lower bounds.");
+    return boost::get<map_type>(*lowerBounds);
+}
+
+template<typename ValueType>
+typename ExplicitQuantitativeCheckResult<ValueType>::map_type const& ExplicitQuantitativeCheckResult<ValueType>::getUpperBoundMap() const {
+    STORM_LOG_THROW(this->hasUpperBounds(), storm::exceptions::InvalidOperationException, "Unable to retrieve unknown upper bounds.");
+    return boost::get<map_type>(*upperBounds);
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::assertBoundsShape([[maybe_unused]] boost::variant<vector_type, map_type> const& bounds) const {
+    STORM_LOG_ASSERT(bounds.which() == values.which(), "Bounds must have the same shape as the values.");
+    if (this->isResultForAllStates()) {
+        STORM_LOG_ASSERT(boost::get<vector_type>(bounds).size() == boost::get<vector_type>(values).size(), "Bounds must have the same size as the values.");
+    } else {
+        STORM_LOG_ASSERT(boost::get<map_type>(bounds).size() == boost::get<map_type>(values).size(), "Bounds must have the same size as the values.");
+    }
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::setLowerBounds(boost::variant<vector_type, map_type> lowerBounds) {
+    this->assertBoundsShape(lowerBounds);
+    this->lowerBounds = std::move(lowerBounds);
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::setUpperBounds(boost::variant<vector_type, map_type> upperBounds) {
+    this->assertBoundsShape(upperBounds);
+    this->upperBounds = std::move(upperBounds);
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::setBounds(boost::variant<vector_type, map_type> lowerBounds,
+                                                           boost::variant<vector_type, map_type> upperBounds) {
+    this->setLowerBounds(std::move(lowerBounds));
+    this->setUpperBounds(std::move(upperBounds));
+}
+
+template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::clearBounds() {
+    lowerBounds = std::nullopt;
+    upperBounds = std::nullopt;
+}
+
+template<typename ValueType>
 void ExplicitQuantitativeCheckResult<ValueType>::filter(QualitativeCheckResult const& filter) {
     STORM_LOG_THROW(filter.isExplicitQualitativeCheckResult(), storm::exceptions::InvalidOperationException,
                     "Cannot filter explicit check result with non-explicit filter.");
@@ -142,29 +266,13 @@ void ExplicitQuantitativeCheckResult<ValueType>::filter(QualitativeCheckResult c
     ExplicitQualitativeCheckResult<ValueType> const& explicitFilter = filter.template asExplicitQualitativeCheckResult<ValueType>();
     typename ExplicitQualitativeCheckResult<ValueType>::vector_type const& filterTruthValues = explicitFilter.getTruthValuesVector();
 
-    if (this->isResultForAllStates()) {
-        map_type newMap;
-
-        for (auto element : filterTruthValues) {
-            STORM_LOG_THROW(element < this->getValueVector().size(), storm::exceptions::InvalidAccessException, "Invalid index in results.");
-            newMap.emplace(element, this->getValueVector()[element]);
-        }
-        this->values = newMap;
-    } else {
-        map_type const& map = boost::get<map_type>(values);
-
-        map_type newMap;
-        for (auto const& element : map) {
-            if (filterTruthValues.get(element.first)) {
-                newMap.insert(element);
-            }
-        }
-
-        STORM_LOG_THROW(newMap.size() == filterTruthValues.getNumberOfSetBits(), storm::exceptions::InvalidOperationException,
-                        "The check result fails to contain some results referred to by the filter.");
-
-        this->values = newMap;
+    if (this->hasLowerBounds()) {
+        this->lowerBounds = detail::filterValues<ExtendedValueType>(*this->lowerBounds, filterTruthValues);
     }
+    if (this->hasUpperBounds()) {
+        this->upperBounds = detail::filterValues<ExtendedValueType>(*this->upperBounds, filterTruthValues);
+    }
+    this->values = detail::filterValues<ExtendedValueType>(this->values, filterTruthValues);
 }
 
 template<typename ValueType>
@@ -321,6 +429,29 @@ void printRange(std::ostream& out, ValueType const& min, ValueType const& max) {
 }
 
 template<typename ValueType>
+void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, storm::storage::sparse::state_type state) const {
+    print(out, (*this)[state]);
+    if (!this->hasLowerBounds() && !this->hasUpperBounds()) {
+        return;
+    }
+    // The enclosure is printed next to the estimate. Note that this is unrelated to the range over all states
+    // that is printed for large results below.
+    out << " [";
+    if (this->hasLowerBounds()) {
+        print(out, this->isResultForAllStates() ? this->getLowerBoundVector()[state] : this->getLowerBoundMap().at(state));
+    } else {
+        out << "-inf";
+    }
+    out << ", ";
+    if (this->hasUpperBounds()) {
+        print(out, this->isResultForAllStates() ? this->getUpperBoundVector()[state] : this->getUpperBoundMap().at(state));
+    } else {
+        out << "inf";
+    }
+    out << "]";
+}
+
+template<typename ValueType>
 std::ostream& ExplicitQuantitativeCheckResult<ValueType>::writeToStream(std::ostream& out) const {
     bool minMaxSupported = std::is_same<ValueType, double>::value || std::is_same<ValueType, storm::RationalNumber>::value;
     bool printAsRange = false;
@@ -332,13 +463,13 @@ std::ostream& ExplicitQuantitativeCheckResult<ValueType>::writeToStream(std::ost
         } else {
             out << "{";
             bool first = true;
-            for (auto const& element : valuesAsVector) {
+            for (uint64_t state = 0; state < valuesAsVector.size(); ++state) {
                 if (!first) {
                     out << ", ";
                 } else {
                     first = false;
                 }
-                print(out, element);
+                this->printValue(out, state);
             }
             out << "}";
         }
@@ -348,7 +479,7 @@ std::ostream& ExplicitQuantitativeCheckResult<ValueType>::writeToStream(std::ost
             printAsRange = true;
         } else {
             if (valuesAsMap.size() == 1) {
-                print(out, valuesAsMap.begin()->second);
+                this->printValue(out, valuesAsMap.begin()->first);
             } else {
                 out << "{";
                 bool first = true;
@@ -358,7 +489,7 @@ std::ostream& ExplicitQuantitativeCheckResult<ValueType>::writeToStream(std::ost
                     } else {
                         first = false;
                     }
-                    print(out, element.second);
+                    this->printValue(out, element.first);
                 }
                 out << "}";
             }
@@ -486,35 +617,51 @@ bool ExplicitQuantitativeCheckResult<ValueType>::isExplicitQuantitativeCheckResu
 
 template<typename ValueType>
 void ExplicitQuantitativeCheckResult<ValueType>::oneMinus() {
-    if (this->isResultForAllStates()) {
-        for (auto& element : boost::get<vector_type>(values)) {
-            element = storm::utility::one<ExtendedValueType>() - element;
-        }
+    detail::complementValues<ExtendedValueType>(values);
+    if (this->hasLowerBounds()) {
+        detail::complementValues<ExtendedValueType>(*lowerBounds);
+    }
+    if (this->hasUpperBounds()) {
+        detail::complementValues<ExtendedValueType>(*upperBounds);
+    }
+    // One minus is antitone, so what used to bound the values from below now bounds them from above.
+    std::swap(lowerBounds, upperBounds);
+}
+
+/*!
+ * Writes the given value under the given key, spelling out an infinity that the plain value type cannot represent.
+ */
+template<typename ValueType>
+void insertJsonValue(storm::json<ValueType>& entry, std::string const& key, storm::utility::ExtendedValueType<ValueType> const& value) {
+    if (storm::utility::isInfinity(value)) {
+        entry[key] = "inf";
+    } else if (storm::utility::isNegativeInfinity(value)) {
+        entry[key] = "-inf";
+    } else if constexpr (std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>) {
+        entry[key] = value;
     } else {
-        for (auto& element : boost::get<map_type>(values)) {
-            element.second = storm::utility::one<ExtendedValueType>() - element.second;
-        }
+        entry[key] = value.getFinite();
     }
 }
 
 template<typename ValueType>
 void insertJsonEntry(storm::json<ValueType>& json, uint64_t const& id, storm::utility::ExtendedValueType<ValueType> const& value,
                      std::optional<storm::storage::sparse::Valuations> const& stateValuations = std::nullopt,
-                     std::optional<storm::models::sparse::StateLabeling> const& stateLabels = std::nullopt) {
+                     std::optional<storm::models::sparse::StateLabeling> const& stateLabels = std::nullopt,
+                     std::optional<storm::utility::ExtendedValueType<ValueType>> const& lowerBound = std::nullopt,
+                     std::optional<storm::utility::ExtendedValueType<ValueType>> const& upperBound = std::nullopt) {
     typename storm::json<ValueType> entry;
     if (stateValuations) {
         entry["s"] = stateValuations->template toJson<ValueType>(id);
     } else {
         entry["s"] = id;
     }
-    if (storm::utility::isInfinity(value)) {
-        entry["v"] = "inf";
-    } else if (storm::utility::isNegativeInfinity(value)) {
-        entry["v"] = "-inf";
-    } else if constexpr (std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>) {
-        entry["v"] = value;
-    } else {
-        entry["v"] = value.getFinite();
+    insertJsonValue(entry, "v", value);
+    if (lowerBound) {
+        insertJsonValue(entry, "lb", *lowerBound);
+    }
+    if (upperBound) {
+        insertJsonValue(entry, "ub", *upperBound);
     }
     if (stateLabels) {
         auto labs = stateLabels->getLabelsOfState(id);
@@ -530,12 +677,16 @@ storm::json<ValueType> ExplicitQuantitativeCheckResult<ValueType>::toJson(std::o
     if (this->isResultForAllStates()) {
         vector_type const& valuesAsVector = boost::get<vector_type>(values);
         for (uint64_t state = 0; state < valuesAsVector.size(); ++state) {
-            insertJsonEntry(result, state, valuesAsVector[state], stateValuations, stateLabels);
+            insertJsonEntry(result, state, valuesAsVector[state], stateValuations, stateLabels,
+                            this->hasLowerBounds() ? std::make_optional(this->getLowerBoundVector()[state]) : std::nullopt,
+                            this->hasUpperBounds() ? std::make_optional(this->getUpperBoundVector()[state]) : std::nullopt);
         }
     } else {
         map_type const& valuesAsMap = boost::get<map_type>(values);
         for (auto const& stateValue : valuesAsMap) {
-            insertJsonEntry(result, stateValue.first, stateValue.second, stateValuations, stateLabels);
+            insertJsonEntry(result, stateValue.first, stateValue.second, stateValuations, stateLabels,
+                            this->hasLowerBounds() ? std::make_optional(this->getLowerBoundMap().at(stateValue.first)) : std::nullopt,
+                            this->hasUpperBounds() ? std::make_optional(this->getUpperBoundMap().at(stateValue.first)) : std::nullopt);
         }
     }
     return result;

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -410,9 +410,9 @@ std::unique_ptr<CheckResult> ExplicitQuantitativeCheckResult<ValueType>::compare
     // A comparison is only sound if the bound fall outside the lower and upperbound of te result.
     if (this->hasLowerBounds() && this->hasUpperBounds()) {
         for (uint64_t offset = 0; offset < values.size(); ++offset) {
-            STORM_LOG_ASSERT(!((*bounds.lower)[offset] < bound && bound < (*bounds.upper)[offset]),
-                             "The bound " << bound << " lies between the lower bound " << (*bounds.lower)[offset] << " and the upper bound "
-                                          << (*bounds.upper)[offset] << ", so the comparison against it is not decided at state " << offset << ".");
+            STORM_LOG_WARN_COND(!((*bounds.lower)[offset] < bound && bound < (*bounds.upper)[offset]),
+                                "The bound " << bound << " lies between the lower bound " << (*bounds.lower)[offset] << " and the upper bound "
+                                             << (*bounds.upper)[offset] << ", so the comparison against it is not decided at state " << offset << ".");
         }
     }
 

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -353,16 +353,18 @@ void ExplicitQuantitativeCheckResult<ValueType>::printValue(std::ostream& out, u
     // The enclosure is printed next to the estimate. Note that this is unrelated to the range over all states
     // that is printed for large results below.
     out << " [";
+    // A side that is not known is written as a dash rather than as the infinity that would bound anything, so
+    // that "nothing was proven here" cannot be read as "the value may be arbitrarily large".
     if (this->hasLowerBounds()) {
         print(out, this->getLowerBoundVector()[offset]);
     } else {
-        out << "-inf";
+        out << "-";
     }
     out << ", ";
     if (this->hasUpperBounds()) {
         print(out, this->getUpperBoundVector()[offset]);
     } else {
-        out << "inf";
+        out << "-";
     }
     out << "]";
 }

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.cpp
@@ -195,10 +195,10 @@ void ExplicitQuantitativeCheckResult<ValueType>::setBounds(storm::solver::Soluti
     requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>)
 {
     if (bounds.hasLower()) {
-        this->setLowerBounds(storm::utility::fromSentinel(std::move(*bounds.lower)));
+        this->setLowerBounds(storm::utility::widen(std::move(*bounds.lower)));
     }
     if (bounds.hasUpper()) {
-        this->setUpperBounds(storm::utility::fromSentinel(std::move(*bounds.upper)));
+        this->setUpperBounds(storm::utility::widen(std::move(*bounds.upper)));
     }
 }
 

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -85,6 +85,36 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
      */
     std::vector<ValueType> getSentinelValueVector() const;
 
+    /*!
+     * Retrieves whether sound lower resp. upper bounds on the actual values are known.
+     * A bound that is not known is not stored at all, so that "no information" cannot be confused with an
+     * infinite bound: an individual entry of a known bound may well be (minus) infinity.
+     */
+    bool hasLowerBounds() const;
+    bool hasUpperBounds() const;
+
+    /*!
+     * Retrieves the sound lower resp. upper bounds on the actual values.
+     * @pre The respective bounds are known.
+     */
+    vector_type const& getLowerBoundVector() const;
+    vector_type const& getUpperBoundVector() const;
+    map_type const& getLowerBoundMap() const;
+    map_type const& getUpperBoundMap() const;
+
+    /*!
+     * Sets sound bounds on the actual values. The bounds must have the same shape as the values, i.e. a vector
+     * of the same size resp. a map with the same keys.
+     */
+    void setLowerBounds(boost::variant<vector_type, map_type> lowerBounds);
+    void setUpperBounds(boost::variant<vector_type, map_type> upperBounds);
+    void setBounds(boost::variant<vector_type, map_type> lowerBounds, boost::variant<vector_type, map_type> upperBounds);
+
+    /*!
+     * Drops all bounds, e.g. after an operation that cannot maintain them.
+     */
+    void clearBounds();
+
     virtual std::ostream& writeToStream(std::ostream& out) const override;
 
     virtual void filter(QualitativeCheckResult const& filter) override;
@@ -110,8 +140,25 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
         return t == typeid(ValueType);
     }
 
-    // The values of the quantitative check result.
+    /*!
+     * Asserts that the given bounds have the same shape as the values.
+     */
+    void assertBoundsShape(boost::variant<vector_type, map_type> const& bounds) const;
+
+    /*!
+     * Writes the value of the given state, followed by its bounds if any are known.
+     */
+    void printValue(std::ostream& out, storm::storage::sparse::state_type state) const;
+
+    // The values of the quantitative check result. These are estimates of the actual values, which lie within
+    // the bounds below but carry no further guarantee.
     boost::variant<vector_type, map_type> values;
+
+    // Sound lower bounds on the actual values, if an algorithm provided them.
+    std::optional<boost::variant<vector_type, map_type>> lowerBounds;
+
+    // Sound upper bounds on the actual values, if an algorithm provided them.
+    std::optional<boost::variant<vector_type, map_type>> upperBounds;
 
     // An optional scheduler that accompanies the values.
     std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler;

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -52,8 +52,10 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
                                     std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
 
     /*!
-     * Takes over values that are still expressed in the plain value type, reading an entry equal to the value that
-     * storm::utility::infinity yields as an infinity.
+     * Takes over values that are still expressed in the plain value type. Those are taken to be finite throughout:
+     * no sentinel is read out of them, mirroring how bounds arriving in the plain type are treated. A computation
+     * that can produce an infinite value says so by handing over the extended type instead, which every such path
+     * in the sparse engine does.
      */
     ExplicitQuantitativeCheckResult(std::vector<ValueType> const& values)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -1,7 +1,4 @@
 #pragma once
-#include <boost/optional.hpp>
-#include <boost/variant.hpp>
-#include <map>
 #include <optional>
 #include <vector>
 
@@ -9,6 +6,7 @@
 #include "storm/modelchecker/results/QuantitativeCheckResult.h"
 #include "storm/models/sparse/StateLabeling.h"
 #include "storm/solver/SolutionBounds.h"
+#include "storm/storage/BitVector.h"
 #include "storm/storage/Scheduler.h"
 #include "storm/storage/sparse/StateType.h"
 #include "storm/storage/valuations/Valuations.h"
@@ -21,34 +19,48 @@ namespace modelchecker {
 template<typename ValueType>
 class ExplicitQualitativeCheckResult;
 
+/*!
+ * A quantitative check result over the states of a sparse model.
+ *
+ * The result either covers every state of the model or just a subset of them, e.g. after filtering it to the
+ * initial states. In the latter case the states in question are recorded in a bit vector and the values are
+ * stored compressed, i.e. the i-th value belongs to the i-th state selected by that bit vector.
+ */
 template<typename ValueType>
 class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType> {
    public:
     typedef typename QuantitativeCheckResult<ValueType>::ExtendedValueType ExtendedValueType;
     typedef std::vector<ExtendedValueType> vector_type;
-    typedef std::map<storm::storage::sparse::state_type, ExtendedValueType> map_type;
-
-    ExplicitQuantitativeCheckResult();
-    ExplicitQuantitativeCheckResult(map_type const& values);
-    ExplicitQuantitativeCheckResult(map_type&& values);
-    ExplicitQuantitativeCheckResult(storm::storage::sparse::state_type const& state, ExtendedValueType const& value);
-    ExplicitQuantitativeCheckResult(vector_type const& values);
-    ExplicitQuantitativeCheckResult(vector_type&& values);
 
     /*!
-     * Takes over a result that is still expressed in the plain value type, reading an entry equal to the value that
+     * Creates a result that holds the given value for the given state only.
+     */
+    ExplicitQuantitativeCheckResult(storm::storage::sparse::state_type const& state, ExtendedValueType const& value);
+
+    /*!
+     * Creates a result for all states of a model with the given number of states.
+     */
+    ExplicitQuantitativeCheckResult(vector_type const& values, std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
+    ExplicitQuantitativeCheckResult(vector_type&& values, std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
+
+    /*!
+     * Creates a result for the given states only.
+     * @param states The states the result is for.
+     * @param values One value per state selected by @p states, in the order of the selected states.
+     */
+    ExplicitQuantitativeCheckResult(storm::storage::BitVector states, vector_type&& values,
+                                    std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
+
+    /*!
+     * Takes over values that are still expressed in the plain value type, reading an entry equal to the value that
      * storm::utility::infinity yields as an infinity.
      */
     ExplicitQuantitativeCheckResult(std::vector<ValueType> const& values)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);
     ExplicitQuantitativeCheckResult(std::vector<ValueType>&& values)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);
-    ExplicitQuantitativeCheckResult(std::map<storm::storage::sparse::state_type, ValueType> const& values)
+    ExplicitQuantitativeCheckResult(storm::storage::BitVector states, std::vector<ValueType>&& values)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);
-    ExplicitQuantitativeCheckResult(boost::variant<vector_type, map_type> const& values,
-                                    std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
-    ExplicitQuantitativeCheckResult(boost::variant<vector_type, map_type>&& values,
-                                    std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
 
     ExplicitQuantitativeCheckResult(ExplicitQuantitativeCheckResult const& other) = default;
     ExplicitQuantitativeCheckResult& operator=(ExplicitQuantitativeCheckResult const& other) = default;
@@ -60,6 +72,10 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
 
     virtual std::unique_ptr<CheckResult> clone() const override;
 
+    /*!
+     * Retrieves the value of the given state.
+     * @pre The result holds a value for that state.
+     */
     ExtendedValueType& operator[](storm::storage::sparse::state_type state);
     ExtendedValueType const& operator[](storm::storage::sparse::state_type state) const;
 
@@ -70,9 +86,23 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
 
     virtual bool isExplicitQuantitativeCheckResult() const override;
 
+    /*!
+     * Retrieves whether the result holds a value for the given state.
+     */
+    bool hasValueForState(storm::storage::sparse::state_type state) const;
+
+    /*!
+     * Retrieves the states this result holds values for.
+     * @pre This is not a result for all states.
+     */
+    storm::storage::BitVector const& getStates() const;
+
+    /*!
+     * Retrieves the values, one per state this result is for. If this is not a result for all states, the i-th
+     * value belongs to the i-th state selected by getStates().
+     */
     vector_type const& getValueVector() const;
     vector_type& getValueVector();
-    map_type const& getValueMap() const;
 
     /*!
      * @pre no value is infinite
@@ -95,21 +125,32 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     bool hasUpperBounds() const;
 
     /*!
-     * Retrieves the sound lower resp. upper bounds on the actual values.
+     * Retrieves the sound lower resp. upper bounds on the actual values. These have the same shape as the
+     * values, i.e. they are indexed in the same way.
      * @pre The respective bounds are known.
      */
     vector_type const& getLowerBoundVector() const;
     vector_type const& getUpperBoundVector() const;
-    map_type const& getLowerBoundMap() const;
-    map_type const& getUpperBoundMap() const;
 
     /*!
-     * Sets sound bounds on the actual values. The bounds must have the same shape as the values, i.e. a vector
-     * of the same size resp. a map with the same keys.
+     * Retrieves both bounds at once, either of which may be unset.
      */
-    void setLowerBounds(boost::variant<vector_type, map_type> lowerBounds);
-    void setUpperBounds(boost::variant<vector_type, map_type> upperBounds);
-    void setBounds(boost::variant<vector_type, map_type> lowerBounds, boost::variant<vector_type, map_type> upperBounds);
+    storm::solver::SolutionBounds<ExtendedValueType> const& getSolutionBounds() const;
+
+    /*!
+     * Sets sound bounds on the actual values. Each bound must have the same shape as the values, i.e. hold one
+     * entry per state this result is for.
+     */
+    void setLowerBounds(vector_type lowerBounds);
+    void setUpperBounds(vector_type upperBounds);
+    void setBounds(storm::solver::SolutionBounds<ExtendedValueType> bounds);
+
+    /*!
+     * Sets bounds that are still expressed in the plain value type, reading an entry equal to the value that
+     * storm::utility::infinity yields as an infinity.
+     */
+    void setBounds(storm::solver::SolutionBounds<ValueType> bounds)
+        requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);
 
     /*!
      * Drops all bounds, e.g. after an operation that cannot maintain them.
@@ -142,41 +183,51 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     }
 
     /*!
-     * Asserts that the given bounds have the same shape as the values.
+     * Retrieves the index at which the value of the given state is stored.
+     * @pre The result holds a value for that state.
      */
-    void assertBoundsShape(boost::variant<vector_type, map_type> const& bounds) const;
+    uint64_t getOffset(storm::storage::sparse::state_type state) const;
 
     /*!
-     * Writes the value of the given state, followed by its bounds if any are known.
+     * Invokes the given function with the state and the offset of its value, for every state this result is for.
      */
-    void printValue(std::ostream& out, storm::storage::sparse::state_type state) const;
+    template<typename Function>
+    void forEachState(Function const& f) const {
+        if (states) {
+            uint64_t offset = 0;
+            for (auto const& state : *states) {
+                f(state, offset);
+                ++offset;
+            }
+        } else {
+            for (uint64_t state = 0; state < values.size(); ++state) {
+                f(state, state);
+            }
+        }
+    }
 
-    // The values of the quantitative check result. These are estimates of the actual values, which lie within
-    // the bounds below but carry no further guarantee.
-    boost::variant<vector_type, map_type> values;
+    /*!
+     * Asserts that the given bounds have the same shape as the values.
+     */
+    void assertBoundsShape(vector_type const& bounds) const;
 
-    // Sound lower bounds on the actual values, if an algorithm provided them.
-    std::optional<boost::variant<vector_type, map_type>> lowerBounds;
+    /*!
+     * Writes the value stored at the given offset, followed by its bounds if any are known.
+     */
+    void printValue(std::ostream& out, uint64_t offset) const;
 
-    // Sound upper bounds on the actual values, if an algorithm provided them.
-    std::optional<boost::variant<vector_type, map_type>> upperBounds;
+    // The states this result holds values for, or nothing at all if it is a result for all states.
+    std::optional<storm::storage::BitVector> states;
+
+    // The values of the quantitative check result, one per state this result is for. These are estimates of the
+    // actual values, which lie within the bounds below but carry no further guarantee.
+    vector_type values;
+
+    // Sound bounds on the actual values, if an algorithm provided them.
+    storm::solver::SolutionBounds<ExtendedValueType> bounds;
 
     // An optional scheduler that accompanies the values.
     std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler;
 };
-
-/*!
- * Transfers the sound bounds that an algorithm computed to the given check result. Each of the two sides is
- * transferred only if the algorithm established it; the other side is left alone.
- */
-template<typename ValueType>
-void setBounds(ExplicitQuantitativeCheckResult<ValueType>& result, storm::solver::SolutionBounds<ValueType>& bounds) {
-    if (bounds.hasLower()) {
-        result.setLowerBounds(std::move(*bounds.lower));
-    }
-    if (bounds.hasUpper()) {
-        result.setUpperBounds(std::move(*bounds.upper));
-    }
-}
 }  // namespace modelchecker
 }  // namespace storm

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -8,6 +8,7 @@
 #include "storm/adapters/JsonForward.h"
 #include "storm/modelchecker/results/QuantitativeCheckResult.h"
 #include "storm/models/sparse/StateLabeling.h"
+#include "storm/solver/SolutionBounds.h"
 #include "storm/storage/Scheduler.h"
 #include "storm/storage/sparse/StateType.h"
 #include "storm/storage/valuations/Valuations.h"
@@ -163,5 +164,19 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     // An optional scheduler that accompanies the values.
     std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler;
 };
+
+/*!
+ * Transfers the sound bounds that an algorithm computed to the given check result. Each of the two sides is
+ * transferred only if the algorithm established it; the other side is left alone.
+ */
+template<typename ValueType>
+void setBounds(ExplicitQuantitativeCheckResult<ValueType>& result, storm::solver::SolutionBounds<ValueType>& bounds) {
+    if (bounds.hasLower()) {
+        result.setLowerBounds(std::move(*bounds.lower));
+    }
+    if (bounds.hasUpper()) {
+        result.setUpperBounds(std::move(*bounds.upper));
+    }
+}
 }  // namespace modelchecker
 }  // namespace storm

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -52,10 +52,8 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
                                     std::optional<std::shared_ptr<storm::storage::Scheduler<ValueType>>> scheduler = {});
 
     /*!
-     * Takes over values that are still expressed in the plain value type. Those are taken to be finite throughout:
-     * no sentinel is read out of them, mirroring how bounds arriving in the plain type are treated. A computation
-     * that can produce an infinite value says so by handing over the extended type instead, which every such path
-     * in the sparse engine does.
+     * Takes over values that are still expressed in the plain value type, which are taken to be finite. A
+     * computation that can produce an infinite value hands over the extended type instead.
      */
     ExplicitQuantitativeCheckResult(std::vector<ValueType> const& values)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);
@@ -120,8 +118,6 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
 
     /*!
      * Retrieves whether sound lower resp. upper bounds on the actual values are known.
-     * A bound that is not known is not stored at all, so that "no information" cannot be confused with an
-     * infinite bound: an individual entry of a known bound may well be (minus) infinity.
      */
     bool hasLowerBounds() const;
     bool hasUpperBounds() const;
@@ -148,9 +144,8 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     void setBounds(storm::solver::SolutionBounds<ExtendedValueType> bounds);
 
     /*!
-     * Sets bounds that are still expressed in the plain value type. Bounds that arrive in that type are taken to
-     * be finite throughout: no sentinel is read out of them, since nothing hands bounds around by sentinel.
-     * An algorithm that can bound a value by infinity states so by handing over the extended type instead.
+     * Sets bounds that are still expressed in the plain value type, which are taken to be finite. An algorithm
+     * that can bound a value by infinity hands over the extended type instead.
      */
     void setBounds(storm::solver::SolutionBounds<ValueType> bounds)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);
@@ -222,8 +217,8 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     // The states this result holds values for, or nothing at all if it is a result for all states.
     std::optional<storm::storage::BitVector> states;
 
-    // The values of the quantitative check result, one per state this result is for. These are estimates of the
-    // actual values, which lie within the bounds below but carry no further guarantee.
+    // The values of the quantitative check result, one per state this result is for. These are estimates that
+    // lie within the bounds below but carry no further guarantee.
     vector_type values;
 
     // Sound bounds on the actual values, if an algorithm provided them.

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -183,9 +183,7 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     }
 
     /*!
-     * Aggregates a single vector of this result, i.e. the values or one of the bounds on them. Unlike sum() and
-     * average(), which are for the values and reject an infinity, this tolerates one: an infinite bound on a value
-     * is a legitimate statement, and it carries over to the aggregate.
+     * Aggregates a single vector of this result, i.e. the values or one of the bounds on them.
      */
     static ExtendedValueType aggregateVector(vector_type const& vector, FilterType filter);
 

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -146,8 +146,9 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     void setBounds(storm::solver::SolutionBounds<ExtendedValueType> bounds);
 
     /*!
-     * Sets bounds that are still expressed in the plain value type, reading an entry equal to the value that
-     * storm::utility::infinity yields as an infinity.
+     * Sets bounds that are still expressed in the plain value type. Bounds that arrive in that type are taken to
+     * be finite throughout: no sentinel is read out of them, since nothing hands bounds around by sentinel.
+     * An algorithm that can bound a value by infinity states so by handing over the extended type instead.
      */
     void setBounds(storm::solver::SolutionBounds<ValueType> bounds)
         requires(!std::is_same_v<storm::utility::ExtendedValueType<ValueType>, ValueType>);

--- a/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/ExplicitQuantitativeCheckResult.h
@@ -167,6 +167,8 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     virtual ExtendedValueType average() const override;
     virtual ExtendedValueType sum() const override;
 
+    virtual AggregatedValue<ExtendedValueType> aggregate(FilterType filter) const override;
+
     virtual bool hasScheduler() const override;
     void setScheduler(std::unique_ptr<storm::storage::Scheduler<ValueType>>&& scheduler);
     storm::storage::Scheduler<ValueType> const& getScheduler() const;
@@ -179,6 +181,13 @@ class ExplicitQuantitativeCheckResult : public QuantitativeCheckResult<ValueType
     bool hasValueType(std::type_info const& t) const override {
         return t == typeid(ValueType);
     }
+
+    /*!
+     * Aggregates a single vector of this result, i.e. the values or one of the bounds on them. Unlike sum() and
+     * average(), which are for the values and reject an infinity, this tolerates one: an infinite bound on a value
+     * is a legitimate statement, and it carries over to the aggregate.
+     */
+    static ExtendedValueType aggregateVector(vector_type const& vector, FilterType filter);
 
     /*!
      * Retrieves the index at which the value of the given state is stored.

--- a/src/storm/modelchecker/results/QuantitativeCheckResult.cpp
+++ b/src/storm/modelchecker/results/QuantitativeCheckResult.cpp
@@ -13,6 +13,22 @@ std::unique_ptr<CheckResult> QuantitativeCheckResult<ValueType>::compareAgainstB
 }
 
 template<typename ValueType>
+AggregatedValue<typename QuantitativeCheckResult<ValueType>::ExtendedValueType> QuantitativeCheckResult<ValueType>::aggregate(FilterType filter) const {
+    switch (filter) {
+        case FilterType::MIN:
+            return {this->getMin(), std::nullopt, std::nullopt};
+        case FilterType::MAX:
+            return {this->getMax(), std::nullopt, std::nullopt};
+        case FilterType::SUM:
+            return {this->sum(), std::nullopt, std::nullopt};
+        case FilterType::AVG:
+            return {this->average(), std::nullopt, std::nullopt};
+        default:
+            STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "The filter " << toString(filter) << " does not aggregate values.");
+    }
+}
+
+template<typename ValueType>
 bool QuantitativeCheckResult<ValueType>::isQuantitative() const {
     return true;
 }

--- a/src/storm/modelchecker/results/QuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/QuantitativeCheckResult.h
@@ -1,10 +1,34 @@
 #pragma once
 
+#include <optional>
+
 #include "storm/modelchecker/results/CheckResult.h"
+#include "storm/modelchecker/results/FilterType.h"
 #include "storm/utility/ExtendedNumber.h"
 
 namespace storm {
 namespace modelchecker {
+
+/*!
+ * The outcome of aggregating a quantitative check result over the states it is for: the aggregate of the values,
+ * together with an aggregate of the lower resp. upper bounds where the result carries them. The two bounds are
+ * independently optional, exactly as the bounds on the individual values are.
+ */
+template<typename ValueType>
+struct AggregatedValue {
+    ValueType value;
+    std::optional<ValueType> lower;
+    std::optional<ValueType> upper;
+
+    bool hasLower() const {
+        return lower.has_value();
+    }
+
+    bool hasUpper() const {
+        return upper.has_value();
+    }
+};
+
 template<typename ValueType>
 class QuantitativeCheckResult : public CheckResult {
    public:
@@ -21,6 +45,17 @@ class QuantitativeCheckResult : public CheckResult {
 
     virtual ExtendedValueType average() const = 0;
     virtual ExtendedValueType sum() const = 0;
+
+    /*!
+     * Aggregates the values of this result with the given filter. Where this result carries sound bounds on its
+     * values, the aggregate of those is reported alongside: every aggregation offered here is monotone in each
+     * individual value, so aggregating the lower resp. upper bounds bounds the aggregate of the values.
+     *
+     * The default implementation reports no bounds, which is what a result that cannot carry any should do.
+     *
+     * @param filter One of MIN, MAX, SUM or AVG.
+     */
+    virtual AggregatedValue<ExtendedValueType> aggregate(FilterType filter) const;
 
     virtual bool isQuantitative() const override;
 };

--- a/src/storm/modelchecker/results/QuantitativeCheckResult.h
+++ b/src/storm/modelchecker/results/QuantitativeCheckResult.h
@@ -10,9 +10,8 @@ namespace storm {
 namespace modelchecker {
 
 /*!
- * The outcome of aggregating a quantitative check result over the states it is for: the aggregate of the values,
- * together with an aggregate of the lower resp. upper bounds where the result carries them. The two bounds are
- * independently optional, exactly as the bounds on the individual values are.
+ * The aggregate of the values of a quantitative check result, together with the aggregate of each bound the
+ * result carries.
  */
 template<typename ValueType>
 struct AggregatedValue {
@@ -47,11 +46,8 @@ class QuantitativeCheckResult : public CheckResult {
     virtual ExtendedValueType sum() const = 0;
 
     /*!
-     * Aggregates the values of this result with the given filter. Where this result carries sound bounds on its
-     * values, the aggregate of those is reported alongside: every aggregation offered here is monotone in each
-     * individual value, so aggregating the lower resp. upper bounds bounds the aggregate of the values.
-     *
-     * The default implementation reports no bounds, which is what a result that cannot carry any should do.
+     * Aggregates the values of this result with the given filter, and each bound it carries alongside. Every
+     * aggregation offered here is monotone in each value, so aggregating a bound bounds the aggregate.
      *
      * @param filter One of MIN, MAX, SUM or AVG.
      */

--- a/src/storm/solver/AbstractEquationSolver.cpp
+++ b/src/storm/solver/AbstractEquationSolver.cpp
@@ -270,6 +270,35 @@ void AbstractEquationSolver<ValueType>::setSolutionBounds(SolutionBounds<ValueTy
 }
 
 template<typename ValueType>
+void AbstractEquationSolver<ValueType>::setSolutionBoundsFromPrecision(std::vector<ValueType> const& x, ValueType const& precision, bool relative) const {
+    if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
+        STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Cannot derive solution bounds from a precision for rational functions.");
+    } else {
+        STORM_LOG_ASSERT(!relative || precision < storm::utility::one<ValueType>(), "A relative precision of one or more carries no information.");
+        SolutionBounds<ValueType> bounds;
+        std::vector<ValueType>& lower = bounds.lower.emplace(x.size());
+        std::vector<ValueType>& upper = bounds.upper.emplace(x.size());
+        bool const tightenFromBelow = this->hasLowerBound();
+        bool const tightenFromAbove = this->hasUpperBound();
+        for (uint64_t i = 0; i < x.size(); ++i) {
+            // For the relative criterion the guarantee reads |x_i - s_i| <= precision * |s_i| for the exact solution s.
+            // That gives |s_i| <= |x_i| / (1 - precision) and hence the deviation below, which does not refer to s.
+            ValueType const deviation =
+                relative ? precision * storm::utility::abs<ValueType>(x[i]) / (storm::utility::one<ValueType>() - precision) : precision;
+            lower[i] = x[i] - deviation;
+            upper[i] = x[i] + deviation;
+            if (tightenFromBelow) {
+                lower[i] = std::max(lower[i], this->getLowerBound(i));
+            }
+            if (tightenFromAbove) {
+                upper[i] = std::min(upper[i], this->getUpperBound(i));
+            }
+        }
+        this->setSolutionBounds(std::move(bounds));
+    }
+}
+
+template<typename ValueType>
 void AbstractEquationSolver<ValueType>::clearSolutionBounds() const {
     solutionBounds.clear();
 }

--- a/src/storm/solver/AbstractEquationSolver.cpp
+++ b/src/storm/solver/AbstractEquationSolver.cpp
@@ -241,6 +241,34 @@ void AbstractEquationSolver<ValueType>::setBoundsFromOtherSolver(AbstractEquatio
 }
 
 template<typename ValueType>
+bool AbstractEquationSolver<ValueType>::hasSolutionBounds() const {
+    return solutionBounds.has_value();
+}
+
+template<typename ValueType>
+std::vector<ValueType> const& AbstractEquationSolver<ValueType>::getSolutionLowerBounds() const {
+    STORM_LOG_ASSERT(this->hasSolutionBounds(), "No bounds on the solution were computed.");
+    return solutionBounds->first;
+}
+
+template<typename ValueType>
+std::vector<ValueType> const& AbstractEquationSolver<ValueType>::getSolutionUpperBounds() const {
+    STORM_LOG_ASSERT(this->hasSolutionBounds(), "No bounds on the solution were computed.");
+    return solutionBounds->second;
+}
+
+template<typename ValueType>
+void AbstractEquationSolver<ValueType>::setSolutionBounds(std::vector<ValueType> lower, std::vector<ValueType> upper) const {
+    STORM_LOG_ASSERT(lower.size() == upper.size(), "Bounds on the solution must have the same size.");
+    solutionBounds = std::make_pair(std::move(lower), std::move(upper));
+}
+
+template<typename ValueType>
+void AbstractEquationSolver<ValueType>::clearSolutionBounds() const {
+    solutionBounds = std::nullopt;
+}
+
+template<typename ValueType>
 void AbstractEquationSolver<ValueType>::clearBounds() {
     lowerBound = boost::none;
     upperBound = boost::none;

--- a/src/storm/solver/AbstractEquationSolver.cpp
+++ b/src/storm/solver/AbstractEquationSolver.cpp
@@ -241,31 +241,37 @@ void AbstractEquationSolver<ValueType>::setBoundsFromOtherSolver(AbstractEquatio
 }
 
 template<typename ValueType>
-bool AbstractEquationSolver<ValueType>::hasSolutionBounds() const {
-    return solutionBounds.has_value();
+bool AbstractEquationSolver<ValueType>::hasSolutionLowerBounds() const {
+    return solutionBounds.hasLower();
+}
+
+template<typename ValueType>
+bool AbstractEquationSolver<ValueType>::hasSolutionUpperBounds() const {
+    return solutionBounds.hasUpper();
 }
 
 template<typename ValueType>
 std::vector<ValueType> const& AbstractEquationSolver<ValueType>::getSolutionLowerBounds() const {
-    STORM_LOG_ASSERT(this->hasSolutionBounds(), "No bounds on the solution were computed.");
-    return solutionBounds->first;
+    STORM_LOG_ASSERT(this->hasSolutionLowerBounds(), "No lower bound on the solution was computed.");
+    return *solutionBounds.lower;
 }
 
 template<typename ValueType>
 std::vector<ValueType> const& AbstractEquationSolver<ValueType>::getSolutionUpperBounds() const {
-    STORM_LOG_ASSERT(this->hasSolutionBounds(), "No bounds on the solution were computed.");
-    return solutionBounds->second;
+    STORM_LOG_ASSERT(this->hasSolutionUpperBounds(), "No upper bound on the solution was computed.");
+    return *solutionBounds.upper;
 }
 
 template<typename ValueType>
-void AbstractEquationSolver<ValueType>::setSolutionBounds(std::vector<ValueType> lower, std::vector<ValueType> upper) const {
-    STORM_LOG_ASSERT(lower.size() == upper.size(), "Bounds on the solution must have the same size.");
-    solutionBounds = std::make_pair(std::move(lower), std::move(upper));
+void AbstractEquationSolver<ValueType>::setSolutionBounds(SolutionBounds<ValueType> bounds) const {
+    STORM_LOG_ASSERT(!bounds.hasLower() || !bounds.hasUpper() || bounds.lower->size() == bounds.upper->size(),
+                     "Bounds on the solution must have the same size.");
+    solutionBounds = std::move(bounds);
 }
 
 template<typename ValueType>
 void AbstractEquationSolver<ValueType>::clearSolutionBounds() const {
-    solutionBounds = std::nullopt;
+    solutionBounds.clear();
 }
 
 template<typename ValueType>

--- a/src/storm/solver/AbstractEquationSolver.cpp
+++ b/src/storm/solver/AbstractEquationSolver.cpp
@@ -270,6 +270,14 @@ void AbstractEquationSolver<ValueType>::setSolutionBounds(SolutionBounds<ValueTy
 }
 
 template<typename ValueType>
+void AbstractEquationSolver<ValueType>::setSolutionBoundsExact(std::vector<ValueType> const& x) const {
+    SolutionBounds<ValueType> bounds;
+    bounds.lower = x;
+    bounds.upper = x;
+    this->setSolutionBounds(std::move(bounds));
+}
+
+template<typename ValueType>
 void AbstractEquationSolver<ValueType>::setSolutionBoundsFromPrecision(std::vector<ValueType> const& x, ValueType const& precision, bool relative) const {
     if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
         STORM_LOG_THROW(false, storm::exceptions::InvalidOperationException, "Cannot derive solution bounds from a precision for rational functions.");

--- a/src/storm/solver/AbstractEquationSolver.h
+++ b/src/storm/solver/AbstractEquationSolver.h
@@ -251,9 +251,8 @@ class AbstractEquationSolver {
 
     /*!
      * Reports the given solution as an exact one, i.e. stores it as both the lower and the upper bound. Only for
-     * procedures that end up at the solution itself rather than approaching it, such as the direct methods and
-     * the ones that verify an exact fixed point. Reading this as exact is subject to the same rounding as every
-     * other bound: for an inexact value type it means the procedure is exact up to its arithmetic.
+     * procedures that end up at the solution rather than approaching it. For an inexact value type this means
+     * exact up to the arithmetic.
      *
      * @param x The computed solution.
      */

--- a/src/storm/solver/AbstractEquationSolver.h
+++ b/src/storm/solver/AbstractEquationSolver.h
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <memory>
 
+#include "storm/solver/SolutionBounds.h"
 #include "storm/solver/SolverStatus.h"
 #include "storm/solver/TerminationCondition.h"
 #include "storm/utility/ProgressMeasurement.h"
@@ -183,6 +184,20 @@ class AbstractEquationSolver {
     void clearBounds();
 
     /*!
+     * Retrieves whether the last call to this solver computed sound bounds on the solution.
+     * Only some algorithms, most notably interval iteration and optimistic value iteration, provide these, and
+     * even those only when they converged.
+     */
+    bool hasSolutionBounds() const;
+
+    /*!
+     * Retrieves sound bounds on the solution that the last call to this solver computed.
+     * @pre Such bounds were computed, see hasSolutionBounds().
+     */
+    std::vector<ValueType> const& getSolutionLowerBounds() const;
+    std::vector<ValueType> const& getSolutionUpperBounds() const;
+
+    /*!
      * Retrieves whether progress is to be shown.
      */
     bool isShowProgressSet() const;
@@ -210,6 +225,18 @@ class AbstractEquationSolver {
      */
     TerminationCondition<ValueType> const& getTerminationCondition() const;
     std::unique_ptr<TerminationCondition<ValueType>> const& getTerminationConditionPointer() const;
+
+    /*!
+     * Stores sound bounds on the solution that were obtained while solving. Note that solving is const, so
+     * that this is as well.
+     */
+    void setSolutionBounds(std::vector<ValueType> lower, std::vector<ValueType> upper) const;
+
+    /*!
+     * Discards any bounds on the solution obtained by a previous call. This must happen whenever solving
+     * starts, so that a solver that is reused does not report stale bounds.
+     */
+    void clearSolutionBounds() const;
 
     void createUpperBoundsVector(std::vector<ValueType>& upperBoundsVector) const;
     void createUpperBoundsVector(std::unique_ptr<std::vector<ValueType>>& upperBoundsVector, uint64_t length) const;
@@ -263,6 +290,9 @@ class AbstractEquationSolver {
     boost::optional<std::vector<ValueType>> upperBounds;
 
    private:
+    // Sound bounds on the solution, if the last call to this solver produced any.
+    mutable SolutionBounds<ValueType> solutionBounds;
+
     // Indicates the progress of this solver.
     mutable boost::optional<storm::utility::ProgressMeasurement> progressMeasurement;
 };

--- a/src/storm/solver/AbstractEquationSolver.h
+++ b/src/storm/solver/AbstractEquationSolver.h
@@ -238,6 +238,17 @@ class AbstractEquationSolver {
      */
     void clearSolutionBounds() const;
 
+    /*!
+     * Turns a precision that the solving procedure is known to have achieved into sound bounds on the solution,
+     * i.e. stores [x_i - d_i, x_i + d_i] where d_i is the largest deviation from x_i that is still compatible with
+     * that precision. Any a priori bounds known to this solver are used to tighten the result.
+     *
+     * @param x The computed solution.
+     * @param precision The precision that the computation is guaranteed to have achieved.
+     * @param relative Whether that precision is to be read relative to the solution instead of as an absolute value.
+     */
+    void setSolutionBoundsFromPrecision(std::vector<ValueType> const& x, ValueType const& precision, bool relative) const;
+
     void createUpperBoundsVector(std::vector<ValueType>& upperBoundsVector) const;
     void createUpperBoundsVector(std::unique_ptr<std::vector<ValueType>>& upperBoundsVector, uint64_t length) const;
     void createLowerBoundsVector(std::vector<ValueType>& lowerBoundsVector) const;

--- a/src/storm/solver/AbstractEquationSolver.h
+++ b/src/storm/solver/AbstractEquationSolver.h
@@ -249,6 +249,16 @@ class AbstractEquationSolver {
      */
     void setSolutionBoundsFromPrecision(std::vector<ValueType> const& x, ValueType const& precision, bool relative) const;
 
+    /*!
+     * Reports the given solution as an exact one, i.e. stores it as both the lower and the upper bound. Only for
+     * procedures that end up at the solution itself rather than approaching it, such as the direct methods and
+     * the ones that verify an exact fixed point. Reading this as exact is subject to the same rounding as every
+     * other bound: for an inexact value type it means the procedure is exact up to its arithmetic.
+     *
+     * @param x The computed solution.
+     */
+    void setSolutionBoundsExact(std::vector<ValueType> const& x) const;
+
     void createUpperBoundsVector(std::vector<ValueType>& upperBoundsVector) const;
     void createUpperBoundsVector(std::unique_ptr<std::vector<ValueType>>& upperBoundsVector, uint64_t length) const;
     void createLowerBoundsVector(std::vector<ValueType>& lowerBoundsVector) const;

--- a/src/storm/solver/AbstractEquationSolver.h
+++ b/src/storm/solver/AbstractEquationSolver.h
@@ -185,9 +185,7 @@ class AbstractEquationSolver {
 
     /*!
      * Retrieves whether the last call to this solver computed a sound lower resp. upper bound on the solution.
-     * Only some algorithms, most notably interval iteration and optimistic value iteration, provide these, and
-     * they need not provide both: optimistic value iteration, for instance, only verifies its upper bound once
-     * it converges, while its lower bound is available in any case.
+     * Only some algorithms provide these, and they need not provide both.
      */
     bool hasSolutionLowerBounds() const;
     bool hasSolutionUpperBounds() const;

--- a/src/storm/solver/AbstractEquationSolver.h
+++ b/src/storm/solver/AbstractEquationSolver.h
@@ -184,15 +184,17 @@ class AbstractEquationSolver {
     void clearBounds();
 
     /*!
-     * Retrieves whether the last call to this solver computed sound bounds on the solution.
+     * Retrieves whether the last call to this solver computed a sound lower resp. upper bound on the solution.
      * Only some algorithms, most notably interval iteration and optimistic value iteration, provide these, and
-     * even those only when they converged.
+     * they need not provide both: optimistic value iteration, for instance, only verifies its upper bound once
+     * it converges, while its lower bound is available in any case.
      */
-    bool hasSolutionBounds() const;
+    bool hasSolutionLowerBounds() const;
+    bool hasSolutionUpperBounds() const;
 
     /*!
      * Retrieves sound bounds on the solution that the last call to this solver computed.
-     * @pre Such bounds were computed, see hasSolutionBounds().
+     * @pre The respective bound was computed, see hasSolutionLowerBounds() resp. hasSolutionUpperBounds().
      */
     std::vector<ValueType> const& getSolutionLowerBounds() const;
     std::vector<ValueType> const& getSolutionUpperBounds() const;
@@ -230,7 +232,7 @@ class AbstractEquationSolver {
      * Stores sound bounds on the solution that were obtained while solving. Note that solving is const, so
      * that this is as well.
      */
-    void setSolutionBounds(std::vector<ValueType> lower, std::vector<ValueType> upper) const;
+    void setSolutionBounds(SolutionBounds<ValueType> bounds) const;
 
     /*!
      * Discards any bounds on the solution obtained by a previous call. This must happen whenever solving

--- a/src/storm/solver/AcyclicLinearEquationSolver.cpp
+++ b/src/storm/solver/AcyclicLinearEquationSolver.cpp
@@ -93,6 +93,10 @@ bool AcyclicLinearEquationSolver<ValueType>::internalSolveEquations(Environment 
         }
     }
 
+    // Ordering the rows topologically means every value is computed from ones that are already final, so the
+    // single sweep above ends at the solution.
+    this->setSolutionBoundsExact(x);
+
     if (!this->isCachingEnabled()) {
         this->clearCache();
     }

--- a/src/storm/solver/AcyclicMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/AcyclicMinMaxLinearEquationSolver.cpp
@@ -108,6 +108,10 @@ bool AcyclicMinMaxLinearEquationSolver<ValueType>::internalSolveEquations(Enviro
         }
     }
 
+    // Ordering the row groups topologically means every value is computed from ones that are already final, so
+    // the single sweep above ends at the solution.
+    this->setSolutionBoundsExact(x);
+
     if (!this->isCachingEnabled()) {
         this->clearCache();
     }

--- a/src/storm/solver/EigenLinearEquationSolver.cpp
+++ b/src/storm/solver/EigenLinearEquationSolver.cpp
@@ -79,7 +79,12 @@ bool EigenLinearEquationSolver<storm::RationalNumber>::internalSolveEquations(En
     solver.compute(*eigenA);
     solver._solve_impl(eigenB, eigenX);
 
-    return solver.info() == Eigen::ComputationInfo::Success;
+    if (solver.info() != Eigen::ComputationInfo::Success) {
+        return false;
+    }
+    // An LU factorization solves the system outright, unlike the iterative methods below.
+    this->setSolutionBoundsExact(x);
+    return true;
 }
 
 // Specialization for storm::RationalFunction
@@ -97,7 +102,12 @@ bool EigenLinearEquationSolver<storm::RationalFunction>::internalSolveEquations(
     Eigen::SparseLU<Eigen::SparseMatrix<storm::RationalFunction>, Eigen::COLAMDOrdering<int>> solver;
     solver.compute(*eigenA);
     solver._solve_impl(eigenB, eigenX);
-    return solver.info() == Eigen::ComputationInfo::Success;
+    if (solver.info() != Eigen::ComputationInfo::Success) {
+        return false;
+    }
+    // An LU factorization solves the system outright, unlike the iterative methods below.
+    this->setSolutionBoundsExact(x);
+    return true;
 }
 
 template<typename ValueType>
@@ -112,6 +122,8 @@ bool EigenLinearEquationSolver<ValueType>::internalSolveEquations(Environment co
         Eigen::SparseLU<Eigen::SparseMatrix<ValueType>, Eigen::COLAMDOrdering<int>> solver;
         solver.compute(*this->eigenA);
         solver._solve_impl(eigenB, eigenX);
+        // An LU factorization solves the system outright, unlike the iterative methods below.
+        this->setSolutionBoundsExact(x);
     } else {
         bool converged = false;
         uint64_t numberOfIterations = 0;

--- a/src/storm/solver/EliminationLinearEquationSolver.cpp
+++ b/src/storm/solver/EliminationLinearEquationSolver.cpp
@@ -91,6 +91,9 @@ bool EliminationLinearEquationSolver<ValueType>::internalSolveEquations(Environm
         eliminator.eliminateState(state, false);
     }
 
+    // State elimination ends at the solution rather than approaching it.
+    this->setSolutionBoundsExact(x);
+
     return true;
 }
 

--- a/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
@@ -596,8 +596,12 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
             guessingFactor = storm::utility::convertNumber<ValueType>(*env.solver().ovi().getUpperBoundGuessingFactor());
         }
         this->startMeasureProgress();
+        storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = oviHelper.OVI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), prec, dir, guessingFactor, lowerBound,
-                                    upperBound, oviCallback);
+                                    upperBound, oviCallback, &solutionBounds);
+        if (solutionBounds) {
+            this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+        }
         this->reportStatus(status, numIterations);
 
         // If requested, we store the scheduler for retrieval.
@@ -806,8 +810,12 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
             optionalRelevantValues = this->getRelevantValues();
         }
         this->startMeasureProgress();
+        storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = iiHelper.II(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback,
-                                  dir, iiCallback, optionalRelevantValues);
+                                  dir, iiCallback, optionalRelevantValues, &solutionBounds);
+        if (solutionBounds) {
+            this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+        }
         this->reportStatus(status, numIterations);
 
         // If requested, we store the scheduler for retrieval.

--- a/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
@@ -733,13 +733,21 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         return this->updateStatus(current, x, guarantee, numIterations, env.solver().minMax().getMaximalNumberOfIterations());
     };
     this->startMeasureProgress();
+    // The bound that value iteration carries on its own is only sound if the equation system has a unique
+    // fixed point; otherwise an iteration that moves in one direction only bounds the greatest (resp. least)
+    // fixed point, which need not be the solution we are after.
+    storm::solver::SolutionBounds<SolutionType> solutionBounds;
+    auto* solutionBoundsPtr = this->hasUniqueSolution() ? &solutionBounds : nullptr;
     // This code duplication is necessary because the helper class is different for the two cases.
     if (this->A->hasTrivialRowGrouping()) {
         storm::solver::helper::ValueIterationHelper<ValueType, true, SolutionType> viHelper(viOperatorTriv);
 
         auto status = viHelper.VI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(),
                                   storm::utility::convertNumber<SolutionType>(env.solver().minMax().getPrecision()), dir, viCallback,
-                                  env.solver().minMax().getMultiplicationStyle(), this->getUncertaintyResolutionMode());
+                                  env.solver().minMax().getMultiplicationStyle(), this->getUncertaintyResolutionMode(), solutionBoundsPtr);
+        if (solutionBounds.hasAny()) {
+            this->setSolutionBounds(std::move(solutionBounds));
+        }
         this->reportStatus(status, numIterations);
 
         // If requested, we store the scheduler for retrieval.
@@ -757,7 +765,10 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
 
         auto status = viHelper.VI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(),
                                   storm::utility::convertNumber<SolutionType>(env.solver().minMax().getPrecision()), dir, viCallback,
-                                  env.solver().minMax().getMultiplicationStyle(), this->getUncertaintyResolutionMode());
+                                  env.solver().minMax().getMultiplicationStyle(), this->getUncertaintyResolutionMode(), solutionBoundsPtr);
+        if (solutionBounds.hasAny()) {
+            this->setSolutionBounds(std::move(solutionBounds));
+        }
         this->reportStatus(status, numIterations);
 
         // If requested, we store the scheduler for retrieval.

--- a/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
@@ -423,6 +423,7 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::performPolicy
         } while (status == SolverStatus::InProgress);
 
         STORM_LOG_INFO("Number of iterations: " << iterations);
+
         this->reportStatus(status, iterations);
 
         // If requested, we store the scheduler for retrieval.
@@ -647,6 +648,15 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         this->startMeasureProgress();
         auto statusIters = helper.solveEquations(lowerX, *upperX, b, numIterations,
                                                  storm::utility::convertNumber<ValueType>(env.solver().minMax().getPrecision()), dir, gviCallback);
+        // Read the enclosure out before the point estimate below overwrites x, which the lower bound aliases, with
+        // the average of the two sides. Guessing value iteration only ever writes back a guess it has verified, so
+        // the two vectors enclose the solution in every iteration and both sides hold even if it was aborted before
+        // converging.
+        storm::solver::SolutionBounds<SolutionType> solutionBounds;
+        solutionBounds.lower = lowerX;
+        solutionBounds.upper = *upperX;
+        this->setSolutionBounds(std::move(solutionBounds));
+
         auto two = storm::utility::convertNumber<ValueType>(2.0);
         storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
             lowerX, *upperX, x, [&two](ValueType const& first, ValueType const& second) -> ValueType { return (first + second) / two; });
@@ -877,8 +887,12 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         if (this->hasRelevantValues()) {
             optionalRelevantValues = this->getRelevantValues();
         }
+        storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = sviHelper.SVI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), precision, dir, lowerBound, upperBound,
-                                    sviCallback, optionalRelevantValues);
+                                    sviCallback, optionalRelevantValues, &solutionBounds);
+        if (solutionBounds.hasAny()) {
+            this->setSolutionBounds(std::move(solutionBounds));
+        }
 
         // If requested, we store the scheduler for retrieval.
         if (this->isTrackSchedulerSet()) {

--- a/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
@@ -21,6 +21,7 @@
 #include "storm/solver/helper/SoundValueIterationHelper.h"
 #include "storm/solver/helper/ValueIterationHelper.h"
 #include "storm/utility/NumberTraits.h"
+#include "storm/utility/OptionalRef.h"
 #include "storm/utility/SignalHandler.h"
 #include "storm/utility/constants.h"
 #include "storm/utility/logging.h"
@@ -764,14 +765,17 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
     // fixed point; otherwise an iteration that moves in one direction only bounds the greatest (resp. least)
     // fixed point, which need not be the solution we are after.
     storm::solver::SolutionBounds<SolutionType> solutionBounds;
-    auto* solutionBoundsPtr = this->hasUniqueSolution() ? &solutionBounds : nullptr;
+    storm::OptionalRef<storm::solver::SolutionBounds<SolutionType>> solutionBoundsRef;
+    if (this->hasUniqueSolution()) {
+        solutionBoundsRef.reset(solutionBounds);
+    }
     // This code duplication is necessary because the helper class is different for the two cases.
     if (this->A->hasTrivialRowGrouping()) {
         storm::solver::helper::ValueIterationHelper<ValueType, true, SolutionType> viHelper(viOperatorTriv);
 
         auto status = viHelper.VI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(),
                                   storm::utility::convertNumber<SolutionType>(env.solver().minMax().getPrecision()), dir, viCallback,
-                                  env.solver().minMax().getMultiplicationStyle(), this->getUncertaintyResolutionMode(), solutionBoundsPtr);
+                                  env.solver().minMax().getMultiplicationStyle(), this->getUncertaintyResolutionMode(), solutionBoundsRef);
         if (solutionBounds.hasAny()) {
             this->setSolutionBounds(std::move(solutionBounds));
         }
@@ -792,7 +796,7 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
 
         auto status = viHelper.VI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(),
                                   storm::utility::convertNumber<SolutionType>(env.solver().minMax().getPrecision()), dir, viCallback,
-                                  env.solver().minMax().getMultiplicationStyle(), this->getUncertaintyResolutionMode(), solutionBoundsPtr);
+                                  env.solver().minMax().getMultiplicationStyle(), this->getUncertaintyResolutionMode(), solutionBoundsRef);
         if (solutionBounds.hasAny()) {
             this->setSolutionBounds(std::move(solutionBounds));
         }
@@ -906,7 +910,7 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         }
         storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = sviHelper.SVI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), precision, dir, lowerBound, upperBound,
-                                    sviCallback, optionalRelevantValues, &solutionBounds);
+                                    sviCallback, optionalRelevantValues, solutionBounds);
         if (solutionBounds.hasAny()) {
             this->setSolutionBounds(std::move(solutionBounds));
         }

--- a/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
@@ -599,8 +599,8 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = oviHelper.OVI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), prec, dir, guessingFactor, lowerBound,
                                     upperBound, oviCallback, &solutionBounds);
-        if (solutionBounds) {
-            this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+        if (solutionBounds.hasAny()) {
+            this->setSolutionBounds(std::move(solutionBounds));
         }
         this->reportStatus(status, numIterations);
 
@@ -813,8 +813,8 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = iiHelper.II(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback,
                                   dir, iiCallback, optionalRelevantValues, &solutionBounds);
-        if (solutionBounds) {
-            this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+        if (solutionBounds.hasAny()) {
+            this->setSolutionBounds(std::move(solutionBounds));
         }
         this->reportStatus(status, numIterations);
 

--- a/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
@@ -425,10 +425,8 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::performPolicy
 
         STORM_LOG_INFO("Number of iterations: " << iterations);
 
-        // Once the scheduler stops improving, x is what the last solve of the induced equation system produced,
-        // so whatever that solver established about its solution carries over to ours. Note that this is the
-        // only statement policy iteration can make: its own termination says the scheduler is optimal, not how
-        // accurately the values under it were computed.
+        // Policy iteration's own termination says the scheduler is optimal, not how accurately the values under
+        // it were computed, so the only statement to make is the one the inner solver made.
         if (status == SolverStatus::Converged) {
             storm::solver::SolutionBounds<SolutionType> solutionBounds;
             if (solver->hasSolutionLowerBounds()) {
@@ -666,10 +664,8 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         this->startMeasureProgress();
         auto statusIters = helper.solveEquations(lowerX, *upperX, b, numIterations,
                                                  storm::utility::convertNumber<ValueType>(env.solver().minMax().getPrecision()), dir, gviCallback);
-        // Read the enclosure out before the point estimate below overwrites x, which the lower bound aliases, with
-        // the average of the two sides. Guessing value iteration only ever writes back a guess it has verified, so
-        // the two vectors enclose the solution in every iteration and both sides hold even if it was aborted before
-        // converging.
+        // Guessing value iteration only writes back a guess it has verified, so the two vectors enclose the
+        // solution in every iteration, aborted or not. Read them out before x is overwritten with the average.
         storm::solver::SolutionBounds<SolutionType> solutionBounds;
         solutionBounds.lower = lowerX;
         solutionBounds.upper = *upperX;
@@ -761,9 +757,8 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         return this->updateStatus(current, x, guarantee, numIterations, env.solver().minMax().getMaximalNumberOfIterations());
     };
     this->startMeasureProgress();
-    // The bound that value iteration carries on its own is only sound if the equation system has a unique
-    // fixed point; otherwise an iteration that moves in one direction only bounds the greatest (resp. least)
-    // fixed point, which need not be the solution we are after.
+    // Without a unique fixed point a monotone iteration only bounds the greatest resp. least one, which need
+    // not be the solution we are after.
     storm::solver::SolutionBounds<SolutionType> solutionBounds;
     storm::OptionalRef<storm::solver::SolutionBounds<SolutionType>> solutionBoundsRef;
     if (this->hasUniqueSolution()) {
@@ -1011,7 +1006,7 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         auto status = rsHelper.RS(x, b, numIterations, storm::utility::convertNumber<ValueType>(env.solver().minMax().getPrecision()), dir, rsCallback);
 
         // Rational search reports convergence only once it has verified a sharpened candidate to be an exact fixed
-        // point of the equation system, so on convergence the result is the solution rather than an approximation of it.
+        // point, so the result is the solution rather than an approximation.
         if (status == SolverStatus::Converged) {
             this->setSolutionBoundsExact(x);
         }

--- a/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
@@ -424,6 +424,23 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::performPolicy
 
         STORM_LOG_INFO("Number of iterations: " << iterations);
 
+        // Once the scheduler stops improving, x is what the last solve of the induced equation system produced,
+        // so whatever that solver established about its solution carries over to ours. Note that this is the
+        // only statement policy iteration can make: its own termination says the scheduler is optimal, not how
+        // accurately the values under it were computed.
+        if (status == SolverStatus::Converged) {
+            storm::solver::SolutionBounds<SolutionType> solutionBounds;
+            if (solver->hasSolutionLowerBounds()) {
+                solutionBounds.lower = solver->getSolutionLowerBounds();
+            }
+            if (solver->hasSolutionUpperBounds()) {
+                solutionBounds.upper = solver->getSolutionUpperBounds();
+            }
+            if (solutionBounds.hasAny()) {
+                this->setSolutionBounds(std::move(solutionBounds));
+            }
+        }
+
         this->reportStatus(status, iterations);
 
         // If requested, we store the scheduler for retrieval.
@@ -988,6 +1005,12 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         };
         this->startMeasureProgress();
         auto status = rsHelper.RS(x, b, numIterations, storm::utility::convertNumber<ValueType>(env.solver().minMax().getPrecision()), dir, rsCallback);
+
+        // Rational search reports convergence only once it has verified a sharpened candidate to be an exact fixed
+        // point of the equation system, so on convergence the result is the solution rather than an approximation of it.
+        if (status == SolverStatus::Converged) {
+            this->setSolutionBoundsExact(x);
+        }
 
         this->reportStatus(status, numIterations);
 

--- a/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/IterativeMinMaxLinearEquationSolver.cpp
@@ -598,7 +598,7 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         this->startMeasureProgress();
         storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = oviHelper.OVI(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), prec, dir, guessingFactor, lowerBound,
-                                    upperBound, oviCallback, &solutionBounds);
+                                    upperBound, oviCallback, solutionBounds);
         if (solutionBounds.hasAny()) {
             this->setSolutionBounds(std::move(solutionBounds));
         }
@@ -812,7 +812,7 @@ bool IterativeMinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquation
         this->startMeasureProgress();
         storm::solver::SolutionBounds<ValueType> solutionBounds;
         auto status = iiHelper.II(x, b, numIterations, env.solver().minMax().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback,
-                                  dir, iiCallback, optionalRelevantValues, &solutionBounds);
+                                  dir, iiCallback, optionalRelevantValues, solutionBounds);
         if (solutionBounds.hasAny()) {
             this->setSolutionBounds(std::move(solutionBounds));
         }

--- a/src/storm/solver/LinearEquationSolver.cpp
+++ b/src/storm/solver/LinearEquationSolver.cpp
@@ -24,6 +24,8 @@ LinearEquationSolver<ValueType>::LinearEquationSolver() : cachingEnabled(false) 
 
 template<typename ValueType>
 bool LinearEquationSolver<ValueType>::solveEquations(Environment const& env, std::vector<ValueType>& x, std::vector<ValueType> const& b) const {
+    // A reused solver must not report bounds that a previous call computed.
+    this->clearSolutionBounds();
     return this->internalSolveEquations(env, x, b);
 }
 

--- a/src/storm/solver/MinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/MinMaxLinearEquationSolver.cpp
@@ -40,6 +40,8 @@ bool MinMaxLinearEquationSolver<ValueType, SolutionType>::solveEquations(Environ
     STORM_LOG_WARN_COND_DEBUG(this->isRequirementsCheckedSet(),
                               "The requirements of the solver have not been marked as checked. Please provide the appropriate check or mark the requirements "
                               "as checked (if applicable).");
+    // A reused solver must not report bounds that a previous call computed.
+    this->clearSolutionBounds();
     return internalSolveEquations(env, d, x, b);
 }
 

--- a/src/storm/solver/NativeLinearEquationSolver.cpp
+++ b/src/storm/solver/NativeLinearEquationSolver.cpp
@@ -441,8 +441,12 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsIntervalIteration(Envi
         optionalRelevantValues = this->getRelevantValues();
     }
     this->startMeasureProgress();
+    storm::solver::SolutionBounds<ValueType> solutionBounds;
     auto status = iiHelper.II(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback, {},
-                              iiCallback, optionalRelevantValues);
+                              iiCallback, optionalRelevantValues, &solutionBounds);
+    if (solutionBounds) {
+        this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+    }
     this->reportStatus(status, numIterations);
 
     if (!this->isCachingEnabled()) {
@@ -525,7 +529,12 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsOptimisticValueIterati
         guessingFactor = storm::utility::convertNumber<ValueType>(*env.solver().ovi().getUpperBoundGuessingFactor());
     }
     this->startMeasureProgress();
-    auto status = oviHelper.OVI(x, b, env.solver().native().getRelativeTerminationCriterion(), prec, {}, guessingFactor, lowerBound, upperBound, oviCallback);
+    storm::solver::SolutionBounds<ValueType> solutionBounds;
+    auto status = oviHelper.OVI(x, b, env.solver().native().getRelativeTerminationCriterion(), prec, {}, guessingFactor, lowerBound, upperBound, oviCallback,
+                                &solutionBounds);
+    if (solutionBounds) {
+        this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+    }
     this->reportStatus(status, numIterations);
 
     if (!this->isCachingEnabled()) {

--- a/src/storm/solver/NativeLinearEquationSolver.cpp
+++ b/src/storm/solver/NativeLinearEquationSolver.cpp
@@ -379,9 +379,13 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsPower(Environment cons
         return this->updateStatus(current, x, guarantee, numIterations, env.solver().native().getMaximalNumberOfIterations());
     };
     this->startMeasureProgress();
+    storm::solver::SolutionBounds<ValueType> solutionBounds;
     auto status = viHelper.VI(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(),
                               storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()), {}, viCallback,
-                              env.solver().native().getPowerMethodMultiplicationStyle());
+                              env.solver().native().getPowerMethodMultiplicationStyle(), UncertaintyResolutionMode::Unset, &solutionBounds);
+    if (solutionBounds.hasAny()) {
+        this->setSolutionBounds(std::move(solutionBounds));
+    }
 
     this->reportStatus(status, numIterations);
 

--- a/src/storm/solver/NativeLinearEquationSolver.cpp
+++ b/src/storm/solver/NativeLinearEquationSolver.cpp
@@ -579,10 +579,8 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsGuessingValueIteration
     auto status = helper.solveEquations(*lowerX, *upperX, b, numIterations, storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()),
                                         {},  // No optimization dir
                                         gviCallback);
-    // Read the enclosure out before the point estimate below overwrites x, which the lower bound aliases, with
-    // the average of the two sides. Guessing value iteration only ever writes back a guess it has verified, so
-    // the two vectors enclose the solution in every iteration and both sides hold even if it was aborted before
-    // converging.
+    // Guessing value iteration only writes back a guess it has verified, so the two vectors enclose the
+    // solution in every iteration, aborted or not. Read them out before x is overwritten with the average.
     storm::solver::SolutionBounds<ValueType> solutionBounds;
     solutionBounds.lower = *lowerX;
     solutionBounds.upper = *upperX;
@@ -627,7 +625,7 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsRationalSearch(Environ
     auto status = rsHelper.RS(x, b, numIterations, storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()), {}, rsCallback);
 
     // Rational search reports convergence only once it has verified a sharpened candidate to be an exact fixed
-    // point of the equation system, so on convergence the result is the solution rather than an approximation of it.
+    // point, so the result is the solution rather than an approximation.
     if (status == SolverStatus::Converged) {
         this->setSolutionBoundsExact(x);
     }

--- a/src/storm/solver/NativeLinearEquationSolver.cpp
+++ b/src/storm/solver/NativeLinearEquationSolver.cpp
@@ -382,7 +382,7 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsPower(Environment cons
     storm::solver::SolutionBounds<ValueType> solutionBounds;
     auto status = viHelper.VI(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(),
                               storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()), {}, viCallback,
-                              env.solver().native().getPowerMethodMultiplicationStyle(), UncertaintyResolutionMode::Unset, &solutionBounds);
+                              env.solver().native().getPowerMethodMultiplicationStyle(), UncertaintyResolutionMode::Unset, solutionBounds);
     if (solutionBounds.hasAny()) {
         this->setSolutionBounds(std::move(solutionBounds));
     }
@@ -492,7 +492,7 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsSoundValueIteration(En
     helper::SoundValueIterationHelper<ValueType, true> sviHelper(viOperator);
     storm::solver::SolutionBounds<ValueType> solutionBounds;
     auto status = sviHelper.SVI(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), precision, {}, lowerBound, upperBound,
-                                sviCallback, optionalRelevantValues, &solutionBounds);
+                                sviCallback, optionalRelevantValues, solutionBounds);
     if (solutionBounds.hasAny()) {
         this->setSolutionBounds(std::move(solutionBounds));
     }

--- a/src/storm/solver/NativeLinearEquationSolver.cpp
+++ b/src/storm/solver/NativeLinearEquationSolver.cpp
@@ -490,8 +490,12 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsSoundValueIteration(En
     }
     this->startMeasureProgress();
     helper::SoundValueIterationHelper<ValueType, true> sviHelper(viOperator);
+    storm::solver::SolutionBounds<ValueType> solutionBounds;
     auto status = sviHelper.SVI(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), precision, {}, lowerBound, upperBound,
-                                sviCallback, optionalRelevantValues);
+                                sviCallback, optionalRelevantValues, &solutionBounds);
+    if (solutionBounds.hasAny()) {
+        this->setSolutionBounds(std::move(solutionBounds));
+    }
 
     this->reportStatus(status, numIterations);
 
@@ -575,6 +579,15 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsGuessingValueIteration
     auto status = helper.solveEquations(*lowerX, *upperX, b, numIterations, storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()),
                                         {},  // No optimization dir
                                         gviCallback);
+    // Read the enclosure out before the point estimate below overwrites x, which the lower bound aliases, with
+    // the average of the two sides. Guessing value iteration only ever writes back a guess it has verified, so
+    // the two vectors enclose the solution in every iteration and both sides hold even if it was aborted before
+    // converging.
+    storm::solver::SolutionBounds<ValueType> solutionBounds;
+    solutionBounds.lower = *lowerX;
+    solutionBounds.upper = *upperX;
+    this->setSolutionBounds(std::move(solutionBounds));
+
     auto two = storm::utility::convertNumber<ValueType>(2.0);
     storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
         *lowerX, *upperX, x, [&two](ValueType const& first, ValueType const& second) -> ValueType { return (first + second) / two; });

--- a/src/storm/solver/NativeLinearEquationSolver.cpp
+++ b/src/storm/solver/NativeLinearEquationSolver.cpp
@@ -443,7 +443,7 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsIntervalIteration(Envi
     this->startMeasureProgress();
     storm::solver::SolutionBounds<ValueType> solutionBounds;
     auto status = iiHelper.II(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback, {},
-                              iiCallback, optionalRelevantValues, &solutionBounds);
+                              iiCallback, optionalRelevantValues, solutionBounds);
     if (solutionBounds.hasAny()) {
         this->setSolutionBounds(std::move(solutionBounds));
     }
@@ -531,7 +531,7 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsOptimisticValueIterati
     this->startMeasureProgress();
     storm::solver::SolutionBounds<ValueType> solutionBounds;
     auto status = oviHelper.OVI(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), prec, {}, guessingFactor, lowerBound, upperBound,
-                                oviCallback, &solutionBounds);
+                                oviCallback, solutionBounds);
     if (solutionBounds.hasAny()) {
         this->setSolutionBounds(std::move(solutionBounds));
     }

--- a/src/storm/solver/NativeLinearEquationSolver.cpp
+++ b/src/storm/solver/NativeLinearEquationSolver.cpp
@@ -626,6 +626,12 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsRationalSearch(Environ
     this->startMeasureProgress();
     auto status = rsHelper.RS(x, b, numIterations, storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()), {}, rsCallback);
 
+    // Rational search reports convergence only once it has verified a sharpened candidate to be an exact fixed
+    // point of the equation system, so on convergence the result is the solution rather than an approximation of it.
+    if (status == SolverStatus::Converged) {
+        this->setSolutionBoundsExact(x);
+    }
+
     this->reportStatus(status, numIterations);
 
     if (!this->isCachingEnabled()) {

--- a/src/storm/solver/NativeLinearEquationSolver.cpp
+++ b/src/storm/solver/NativeLinearEquationSolver.cpp
@@ -444,8 +444,8 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsIntervalIteration(Envi
     storm::solver::SolutionBounds<ValueType> solutionBounds;
     auto status = iiHelper.II(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), prec, lowerBoundsCallback, upperBoundsCallback, {},
                               iiCallback, optionalRelevantValues, &solutionBounds);
-    if (solutionBounds) {
-        this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+    if (solutionBounds.hasAny()) {
+        this->setSolutionBounds(std::move(solutionBounds));
     }
     this->reportStatus(status, numIterations);
 
@@ -530,10 +530,10 @@ bool NativeLinearEquationSolver<ValueType>::solveEquationsOptimisticValueIterati
     }
     this->startMeasureProgress();
     storm::solver::SolutionBounds<ValueType> solutionBounds;
-    auto status = oviHelper.OVI(x, b, env.solver().native().getRelativeTerminationCriterion(), prec, {}, guessingFactor, lowerBound, upperBound, oviCallback,
-                                &solutionBounds);
-    if (solutionBounds) {
-        this->setSolutionBounds(std::move(solutionBounds->first), std::move(solutionBounds->second));
+    auto status = oviHelper.OVI(x, b, numIterations, env.solver().native().getRelativeTerminationCriterion(), prec, {}, guessingFactor, lowerBound, upperBound,
+                                oviCallback, &solutionBounds);
+    if (solutionBounds.hasAny()) {
+        this->setSolutionBounds(std::move(solutionBounds));
     }
     this->reportStatus(status, numIterations);
 

--- a/src/storm/solver/SolutionBounds.h
+++ b/src/storm/solver/SolutionBounds.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace storm::solver {
+
+/*!
+ * Sound lower and upper bounds on a solution vector, as computed by e.g. interval iteration.
+ * The first component bounds the solution from below, the second one from above. Both have the same size as
+ * the solution. An unset value means that the algorithm in question did not provide any bounds.
+ */
+template<typename ValueType>
+using SolutionBounds = std::optional<std::pair<std::vector<ValueType>, std::vector<ValueType>>>;
+
+}  // namespace storm::solver

--- a/src/storm/solver/SolutionBounds.h
+++ b/src/storm/solver/SolutionBounds.h
@@ -14,18 +14,30 @@ struct SolutionBounds {
     std::optional<std::vector<ValueType>> lower;
     std::optional<std::vector<ValueType>> upper;
 
+    /*
+     * Returns true if the lower bound is set.
+     */
     bool hasLower() const {
         return lower.has_value();
     }
 
+    /*
+     * Returns true if the upper bound is set.
+     */
     bool hasUpper() const {
         return upper.has_value();
     }
 
+    /*
+     * Returns true if at least one of the bounds is set.
+     */
     bool hasAny() const {
         return hasLower() || hasUpper();
     }
 
+    /*
+     * Clears both bounds.
+     */
     void clear() {
         lower = std::nullopt;
         upper = std::nullopt;

--- a/src/storm/solver/SolutionBounds.h
+++ b/src/storm/solver/SolutionBounds.h
@@ -6,11 +6,8 @@
 namespace storm::solver {
 
 /*!
- * Sound lower and upper bounds on a solution vector, as computed by e.g. interval iteration.
- * Both bounds have the same size as the solution. They are tracked independently because an algorithm may
- * well establish only one of them: optimistic value iteration, for instance, keeps a sound lower bound in
- * every iteration but only verifies its upper bound once it converges. An unset bound means that the
- * algorithm in question did not provide that side.
+ * Sound lower and upper bounds on a solution vector. Both have the same size as the solution. They are tracked
+ * independently, as an algorithm may establish only one of them; an unset bound means that side is not known.
  */
 template<typename ValueType>
 struct SolutionBounds {
@@ -25,9 +22,6 @@ struct SolutionBounds {
         return upper.has_value();
     }
 
-    /*!
-     * Retrieves whether at least one of the two bounds is known.
-     */
     bool hasAny() const {
         return hasLower() || hasUpper();
     }

--- a/src/storm/solver/SolutionBounds.h
+++ b/src/storm/solver/SolutionBounds.h
@@ -1,17 +1,41 @@
 #pragma once
 
 #include <optional>
-#include <utility>
 #include <vector>
 
 namespace storm::solver {
 
 /*!
  * Sound lower and upper bounds on a solution vector, as computed by e.g. interval iteration.
- * The first component bounds the solution from below, the second one from above. Both have the same size as
- * the solution. An unset value means that the algorithm in question did not provide any bounds.
+ * Both bounds have the same size as the solution. They are tracked independently because an algorithm may
+ * well establish only one of them: optimistic value iteration, for instance, keeps a sound lower bound in
+ * every iteration but only verifies its upper bound once it converges. An unset bound means that the
+ * algorithm in question did not provide that side.
  */
 template<typename ValueType>
-using SolutionBounds = std::optional<std::pair<std::vector<ValueType>, std::vector<ValueType>>>;
+struct SolutionBounds {
+    std::optional<std::vector<ValueType>> lower;
+    std::optional<std::vector<ValueType>> upper;
+
+    bool hasLower() const {
+        return lower.has_value();
+    }
+
+    bool hasUpper() const {
+        return upper.has_value();
+    }
+
+    /*!
+     * Retrieves whether at least one of the two bounds is known.
+     */
+    bool hasAny() const {
+        return hasLower() || hasUpper();
+    }
+
+    void clear() {
+        lower = std::nullopt;
+        upper = std::nullopt;
+    }
+};
 
 }  // namespace storm::solver

--- a/src/storm/solver/TopologicalLinearEquationSolver.cpp
+++ b/src/storm/solver/TopologicalLinearEquationSolver.cpp
@@ -1,6 +1,7 @@
 #include "storm/solver/TopologicalLinearEquationSolver.h"
 
 #include "storm/adapters/RationalFunctionAdapter.h"
+#include "storm/environment/solver/NativeSolverEnvironment.h"
 #include "storm/environment/solver/TopologicalSolverEnvironment.h"
 #include "storm/utility/ProgressMeasurement.h"
 #include "storm/utility/SignalHandler.h"
@@ -84,6 +85,7 @@ bool TopologicalLinearEquationSolver<ValueType>::internalSolveEquations(Environm
 
     // Handle the case where there is just one large SCC
     bool returnValue = true;
+    bool aborted = false;
     if (this->sortedSccDecomposition->size() == 1) {
         if (auto const& scc = *this->sortedSccDecomposition->begin(); scc.size() == 1) {
             // Catch the trivial case where the whole system is just a single state.
@@ -127,9 +129,14 @@ bool TopologicalLinearEquationSolver<ValueType>::internalSolveEquations(Environm
             progress.updateProgress(sccIndex);
             if (storm::utility::resources::isTerminate()) {
                 STORM_LOG_WARN("Topological solver aborted after analyzing " << sccIndex << "/" << this->sortedSccDecomposition->size() << " SCCs.");
+                aborted = true;
                 break;
             }
         }
+    }
+
+    if (returnValue && !aborted) {
+        trySetSolutionBoundsFromPrecision(env, x);
     }
 
     if (!this->isCachingEnabled()) {
@@ -137,6 +144,30 @@ bool TopologicalLinearEquationSolver<ValueType>::internalSolveEquations(Environm
     }
 
     return returnValue;
+}
+
+template<typename ValueType>
+void TopologicalLinearEquationSolver<ValueType>::trySetSolutionBoundsFromPrecision(Environment const& env, std::vector<ValueType> const& x) const {
+    if constexpr (std::is_same_v<ValueType, storm::RationalFunction>) {
+        // Precisions are meaningless for rational functions.
+        return;
+    } else {
+        // Only a sound solve gives us anything to work with: it hands every SCC a precision of eps divided by the
+        // length of the longest SCC chain, and the deviation an SCC inherits from its predecessors enters its own
+        // solution as a convex combination of the values at the exits, i.e. without amplification. The per-SCC
+        // deviations therefore add up to at most eps along any chain, so eps bounds the error of the overall
+        // solution. An unsound underlying solver instead only reports that its iteration stopped moving, which is
+        // no statement about the distance to the solution at all, so nothing is claimed in that case.
+        if (!env.solver().isForceSoundness()) {
+            return;
+        }
+        // Sound solving picks the native solver unless the user insisted on one of the exact ones, and the native
+        // precision is kept in sync with the one of whichever solver type is configured (see
+        // SolverEnvironment::setLinearEquationSolverPrecision), so this is the precision that was actually enforced
+        // in the SCCs. For an exact underlying solver it merely is a loose bound rather than a wrong one.
+        this->setSolutionBoundsFromPrecision(x, storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()),
+                                             env.solver().native().getRelativeTerminationCriterion());
+    }
 }
 
 template<typename ValueType>

--- a/src/storm/solver/TopologicalLinearEquationSolver.cpp
+++ b/src/storm/solver/TopologicalLinearEquationSolver.cpp
@@ -152,19 +152,16 @@ void TopologicalLinearEquationSolver<ValueType>::trySetSolutionBoundsFromPrecisi
         // Precisions are meaningless for rational functions.
         return;
     } else {
-        // Only a sound solve gives us anything to work with: it hands every SCC a precision of eps divided by the
-        // length of the longest SCC chain, and the deviation an SCC inherits from its predecessors enters its own
-        // solution as a convex combination of the values at the exits, i.e. without amplification. The per-SCC
-        // deviations therefore add up to at most eps along any chain, so eps bounds the error of the overall
-        // solution. An unsound underlying solver instead only reports that its iteration stopped moving, which is
-        // no statement about the distance to the solution at all, so nothing is claimed in that case.
+        // A sound solve hands every SCC a precision of eps divided by the length of the longest SCC chain, and the
+        // deviation an SCC inherits from its predecessors enters its own solution as a convex combination of the
+        // values at the exits, without amplification. The per-SCC deviations therefore add up to at most eps along
+        // any chain. An unsound solve only reports that its iteration stopped moving, which says nothing about the
+        // distance to the solution.
         if (!env.solver().isForceSoundness()) {
             return;
         }
-        // Sound solving picks the native solver unless the user insisted on one of the exact ones, and the native
-        // precision is kept in sync with the one of whichever solver type is configured (see
-        // SolverEnvironment::setLinearEquationSolverPrecision), so this is the precision that was actually enforced
-        // in the SCCs. For an exact underlying solver it merely is a loose bound rather than a wrong one.
+        // The native precision is kept in sync with the one of whichever solver type is configured (see
+        // SolverEnvironment::setLinearEquationSolverPrecision), so this is the precision enforced in the SCCs.
         this->setSolutionBoundsFromPrecision(x, storm::utility::convertNumber<ValueType>(env.solver().native().getPrecision()),
                                              env.solver().native().getRelativeTerminationCriterion());
     }

--- a/src/storm/solver/TopologicalLinearEquationSolver.h
+++ b/src/storm/solver/TopologicalLinearEquationSolver.h
@@ -39,6 +39,12 @@ class TopologicalLinearEquationSolver : public LinearEquationSolver<ValueType> {
     // Creates an SCC decomposition and sorts the SCCs according to a topological sort.
     void createSortedSccDecomposition(bool needLongestChainSize) const;
 
+    /*!
+     * Reports the precision that the SCCs were solved with as a bound on the solution, if that precision is a
+     * sound one. Does nothing otherwise.
+     */
+    void trySetSolutionBoundsFromPrecision(Environment const& env, std::vector<ValueType> const& x) const;
+
     // Solves the SCC with the given index
     // ... for the case that the SCC is trivial
     bool solveTrivialScc(uint64_t const& sccState, std::vector<ValueType>& globalX, std::vector<ValueType> const& globalB) const;

--- a/src/storm/solver/TopologicalMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/TopologicalMinMaxLinearEquationSolver.cpp
@@ -79,6 +79,7 @@ bool TopologicalMinMaxLinearEquationSolver<ValueType, SolutionType>::internalSol
     }
 
     bool returnValue = true;
+    bool aborted = false;
     if (this->sortedSccDecomposition->size() == 1 && (!this->choiceFixedForRowGroup || this->choiceFixedForRowGroup.get().empty())) {
         // Handle the case where there is just one large SCC, as there are no fixed choices for states, we solve it like this
         if (auto const& scc = *this->sortedSccDecomposition->begin(); scc.size() == 1) {
@@ -146,9 +147,14 @@ bool TopologicalMinMaxLinearEquationSolver<ValueType, SolutionType>::internalSol
             progress.updateProgress(sccIndex);
             if (storm::utility::resources::isTerminate()) {
                 STORM_LOG_WARN("Topological solver aborted after analyzing " << sccIndex << "/" << this->sortedSccDecomposition->size() << " SCCs.");
+                aborted = true;
                 break;
             }
         }
+    }
+
+    if (returnValue && !aborted) {
+        trySetSolutionBoundsFromPrecision(env, x);
     }
 
     if (!this->isCachingEnabled()) {
@@ -156,6 +162,22 @@ bool TopologicalMinMaxLinearEquationSolver<ValueType, SolutionType>::internalSol
     }
 
     return returnValue;
+}
+
+template<typename ValueType, typename SolutionType>
+void TopologicalMinMaxLinearEquationSolver<ValueType, SolutionType>::trySetSolutionBoundsFromPrecision(Environment const& env,
+                                                                                                       std::vector<SolutionType> const& x) const {
+    // Only a sound solve gives us anything to work with: it hands every SCC a precision of eps divided by the length
+    // of the longest SCC chain, and the deviation an SCC inherits from its predecessors enters its own solution as a
+    // convex combination of the values at the exits, i.e. without amplification. The per-SCC deviations therefore add
+    // up to at most eps along any chain, so eps bounds the error of the overall solution. An unsound underlying
+    // solver instead only reports that its iteration stopped moving, which is no statement about the distance to the
+    // solution at all, so nothing is claimed in that case.
+    if (!env.solver().isForceSoundness()) {
+        return;
+    }
+    this->setSolutionBoundsFromPrecision(x, storm::utility::convertNumber<SolutionType>(env.solver().minMax().getPrecision()),
+                                         env.solver().minMax().getRelativeTerminationCriterion());
 }
 
 template<typename ValueType, typename SolutionType>

--- a/src/storm/solver/TopologicalMinMaxLinearEquationSolver.cpp
+++ b/src/storm/solver/TopologicalMinMaxLinearEquationSolver.cpp
@@ -167,12 +167,11 @@ bool TopologicalMinMaxLinearEquationSolver<ValueType, SolutionType>::internalSol
 template<typename ValueType, typename SolutionType>
 void TopologicalMinMaxLinearEquationSolver<ValueType, SolutionType>::trySetSolutionBoundsFromPrecision(Environment const& env,
                                                                                                        std::vector<SolutionType> const& x) const {
-    // Only a sound solve gives us anything to work with: it hands every SCC a precision of eps divided by the length
-    // of the longest SCC chain, and the deviation an SCC inherits from its predecessors enters its own solution as a
-    // convex combination of the values at the exits, i.e. without amplification. The per-SCC deviations therefore add
-    // up to at most eps along any chain, so eps bounds the error of the overall solution. An unsound underlying
-    // solver instead only reports that its iteration stopped moving, which is no statement about the distance to the
-    // solution at all, so nothing is claimed in that case.
+    // A sound solve hands every SCC a precision of eps divided by the length of the longest SCC chain, and the
+    // deviation an SCC inherits from its predecessors enters its own solution as a convex combination of the values
+    // at the exits, without amplification. The per-SCC deviations therefore add up to at most eps along any chain.
+    // An unsound solve only reports that its iteration stopped moving, which says nothing about the distance to the
+    // solution.
     if (!env.solver().isForceSoundness()) {
         return;
     }

--- a/src/storm/solver/TopologicalMinMaxLinearEquationSolver.h
+++ b/src/storm/solver/TopologicalMinMaxLinearEquationSolver.h
@@ -38,6 +38,12 @@ class TopologicalMinMaxLinearEquationSolver : public StandardMinMaxLinearEquatio
     // Creates an SCC decomposition and sorts the SCCs according to a topological sort.
     void createSortedSccDecomposition(bool needLongestChainSize) const;
 
+    /*!
+     * Reports the precision that the SCCs were solved with as a bound on the solution, if that precision is a
+     * sound one. Does nothing otherwise.
+     */
+    void trySetSolutionBoundsFromPrecision(Environment const& env, std::vector<SolutionType> const& x) const;
+
     // Solves the SCC with the given index
     // ... for the case that the SCC is trivial
     bool solveTrivialScc(uint64_t const& sccState, OptimizationDirection d, std::vector<SolutionType>& globalX, std::vector<ValueType> const& globalB) const;

--- a/src/storm/solver/helper/IntervalterationHelper.cpp
+++ b/src/storm/solver/helper/IntervalterationHelper.cpp
@@ -116,13 +116,11 @@ SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(std::pai
 }
 
 template<typename ValueType, bool TrivialRowGrouping>
-SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets,
-                                                                        uint64_t& numIterations, bool relative, ValueType const& precision,
-                                                                        std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,
-                                                                        std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds,
-                                                                        std::optional<storm::OptimizationDirection> const& dir,
-                                                                        std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback,
-                                                                        std::optional<storm::storage::BitVector> const& relevantValues) const {
+SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(
+    std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
+    std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds, std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds,
+    std::optional<storm::OptimizationDirection> const& dir, std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback,
+    std::optional<storm::storage::BitVector> const& relevantValues, SolutionBounds<ValueType>* solutionBounds) const {
     // Create two vectors x and y using the given operand plus an auxiliary vector.
     std::pair<std::vector<ValueType>, std::vector<ValueType>> xy;
     auto& auxVector = viOperator->allocateAuxiliaryVector(operand.size());
@@ -139,6 +137,12 @@ SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(std::vec
         status = II<OptimizationDirection::Maximize>(xy, offsets, numIterations, relative, precision, iterationCallback, relevantValues);
     } else {
         status = II<OptimizationDirection::Minimize>(xy, offsets, numIterations, relative, precision, iterationCallback, relevantValues);
+    }
+    if (solutionBounds != nullptr) {
+        // Hand out the enclosure before it is collapsed into the point estimate below. Interval iteration
+        // maintains xy.first below and xy.second above the solution in every iteration, so these are sound
+        // even if the iteration was aborted before converging.
+        *solutionBounds = std::make_pair(xy.first, xy.second);
     }
     auto two = storm::utility::convertNumber<ValueType>(2.0);
     // get the average of lower- and upper result

--- a/src/storm/solver/helper/IntervalterationHelper.cpp
+++ b/src/storm/solver/helper/IntervalterationHelper.cpp
@@ -139,9 +139,8 @@ SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(
         status = II<OptimizationDirection::Minimize>(xy, offsets, numIterations, relative, precision, iterationCallback, relevantValues);
     }
     if (solutionBounds.has_value()) {
-        // Hand out the enclosure before it is collapsed into the point estimate below. Interval iteration
-        // maintains xy.first below and xy.second above the solution in every iteration, so both sides are
-        // sound even if the iteration was aborted before converging.
+        // Interval iteration keeps xy.first below and xy.second above the solution in every iteration, so both
+        // sides are sound even if it was aborted. Read them out before they are collapsed into the estimate.
         solutionBounds->lower = xy.first;
         solutionBounds->upper = xy.second;
     }

--- a/src/storm/solver/helper/IntervalterationHelper.cpp
+++ b/src/storm/solver/helper/IntervalterationHelper.cpp
@@ -120,7 +120,7 @@ SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
     std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds, std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds,
     std::optional<storm::OptimizationDirection> const& dir, std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback,
-    std::optional<storm::storage::BitVector> const& relevantValues, SolutionBounds<ValueType>* solutionBounds) const {
+    std::optional<storm::storage::BitVector> const& relevantValues, storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds) const {
     // Create two vectors x and y using the given operand plus an auxiliary vector.
     std::pair<std::vector<ValueType>, std::vector<ValueType>> xy;
     auto& auxVector = viOperator->allocateAuxiliaryVector(operand.size());
@@ -138,7 +138,7 @@ SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(
     } else {
         status = II<OptimizationDirection::Minimize>(xy, offsets, numIterations, relative, precision, iterationCallback, relevantValues);
     }
-    if (solutionBounds != nullptr) {
+    if (solutionBounds.has_value()) {
         // Hand out the enclosure before it is collapsed into the point estimate below. Interval iteration
         // maintains xy.first below and xy.second above the solution in every iteration, so both sides are
         // sound even if the iteration was aborted before converging.

--- a/src/storm/solver/helper/IntervalterationHelper.cpp
+++ b/src/storm/solver/helper/IntervalterationHelper.cpp
@@ -140,9 +140,10 @@ SolverStatus IntervalIterationHelper<ValueType, TrivialRowGrouping>::II(
     }
     if (solutionBounds != nullptr) {
         // Hand out the enclosure before it is collapsed into the point estimate below. Interval iteration
-        // maintains xy.first below and xy.second above the solution in every iteration, so these are sound
-        // even if the iteration was aborted before converging.
-        *solutionBounds = std::make_pair(xy.first, xy.second);
+        // maintains xy.first below and xy.second above the solution in every iteration, so both sides are
+        // sound even if the iteration was aborted before converging.
+        solutionBounds->lower = xy.first;
+        solutionBounds->upper = xy.second;
     }
     auto two = storm::utility::convertNumber<ValueType>(2.0);
     // get the average of lower- and upper result

--- a/src/storm/solver/helper/IntervalterationHelper.h
+++ b/src/storm/solver/helper/IntervalterationHelper.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "storm/solver/OptimizationDirection.h"
+#include "storm/solver/SolutionBounds.h"
 #include "storm/solver/SolverStatus.h"
 #include "storm/solver/helper/ValueIterationOperatorForward.h"
 #include "storm/storage/BitVector.h"
@@ -37,7 +38,7 @@ class IntervalIterationHelper {
                     std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,
                     std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds, std::optional<storm::OptimizationDirection> const& dir = {},
                     std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback = {},
-                    std::optional<storm::storage::BitVector> const& relevantValues = {}) const;
+                    std::optional<storm::storage::BitVector> const& relevantValues = {}, SolutionBounds<ValueType>* solutionBounds = nullptr) const;
 
     SolverStatus II(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
                     std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,

--- a/src/storm/solver/helper/IntervalterationHelper.h
+++ b/src/storm/solver/helper/IntervalterationHelper.h
@@ -10,6 +10,7 @@
 #include "storm/solver/SolverStatus.h"
 #include "storm/solver/helper/ValueIterationOperatorForward.h"
 #include "storm/storage/BitVector.h"
+#include "storm/utility/OptionalRef.h"
 
 namespace storm::solver::helper {
 
@@ -38,7 +39,8 @@ class IntervalIterationHelper {
                     std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,
                     std::function<void(std::vector<ValueType>&)> const& prepareUpperBounds, std::optional<storm::OptimizationDirection> const& dir = {},
                     std::function<SolverStatus(IIData<ValueType> const&)> const& iterationCallback = {},
-                    std::optional<storm::storage::BitVector> const& relevantValues = {}, SolutionBounds<ValueType>* solutionBounds = nullptr) const;
+                    std::optional<storm::storage::BitVector> const& relevantValues = {},
+                    storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds = storm::NullRef) const;
 
     SolverStatus II(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
                     std::function<void(std::vector<ValueType>&)> const& prepareLowerBounds,

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
@@ -269,8 +269,8 @@ template<typename ValueType, bool TrivialRowGrouping>
 SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& guessValue, std::optional<ValueType> const& lowerBound,
-    std::optional<ValueType> const& upperBound,
-    std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback) const {
+    std::optional<ValueType> const& upperBound, std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback,
+    SolutionBounds<ValueType>* solutionBounds) const {
     // Create two vectors v and u using the given operand plus an auxiliary vector.
     std::pair<std::vector<ValueType>, std::vector<ValueType>> vu;
     auto& auxVector = viOperator->allocateAuxiliaryVector(operand.size());
@@ -281,6 +281,11 @@ SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
         doublePrec -= precision * 1e-6;  // be slightly more precise to avoid a good chunk of floating point issues
     }
     auto status = OVI(vu, offsets, numIterations, relative, doublePrec, dir, guessValue ? *guessValue : doublePrec, lowerBound, upperBound, iterationCallback);
+    if (solutionBounds != nullptr && status == SolverStatus::Converged) {
+        // Only a converged run has verified that vu.second lies above the solution. Until the verification
+        // phase succeeds it is merely a guess, so handing it out as an upper bound would be unsound.
+        *solutionBounds = std::make_pair(vu.first, vu.second);
+    }
     auto two = storm::utility::convertNumber<ValueType>(2.0);
     // get the average of lower- and upper result
     storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
@@ -296,10 +301,10 @@ template<typename ValueType, bool TrivialRowGrouping>
 SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& guessValue, std::optional<ValueType> const& lowerBound,
-    std::optional<ValueType> const& upperBound,
-    std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback) const {
+    std::optional<ValueType> const& upperBound, std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback,
+    SolutionBounds<ValueType>* solutionBounds) const {
     uint64_t numIterations = 0;
-    return OVI(operand, offsets, numIterations, relative, precision, dir, guessValue, lowerBound, upperBound, iterationCallback);
+    return OVI(operand, offsets, numIterations, relative, precision, dir, guessValue, lowerBound, upperBound, iterationCallback, solutionBounds);
 }
 
 template class OptimisticValueIterationHelper<double, true>;

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
@@ -281,15 +281,26 @@ SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
         doublePrec -= precision * 1e-6;  // be slightly more precise to avoid a good chunk of floating point issues
     }
     auto status = OVI(vu, offsets, numIterations, relative, doublePrec, dir, guessValue ? *guessValue : doublePrec, lowerBound, upperBound, iterationCallback);
-    if (solutionBounds != nullptr && status == SolverStatus::Converged) {
+    bool const converged = status == SolverStatus::Converged;
+    if (solutionBounds != nullptr) {
+        // The operand was initialized below the solution and every iteration -- both the ones of the value
+        // iteration phase and the ones of the verification phase -- applies the (monotone) operator to it, so
+        // vu.first lies below the solution no matter why we stopped iterating.
+        solutionBounds->lower = vu.first;
         // Only a converged run has verified that vu.second lies above the solution. Until the verification
         // phase succeeds it is merely a guess, so handing it out as an upper bound would be unsound.
-        *solutionBounds = std::make_pair(vu.first, vu.second);
+        if (converged) {
+            solutionBounds->upper = vu.second;
+        }
     }
-    auto two = storm::utility::convertNumber<ValueType>(2.0);
-    // get the average of lower- and upper result
-    storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
-        vu.first, vu.second, vu.first, [&two](ValueType const& a, ValueType const& b) -> ValueType { return (a + b) / two; });
+    if (converged) {
+        auto two = storm::utility::convertNumber<ValueType>(2.0);
+        // get the average of lower- and upper result
+        storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
+            vu.first, vu.second, vu.first, [&two](ValueType const& a, ValueType const& b) -> ValueType { return (a + b) / two; });
+    }
+    // Otherwise vu.second holds an unverified guess (or, if we never got to guessing, uninitialized data), so
+    // averaging it into the result would be meaningless and could even push the result below vu.first.
     // Swap operand and aux vector back to original positions.
     vu.first.swap(operand);
     vu.second.swap(auxVector);

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
@@ -270,7 +270,7 @@ SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& guessValue, std::optional<ValueType> const& lowerBound,
     std::optional<ValueType> const& upperBound, std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback,
-    SolutionBounds<ValueType>* solutionBounds) const {
+    storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds) const {
     // Create two vectors v and u using the given operand plus an auxiliary vector.
     std::pair<std::vector<ValueType>, std::vector<ValueType>> vu;
     auto& auxVector = viOperator->allocateAuxiliaryVector(operand.size());
@@ -282,7 +282,7 @@ SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
     }
     auto status = OVI(vu, offsets, numIterations, relative, doublePrec, dir, guessValue ? *guessValue : doublePrec, lowerBound, upperBound, iterationCallback);
     bool const converged = status == SolverStatus::Converged;
-    if (solutionBounds != nullptr) {
+    if (solutionBounds.has_value()) {
         // The operand was initialized below the solution and every iteration -- both the ones of the value
         // iteration phase and the ones of the verification phase -- applies the (monotone) operator to it, so
         // vu.first lies below the solution no matter why we stopped iterating.
@@ -313,7 +313,7 @@ SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& guessValue, std::optional<ValueType> const& lowerBound,
     std::optional<ValueType> const& upperBound, std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback,
-    SolutionBounds<ValueType>* solutionBounds) const {
+    storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds) const {
     uint64_t numIterations = 0;
     return OVI(operand, offsets, numIterations, relative, precision, dir, guessValue, lowerBound, upperBound, iterationCallback, solutionBounds);
 }

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.cpp
@@ -283,24 +283,19 @@ SolverStatus OptimisticValueIterationHelper<ValueType, TrivialRowGrouping>::OVI(
     auto status = OVI(vu, offsets, numIterations, relative, doublePrec, dir, guessValue ? *guessValue : doublePrec, lowerBound, upperBound, iterationCallback);
     bool const converged = status == SolverStatus::Converged;
     if (solutionBounds.has_value()) {
-        // The operand was initialized below the solution and every iteration -- both the ones of the value
-        // iteration phase and the ones of the verification phase -- applies the (monotone) operator to it, so
-        // vu.first lies below the solution no matter why we stopped iterating.
+        // The operand started below the solution and every iteration applies the monotone operator to it, so
+        // vu.first lies below the solution whatever stopped the iteration.
         solutionBounds->lower = vu.first;
-        // Only a converged run has verified that vu.second lies above the solution. Until the verification
-        // phase succeeds it is merely a guess, so handing it out as an upper bound would be unsound.
+        // Until the verification phase succeeds vu.second is merely a guess, not an upper bound.
         if (converged) {
             solutionBounds->upper = vu.second;
         }
     }
     if (converged) {
         auto two = storm::utility::convertNumber<ValueType>(2.0);
-        // get the average of lower- and upper result
         storm::utility::vector::applyPointwise<ValueType, ValueType, ValueType>(
             vu.first, vu.second, vu.first, [&two](ValueType const& a, ValueType const& b) -> ValueType { return (a + b) / two; });
     }
-    // Otherwise vu.second holds an unverified guess (or, if we never got to guessing, uninitialized data), so
-    // averaging it into the result would be meaningless and could even push the result below vu.first.
     // Swap operand and aux vector back to original positions.
     vu.first.swap(operand);
     vu.second.swap(auxVector);

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.h
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "storm/solver/OptimizationDirection.h"
+#include "storm/solver/SolutionBounds.h"
 #include "storm/solver/SolverStatus.h"
 
 #include "storm/solver/helper/ValueIterationOperatorForward.h"
@@ -36,12 +37,14 @@ class OptimisticValueIterationHelper {
     SolverStatus OVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
                      std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& guessValue = {},
                      std::optional<ValueType> const& lowerBound = {}, std::optional<ValueType> const& upperBound = {},
-                     std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {}) const;
+                     std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {},
+                     SolutionBounds<ValueType>* solutionBounds = nullptr) const;
 
     SolverStatus OVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
                      std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& guessValue = {},
                      std::optional<ValueType> const& lowerBound = {}, std::optional<ValueType> const& upperBound = {},
-                     std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {}) const;
+                     std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {},
+                     SolutionBounds<ValueType>* solutionBounds = nullptr) const;
 
    private:
     template<storm::OptimizationDirection Dir, bool Relative>

--- a/src/storm/solver/helper/OptimisticValueIterationHelper.h
+++ b/src/storm/solver/helper/OptimisticValueIterationHelper.h
@@ -11,6 +11,7 @@
 #include "storm/solver/SolverStatus.h"
 
 #include "storm/solver/helper/ValueIterationOperatorForward.h"
+#include "storm/utility/OptionalRef.h"
 
 namespace storm::solver::helper {
 
@@ -38,13 +39,13 @@ class OptimisticValueIterationHelper {
                      std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& guessValue = {},
                      std::optional<ValueType> const& lowerBound = {}, std::optional<ValueType> const& upperBound = {},
                      std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {},
-                     SolutionBounds<ValueType>* solutionBounds = nullptr) const;
+                     storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds = storm::NullRef) const;
 
     SolverStatus OVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
                      std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& guessValue = {},
                      std::optional<ValueType> const& lowerBound = {}, std::optional<ValueType> const& upperBound = {},
                      std::function<SolverStatus(SolverStatus const&, std::vector<ValueType> const&)> const& iterationCallback = {},
-                     SolutionBounds<ValueType>* solutionBounds = nullptr) const;
+                     storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds = storm::NullRef) const;
 
    private:
     template<storm::OptimizationDirection Dir, bool Relative>

--- a/src/storm/solver/helper/SoundValueIterationHelper.cpp
+++ b/src/storm/solver/helper/SoundValueIterationHelper.cpp
@@ -413,9 +413,8 @@ SolverStatus SoundValueIterationHelper<ValueType, TrivialRowGrouping>::SVI(
     }
     auto res = SVI(xy, offsets, numIterations, relative, doublePrec, dir, lowerBound, upperBound, iterationCallback, relevantValues);
     if (solutionBounds.has_value()) {
-        // Read the enclosure out before the point estimate below overwrites x with the average of its two sides.
-        // Sound value iteration keeps the solution enclosed in every iteration, so both sides hold even if the
-        // iteration was aborted before converging. They are only expressible once both scaling factors are known.
+        // Sound value iteration keeps the solution enclosed in every iteration, aborted or not, but only once
+        // both scaling factors are known. Read it out before x is overwritten with the average of the two sides.
         std::vector<ValueType>& lower = solutionBounds->lower.emplace(xy.first.size());
         std::vector<ValueType>& upper = solutionBounds->upper.emplace(xy.first.size());
         if (!res.trySetLowerUpper(lower, upper)) {

--- a/src/storm/solver/helper/SoundValueIterationHelper.cpp
+++ b/src/storm/solver/helper/SoundValueIterationHelper.cpp
@@ -401,7 +401,7 @@ SolverStatus SoundValueIterationHelper<ValueType, TrivialRowGrouping>::SVI(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& lowerBound, std::optional<ValueType> const& upperBound,
     std::function<SolverStatus(SVIData const&)> const& iterationCallback, std::optional<storm::storage::BitVector> const& relevantValues,
-    SolutionBounds<ValueType>* solutionBounds) const {
+    storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds) const {
     // Create two vectors x and y using the given operand plus an auxiliary vector.
     std::pair<std::vector<ValueType>, std::vector<ValueType>> xy;
     auto& auxVector = viOperator->allocateAuxiliaryVector(operand.size());
@@ -412,7 +412,7 @@ SolverStatus SoundValueIterationHelper<ValueType, TrivialRowGrouping>::SVI(
         doublePrec -= precision * 1e-6;  // be slightly more precise to avoid a good chunk of floating point issues
     }
     auto res = SVI(xy, offsets, numIterations, relative, doublePrec, dir, lowerBound, upperBound, iterationCallback, relevantValues);
-    if (solutionBounds != nullptr) {
+    if (solutionBounds.has_value()) {
         // Read the enclosure out before the point estimate below overwrites x with the average of its two sides.
         // Sound value iteration keeps the solution enclosed in every iteration, so both sides hold even if the
         // iteration was aborted before converging. They are only expressible once both scaling factors are known.
@@ -435,7 +435,7 @@ SolverStatus SoundValueIterationHelper<ValueType, TrivialRowGrouping>::SVI(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& lowerBound, std::optional<ValueType> const& upperBound,
     std::function<SolverStatus(SVIData const&)> const& iterationCallback, std::optional<storm::storage::BitVector> const& relevantValues,
-    SolutionBounds<ValueType>* solutionBounds) const {
+    storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds) const {
     uint64_t numIterations = 0;
     return SVI(operand, offsets, numIterations, relative, precision, dir, lowerBound, upperBound, iterationCallback, relevantValues, solutionBounds);
 }

--- a/src/storm/solver/helper/SoundValueIterationHelper.cpp
+++ b/src/storm/solver/helper/SoundValueIterationHelper.cpp
@@ -226,8 +226,11 @@ void SoundValueIterationHelper<ValueType, TrivialRowGrouping>::SVIData::trySetAv
 }
 
 template<typename ValueType, bool TrivialRowGrouping>
-void SoundValueIterationHelper<ValueType, TrivialRowGrouping>::SVIData::trySetLowerUpper(std::vector<ValueType>& lowerOut,
+bool SoundValueIterationHelper<ValueType, TrivialRowGrouping>::SVIData::trySetLowerUpper(std::vector<ValueType>& lowerOut,
                                                                                          std::vector<ValueType>& upperOut) const {
+    if (!a.has_value() || !b.has_value()) {
+        return false;
+    }
     auto [min, max] = std::minmax(*a, *b);
     uint64_t const size = xy.first.size();
     for (uint64_t i = 0; i < size; ++i) {
@@ -238,6 +241,7 @@ void SoundValueIterationHelper<ValueType, TrivialRowGrouping>::SVIData::trySetLo
         lowerOut[i] = xi + min * yi;
         upperOut[i] = xi + max * yi;
     }
+    return true;
 }
 
 template<typename ValueType, bool TrivialRowGrouping>
@@ -396,7 +400,8 @@ template<typename ValueType, bool TrivialRowGrouping>
 SolverStatus SoundValueIterationHelper<ValueType, TrivialRowGrouping>::SVI(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& lowerBound, std::optional<ValueType> const& upperBound,
-    std::function<SolverStatus(SVIData const&)> const& iterationCallback, std::optional<storm::storage::BitVector> const& relevantValues) const {
+    std::function<SolverStatus(SVIData const&)> const& iterationCallback, std::optional<storm::storage::BitVector> const& relevantValues,
+    SolutionBounds<ValueType>* solutionBounds) const {
     // Create two vectors x and y using the given operand plus an auxiliary vector.
     std::pair<std::vector<ValueType>, std::vector<ValueType>> xy;
     auto& auxVector = viOperator->allocateAuxiliaryVector(operand.size());
@@ -407,6 +412,16 @@ SolverStatus SoundValueIterationHelper<ValueType, TrivialRowGrouping>::SVI(
         doublePrec -= precision * 1e-6;  // be slightly more precise to avoid a good chunk of floating point issues
     }
     auto res = SVI(xy, offsets, numIterations, relative, doublePrec, dir, lowerBound, upperBound, iterationCallback, relevantValues);
+    if (solutionBounds != nullptr) {
+        // Read the enclosure out before the point estimate below overwrites x with the average of its two sides.
+        // Sound value iteration keeps the solution enclosed in every iteration, so both sides hold even if the
+        // iteration was aborted before converging. They are only expressible once both scaling factors are known.
+        std::vector<ValueType>& lower = solutionBounds->lower.emplace(xy.first.size());
+        std::vector<ValueType>& upper = solutionBounds->upper.emplace(xy.first.size());
+        if (!res.trySetLowerUpper(lower, upper)) {
+            solutionBounds->clear();
+        }
+    }
     res.trySetAverage(xy.first);
     // Swap operand and aux vector back to original positions.
     xy.first.swap(operand);
@@ -419,9 +434,10 @@ template<typename ValueType, bool TrivialRowGrouping>
 SolverStatus SoundValueIterationHelper<ValueType, TrivialRowGrouping>::SVI(
     std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::optional<ValueType> const& lowerBound, std::optional<ValueType> const& upperBound,
-    std::function<SolverStatus(SVIData const&)> const& iterationCallback, std::optional<storm::storage::BitVector> const& relevantValues) const {
+    std::function<SolverStatus(SVIData const&)> const& iterationCallback, std::optional<storm::storage::BitVector> const& relevantValues,
+    SolutionBounds<ValueType>* solutionBounds) const {
     uint64_t numIterations = 0;
-    return SVI(operand, offsets, numIterations, relative, precision, dir, lowerBound, upperBound, iterationCallback, relevantValues);
+    return SVI(operand, offsets, numIterations, relative, precision, dir, lowerBound, upperBound, iterationCallback, relevantValues, solutionBounds);
 }
 
 template class SoundValueIterationHelper<double, true>;

--- a/src/storm/solver/helper/SoundValueIterationHelper.h
+++ b/src/storm/solver/helper/SoundValueIterationHelper.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "storm/solver/OptimizationDirection.h"
+#include "storm/solver/SolutionBounds.h"
 #include "storm/solver/SolverStatus.h"
 #include "storm/solver/TerminationCondition.h"
 #include "storm/solver/helper/ValueIterationOperatorForward.h"
@@ -27,7 +28,12 @@ class SoundValueIterationHelper {
         std::optional<ValueType> const a, b;
 
         void trySetAverage(std::vector<ValueType>& out) const;
-        void trySetLowerUpper(std::vector<ValueType>& lowerOut, std::vector<ValueType>& upperOut) const;
+
+        /*!
+         * Writes the enclosure of the solution that this data represents.
+         * @return whether the two scaling factors it is built from are both known, i.e. whether anything was written.
+         */
+        bool trySetLowerUpper(std::vector<ValueType>& lowerOut, std::vector<ValueType>& upperOut) const;
         bool checkCustomTerminationCondition(storm::solver::TerminationCondition<ValueType> const& condition) const;
 
         bool checkConvergence(uint64_t& convergenceCheckState, std::function<void()> const& getNextConvergenceCheckState, bool relative,
@@ -54,12 +60,12 @@ class SoundValueIterationHelper {
     SolverStatus SVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
                      std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& lowerBound = {},
                      std::optional<ValueType> const& upperBound = {}, std::function<SolverStatus(SVIData const&)> const& iterationCallback = {},
-                     std::optional<storm::storage::BitVector> const& relevantValues = {}) const;
+                     std::optional<storm::storage::BitVector> const& relevantValues = {}, SolutionBounds<ValueType>* solutionBounds = nullptr) const;
 
     SolverStatus SVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
                      std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& lowerBound = {},
                      std::optional<ValueType> const& upperBound = {}, std::function<SolverStatus(SVIData const&)> const& iterationCallback = {},
-                     std::optional<storm::storage::BitVector> const& relevantValues = {}) const;
+                     std::optional<storm::storage::BitVector> const& relevantValues = {}, SolutionBounds<ValueType>* solutionBounds = nullptr) const;
 
    private:
     std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator;

--- a/src/storm/solver/helper/SoundValueIterationHelper.h
+++ b/src/storm/solver/helper/SoundValueIterationHelper.h
@@ -10,6 +10,7 @@
 #include "storm/solver/SolverStatus.h"
 #include "storm/solver/TerminationCondition.h"
 #include "storm/solver/helper/ValueIterationOperatorForward.h"
+#include "storm/utility/OptionalRef.h"
 
 namespace storm::solver::helper {
 
@@ -60,12 +61,14 @@ class SoundValueIterationHelper {
     SolverStatus SVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, ValueType const& precision,
                      std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& lowerBound = {},
                      std::optional<ValueType> const& upperBound = {}, std::function<SolverStatus(SVIData const&)> const& iterationCallback = {},
-                     std::optional<storm::storage::BitVector> const& relevantValues = {}, SolutionBounds<ValueType>* solutionBounds = nullptr) const;
+                     std::optional<storm::storage::BitVector> const& relevantValues = {},
+                     storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds = storm::NullRef) const;
 
     SolverStatus SVI(std::vector<ValueType>& operand, std::vector<ValueType> const& offsets, bool relative, ValueType const& precision,
                      std::optional<storm::OptimizationDirection> const& dir = {}, std::optional<ValueType> const& lowerBound = {},
                      std::optional<ValueType> const& upperBound = {}, std::function<SolverStatus(SVIData const&)> const& iterationCallback = {},
-                     std::optional<storm::storage::BitVector> const& relevantValues = {}, SolutionBounds<ValueType>* solutionBounds = nullptr) const;
+                     std::optional<storm::storage::BitVector> const& relevantValues = {},
+                     storm::OptionalRef<SolutionBounds<ValueType>> solutionBounds = storm::NullRef) const;
 
    private:
     std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping>> viOperator;

--- a/src/storm/solver/helper/ValueIterationHelper.cpp
+++ b/src/storm/solver/helper/ValueIterationHelper.cpp
@@ -92,7 +92,7 @@ SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::
                                                                                    uint64_t& numIterations, SolutionType const& precision,
                                                                                    std::function<SolverStatus(SolverStatus const&)> const& iterationCallback,
                                                                                    MultiplicationStyle mult,
-                                                                                   SolutionBounds<SolutionType>* solutionBounds) const {
+                                                                                   storm::OptionalRef<SolutionBounds<SolutionType>> solutionBounds) const {
     VIOperatorBackend<SolutionType, Dir, Relative> backend{precision};
     std::vector<SolutionType>* operand1{&operand};
     std::vector<SolutionType>* operand2{&operand};
@@ -121,7 +121,7 @@ SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::
         }
         viOperator->freeAuxiliaryVector();
     }
-    if (solutionBounds != nullptr && mult == MultiplicationStyle::GaussSeidel) {
+    if (solutionBounds.has_value() && mult == MultiplicationStyle::GaussSeidel) {
         /*
          * Value iteration itself carries a sound bound on the solution whenever an entire iteration moved the
          * operand in a single direction. Writing T for the update operator and x for the operand at the end of
@@ -161,7 +161,7 @@ SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::
                                                                                    const std::function<SolverStatus(const SolverStatus&)>& iterationCallback,
                                                                                    MultiplicationStyle mult,
                                                                                    UncertaintyResolutionMode const& uncertaintyResolutionMode,
-                                                                                   SolutionBounds<SolutionType>* solutionBounds) const {
+                                                                                   storm::OptionalRef<SolutionBounds<SolutionType>> solutionBounds) const {
     bool robustUncertainty = false;
     if constexpr (storm::IsIntervalType<ValueType>) {
         robustUncertainty = isUncertaintyResolvedRobust(uncertaintyResolutionMode, Dir);
@@ -178,7 +178,7 @@ template<typename ValueType, bool TrivialRowGrouping, typename SolutionType>
 SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::VI(
     std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, SolutionType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::function<SolverStatus(SolverStatus const&)> const& iterationCallback, MultiplicationStyle mult,
-    UncertaintyResolutionMode const& uncertaintyResolutionMode, SolutionBounds<SolutionType>* solutionBounds) const {
+    UncertaintyResolutionMode const& uncertaintyResolutionMode, storm::OptionalRef<SolutionBounds<SolutionType>> solutionBounds) const {
     if constexpr (storm::IsIntervalType<ValueType>) {
         STORM_LOG_THROW(uncertaintyResolutionMode != UncertaintyResolutionMode::Unset, storm::exceptions::IllegalFunctionCallException,
                         "Uncertainty resolution mode must be set for uncertain (interval) models.");
@@ -212,7 +212,7 @@ template<typename ValueType, bool TrivialRowGrouping, typename SolutionType>
 SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::VI(
     std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets, bool relative, SolutionType const& precision,
     std::optional<storm::OptimizationDirection> const& dir, std::function<SolverStatus(SolverStatus const&)> const& iterationCallback, MultiplicationStyle mult,
-    UncertaintyResolutionMode const& uncertaintyResolutionMode, SolutionBounds<SolutionType>* solutionBounds) const {
+    UncertaintyResolutionMode const& uncertaintyResolutionMode, storm::OptionalRef<SolutionBounds<SolutionType>> solutionBounds) const {
     uint64_t numIterations = 0;
     return VI(operand, offsets, numIterations, relative, precision, dir, iterationCallback, mult, uncertaintyResolutionMode, solutionBounds);
 }

--- a/src/storm/solver/helper/ValueIterationHelper.cpp
+++ b/src/storm/solver/helper/ValueIterationHelper.cpp
@@ -37,8 +37,7 @@ class VIOperatorBackend {
                 isConverged = storm::utility::abs<ValueType>(currValue - *best) <= precision;
             }
         }
-        // Record in which direction this iteration moves the operand, so that a sound bound on the solution can
-        // be derived once the iteration is over. See the comment in ValueIterationHelper::VI.
+        // Record the direction this iteration moves the operand in; see the comment in ValueIterationHelper::VI.
         if (isNonDecreasing && *best < currValue) {
             isNonDecreasing = false;
         }
@@ -123,26 +122,16 @@ SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::
     }
     if (solutionBounds.has_value() && mult == MultiplicationStyle::GaussSeidel) {
         /*
-         * Value iteration itself carries a sound bound on the solution whenever an entire iteration moved the
-         * operand in a single direction. Writing T for the update operator and x for the operand at the end of
-         * the last iteration, an iteration that decreased nothing means x >= x_old, and every entry of x was
-         * computed from entries that are at most the corresponding ones of x, so monotonicity of T gives
-         * x <= T(x). Iterating T from there yields an increasing sequence that converges to a fixpoint, and the
-         * equation systems handed to this helper have only one, so that is the solution and x lies below it.
-         * The dual argument applies to an iteration that increased nothing. Both apply at once to an iteration
-         * that moved nothing at all: the operator reproduced its operand, so x is the fixed point and bounds
-         * itself from either side.
+         * An iteration that decreased nothing gives x >= x_old, so every entry of x was computed from entries at
+         * most the corresponding ones of x and monotonicity of the update operator T gives x <= T(x). Iterating T
+         * from there increases towards a fixpoint, of which the systems handed to this helper have only one, so x
+         * lies below the solution. The dual argument applies to an iteration that increased nothing, and both at
+         * once to one that moved nothing. This is a property of the last iteration alone: it needs neither
+         * convergence nor a particular starting point.
          *
-         * Note that this reasoning does not depend on the iteration having converged, nor on the operand having
-         * been initialized below (resp. above) the solution: it is a property of the last completed iteration
-         * alone, which is exactly what the backend records.
-         *
-         * It does depend on the operand being updated in place: the backend learns the direction by comparing
-         * the new value of an entry against the one it overwrites, which is the previous iterate only for
-         * Gauss-Seidel. With a regular multiplication the two operands alternate, so the entry being overwritten
-         * holds the iterate from two steps ago (and, in the very first iteration, whatever the auxiliary vector
-         * happened to contain), which says nothing about the direction of the last step. Nothing is claimed
-         * there rather than claiming something unsound.
+         * It does need the operand to be updated in place, as the backend reads the direction off the entry it
+         * overwrites. With a regular multiplication that entry holds the iterate from two steps ago, so nothing
+         * is claimed there.
          */
         if (backend.nonDecreasing()) {
             solutionBounds->lower = operand;

--- a/src/storm/solver/helper/ValueIterationHelper.cpp
+++ b/src/storm/solver/helper/ValueIterationHelper.cpp
@@ -17,6 +17,8 @@ class VIOperatorBackend {
 
     void startNewIteration() {
         isConverged = true;
+        isNonDecreasing = true;
+        isNonIncreasing = true;
     }
 
     void firstRow(ValueType&& value, [[maybe_unused]] uint64_t rowGroup, [[maybe_unused]] uint64_t row) {
@@ -35,6 +37,14 @@ class VIOperatorBackend {
                 isConverged = storm::utility::abs<ValueType>(currValue - *best) <= precision;
             }
         }
+        // Record in which direction this iteration moves the operand, so that a sound bound on the solution can
+        // be derived once the iteration is over. See the comment in ValueIterationHelper::VI.
+        if (isNonDecreasing && *best < currValue) {
+            isNonDecreasing = false;
+        }
+        if (isNonIncreasing && currValue < *best) {
+            isNonIncreasing = false;
+        }
         currValue = std::move(*best);
     }
 
@@ -46,6 +56,17 @@ class VIOperatorBackend {
         return isConverged;
     }
 
+    /*!
+     * Retrieves whether the last iteration did not decrease resp. increase any entry of the operand.
+     */
+    bool nonDecreasing() const {
+        return isNonDecreasing;
+    }
+
+    bool nonIncreasing() const {
+        return isNonIncreasing;
+    }
+
     bool constexpr abort() const {
         return false;
     }
@@ -54,6 +75,8 @@ class VIOperatorBackend {
     storm::utility::Extremum<Dir, ValueType> best;
     ValueType const precision;
     bool isConverged{true};
+    bool isNonDecreasing{true};
+    bool isNonIncreasing{true};
 };
 
 template<typename ValueType, bool TrivialRowGrouping, typename SolutionType>
@@ -68,7 +91,8 @@ template<storm::OptimizationDirection Dir, bool Relative, storm::OptimizationDir
 SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::VI(std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets,
                                                                                    uint64_t& numIterations, SolutionType const& precision,
                                                                                    std::function<SolverStatus(SolverStatus const&)> const& iterationCallback,
-                                                                                   MultiplicationStyle mult) const {
+                                                                                   MultiplicationStyle mult,
+                                                                                   SolutionBounds<SolutionType>* solutionBounds) const {
     VIOperatorBackend<SolutionType, Dir, Relative> backend{precision};
     std::vector<SolutionType>* operand1{&operand};
     std::vector<SolutionType>* operand2{&operand};
@@ -97,6 +121,25 @@ SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::
         }
         viOperator->freeAuxiliaryVector();
     }
+    if (solutionBounds != nullptr) {
+        /*
+         * Value iteration itself carries a sound bound on the solution whenever an entire iteration moved the
+         * operand in a single direction. Writing T for the (Gauss-Seidel or regular) update operator, an
+         * iteration that decreased nothing means x_old <= T(x_old), so x_old is a post-fixpoint and therefore
+         * below the greatest fixpoint; since x = T(x_old) and T is monotone, x is below it as well. The
+         * equation systems handed to this helper have a unique fixpoint, so that is the solution and x is a
+         * lower bound on it. The dual argument applies to an iteration that increased nothing.
+         *
+         * Note that this reasoning does not depend on the iteration having converged, nor on the operand having
+         * been initialized below (resp. above) the solution: it is a property of the last completed iteration
+         * alone, which is exactly what the backend records.
+         */
+        if (backend.nonDecreasing()) {
+            solutionBounds->lower = operand;
+        } else if (backend.nonIncreasing()) {
+            solutionBounds->upper = operand;
+        }
+    }
     return status;
 }
 
@@ -106,26 +149,25 @@ SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::
                                                                                    uint64_t& numIterations, SolutionType const& precision,
                                                                                    const std::function<SolverStatus(const SolverStatus&)>& iterationCallback,
                                                                                    MultiplicationStyle mult,
-                                                                                   UncertaintyResolutionMode const& uncertaintyResolutionMode) const {
+                                                                                   UncertaintyResolutionMode const& uncertaintyResolutionMode,
+                                                                                   SolutionBounds<SolutionType>* solutionBounds) const {
     bool robustUncertainty = false;
     if constexpr (storm::IsIntervalType<ValueType>) {
         robustUncertainty = isUncertaintyResolvedRobust(uncertaintyResolutionMode, Dir);
     }
 
     if (robustUncertainty) {
-        return VI<Dir, Relative, invert(Dir)>(operand, offsets, numIterations, precision, iterationCallback, mult);
+        return VI<Dir, Relative, invert(Dir)>(operand, offsets, numIterations, precision, iterationCallback, mult, solutionBounds);
     } else {
-        return VI<Dir, Relative, Dir>(operand, offsets, numIterations, precision, iterationCallback, mult);
+        return VI<Dir, Relative, Dir>(operand, offsets, numIterations, precision, iterationCallback, mult, solutionBounds);
     }
 }
 
 template<typename ValueType, bool TrivialRowGrouping, typename SolutionType>
-SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::VI(std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets,
-                                                                                   uint64_t& numIterations, bool relative, SolutionType const& precision,
-                                                                                   std::optional<storm::OptimizationDirection> const& dir,
-                                                                                   std::function<SolverStatus(SolverStatus const&)> const& iterationCallback,
-                                                                                   MultiplicationStyle mult,
-                                                                                   UncertaintyResolutionMode const& uncertaintyResolutionMode) const {
+SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::VI(
+    std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative, SolutionType const& precision,
+    std::optional<storm::OptimizationDirection> const& dir, std::function<SolverStatus(SolverStatus const&)> const& iterationCallback, MultiplicationStyle mult,
+    UncertaintyResolutionMode const& uncertaintyResolutionMode, SolutionBounds<SolutionType>* solutionBounds) const {
     if constexpr (storm::IsIntervalType<ValueType>) {
         STORM_LOG_THROW(uncertaintyResolutionMode != UncertaintyResolutionMode::Unset, storm::exceptions::IllegalFunctionCallException,
                         "Uncertainty resolution mode must be set for uncertain (interval) models.");
@@ -139,31 +181,29 @@ SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::
     if (!dir.has_value() || maximize(*dir)) {
         if (relative) {
             return VI<storm::OptimizationDirection::Maximize, true>(operand, offsets, numIterations, precision, iterationCallback, mult,
-                                                                    uncertaintyResolutionMode);
+                                                                    uncertaintyResolutionMode, solutionBounds);
         } else {
             return VI<storm::OptimizationDirection::Maximize, false>(operand, offsets, numIterations, precision, iterationCallback, mult,
-                                                                     uncertaintyResolutionMode);
+                                                                     uncertaintyResolutionMode, solutionBounds);
         }
     } else {
         if (relative) {
             return VI<storm::OptimizationDirection::Minimize, true>(operand, offsets, numIterations, precision, iterationCallback, mult,
-                                                                    uncertaintyResolutionMode);
+                                                                    uncertaintyResolutionMode, solutionBounds);
         } else {
             return VI<storm::OptimizationDirection::Minimize, false>(operand, offsets, numIterations, precision, iterationCallback, mult,
-                                                                     uncertaintyResolutionMode);
+                                                                     uncertaintyResolutionMode, solutionBounds);
         }
     }
 }
 
 template<typename ValueType, bool TrivialRowGrouping, typename SolutionType>
-SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::VI(std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets,
-                                                                                   bool relative, SolutionType const& precision,
-                                                                                   std::optional<storm::OptimizationDirection> const& dir,
-                                                                                   std::function<SolverStatus(SolverStatus const&)> const& iterationCallback,
-                                                                                   MultiplicationStyle mult,
-                                                                                   UncertaintyResolutionMode const& uncertaintyResolutionMode) const {
+SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::VI(
+    std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets, bool relative, SolutionType const& precision,
+    std::optional<storm::OptimizationDirection> const& dir, std::function<SolverStatus(SolverStatus const&)> const& iterationCallback, MultiplicationStyle mult,
+    UncertaintyResolutionMode const& uncertaintyResolutionMode, SolutionBounds<SolutionType>* solutionBounds) const {
     uint64_t numIterations = 0;
-    return VI(operand, offsets, numIterations, relative, precision, dir, iterationCallback, mult, uncertaintyResolutionMode);
+    return VI(operand, offsets, numIterations, relative, precision, dir, iterationCallback, mult, uncertaintyResolutionMode, solutionBounds);
 }
 
 template class ValueIterationHelper<double, true>;

--- a/src/storm/solver/helper/ValueIterationHelper.cpp
+++ b/src/storm/solver/helper/ValueIterationHelper.cpp
@@ -129,7 +129,9 @@ SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::
          * computed from entries that are at most the corresponding ones of x, so monotonicity of T gives
          * x <= T(x). Iterating T from there yields an increasing sequence that converges to a fixpoint, and the
          * equation systems handed to this helper have only one, so that is the solution and x lies below it.
-         * The dual argument applies to an iteration that increased nothing.
+         * The dual argument applies to an iteration that increased nothing. Both apply at once to an iteration
+         * that moved nothing at all: the operator reproduced its operand, so x is the fixed point and bounds
+         * itself from either side.
          *
          * Note that this reasoning does not depend on the iteration having converged, nor on the operand having
          * been initialized below (resp. above) the solution: it is a property of the last completed iteration
@@ -144,7 +146,8 @@ SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::
          */
         if (backend.nonDecreasing()) {
             solutionBounds->lower = operand;
-        } else if (backend.nonIncreasing()) {
+        }
+        if (backend.nonIncreasing()) {
             solutionBounds->upper = operand;
         }
     }

--- a/src/storm/solver/helper/ValueIterationHelper.cpp
+++ b/src/storm/solver/helper/ValueIterationHelper.cpp
@@ -121,18 +121,26 @@ SolverStatus ValueIterationHelper<ValueType, TrivialRowGrouping, SolutionType>::
         }
         viOperator->freeAuxiliaryVector();
     }
-    if (solutionBounds != nullptr) {
+    if (solutionBounds != nullptr && mult == MultiplicationStyle::GaussSeidel) {
         /*
          * Value iteration itself carries a sound bound on the solution whenever an entire iteration moved the
-         * operand in a single direction. Writing T for the (Gauss-Seidel or regular) update operator, an
-         * iteration that decreased nothing means x_old <= T(x_old), so x_old is a post-fixpoint and therefore
-         * below the greatest fixpoint; since x = T(x_old) and T is monotone, x is below it as well. The
-         * equation systems handed to this helper have a unique fixpoint, so that is the solution and x is a
-         * lower bound on it. The dual argument applies to an iteration that increased nothing.
+         * operand in a single direction. Writing T for the update operator and x for the operand at the end of
+         * the last iteration, an iteration that decreased nothing means x >= x_old, and every entry of x was
+         * computed from entries that are at most the corresponding ones of x, so monotonicity of T gives
+         * x <= T(x). Iterating T from there yields an increasing sequence that converges to a fixpoint, and the
+         * equation systems handed to this helper have only one, so that is the solution and x lies below it.
+         * The dual argument applies to an iteration that increased nothing.
          *
          * Note that this reasoning does not depend on the iteration having converged, nor on the operand having
          * been initialized below (resp. above) the solution: it is a property of the last completed iteration
          * alone, which is exactly what the backend records.
+         *
+         * It does depend on the operand being updated in place: the backend learns the direction by comparing
+         * the new value of an entry against the one it overwrites, which is the previous iterate only for
+         * Gauss-Seidel. With a regular multiplication the two operands alternate, so the entry being overwritten
+         * holds the iterate from two steps ago (and, in the very first iteration, whatever the auxiliary vector
+         * happened to contain), which says nothing about the direction of the last step. Nothing is claimed
+         * there rather than claiming something unsound.
          */
         if (backend.nonDecreasing()) {
             solutionBounds->lower = operand;

--- a/src/storm/solver/helper/ValueIterationHelper.h
+++ b/src/storm/solver/helper/ValueIterationHelper.h
@@ -8,6 +8,7 @@
 
 #include "storm/solver/MultiplicationStyle.h"
 #include "storm/solver/OptimizationDirection.h"
+#include "storm/solver/SolutionBounds.h"
 #include "storm/solver/SolverStatus.h"
 #include "storm/solver/UncertaintyResolutionMode.h"
 #include "storm/solver/helper/ValueIterationOperatorForward.h"
@@ -21,23 +22,26 @@ class ValueIterationHelper {
 
     template<storm::OptimizationDirection Dir, bool Relative, storm::OptimizationDirection RobustDir>
     SolverStatus VI(std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, SolutionType const& precision,
-                    std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {},
-                    MultiplicationStyle mult = MultiplicationStyle::GaussSeidel) const;
+                    std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {}, MultiplicationStyle mult = MultiplicationStyle::GaussSeidel,
+                    SolutionBounds<SolutionType>* solutionBounds = nullptr) const;
 
     template<storm::OptimizationDirection Dir, bool Relative>
     SolverStatus VI(std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, SolutionType const& precision,
                     const std::function<SolverStatus(const SolverStatus&)>& iterationCallback = {}, MultiplicationStyle mult = MultiplicationStyle::GaussSeidel,
-                    UncertaintyResolutionMode const& uncertaintyResolutionMode = UncertaintyResolutionMode::Unset) const;
+                    UncertaintyResolutionMode const& uncertaintyResolutionMode = UncertaintyResolutionMode::Unset,
+                    SolutionBounds<SolutionType>* solutionBounds = nullptr) const;
 
     SolverStatus VI(std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative,
                     SolutionType const& precision, std::optional<storm::OptimizationDirection> const& dir = {},
                     std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {}, MultiplicationStyle mult = MultiplicationStyle::GaussSeidel,
-                    UncertaintyResolutionMode const& uncertaintyResolutionMode = UncertaintyResolutionMode::Unset) const;
+                    UncertaintyResolutionMode const& uncertaintyResolutionMode = UncertaintyResolutionMode::Unset,
+                    SolutionBounds<SolutionType>* solutionBounds = nullptr) const;
 
     SolverStatus VI(std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets, bool relative, SolutionType const& precision,
                     std::optional<storm::OptimizationDirection> const& dir = {}, std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {},
                     MultiplicationStyle mult = MultiplicationStyle::GaussSeidel,
-                    UncertaintyResolutionMode const& uncertaintyResolutionMode = UncertaintyResolutionMode::Unset) const;
+                    UncertaintyResolutionMode const& uncertaintyResolutionMode = UncertaintyResolutionMode::Unset,
+                    SolutionBounds<SolutionType>* solutionBounds = nullptr) const;
 
    private:
     std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping, SolutionType>> viOperator;

--- a/src/storm/solver/helper/ValueIterationHelper.h
+++ b/src/storm/solver/helper/ValueIterationHelper.h
@@ -12,6 +12,7 @@
 #include "storm/solver/SolverStatus.h"
 #include "storm/solver/UncertaintyResolutionMode.h"
 #include "storm/solver/helper/ValueIterationOperatorForward.h"
+#include "storm/utility/OptionalRef.h"
 
 namespace storm::solver::helper {
 
@@ -23,25 +24,25 @@ class ValueIterationHelper {
     template<storm::OptimizationDirection Dir, bool Relative, storm::OptimizationDirection RobustDir>
     SolverStatus VI(std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, SolutionType const& precision,
                     std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {}, MultiplicationStyle mult = MultiplicationStyle::GaussSeidel,
-                    SolutionBounds<SolutionType>* solutionBounds = nullptr) const;
+                    storm::OptionalRef<SolutionBounds<SolutionType>> solutionBounds = storm::NullRef) const;
 
     template<storm::OptimizationDirection Dir, bool Relative>
     SolverStatus VI(std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, SolutionType const& precision,
                     const std::function<SolverStatus(const SolverStatus&)>& iterationCallback = {}, MultiplicationStyle mult = MultiplicationStyle::GaussSeidel,
                     UncertaintyResolutionMode const& uncertaintyResolutionMode = UncertaintyResolutionMode::Unset,
-                    SolutionBounds<SolutionType>* solutionBounds = nullptr) const;
+                    storm::OptionalRef<SolutionBounds<SolutionType>> solutionBounds = storm::NullRef) const;
 
     SolverStatus VI(std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets, uint64_t& numIterations, bool relative,
                     SolutionType const& precision, std::optional<storm::OptimizationDirection> const& dir = {},
                     std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {}, MultiplicationStyle mult = MultiplicationStyle::GaussSeidel,
                     UncertaintyResolutionMode const& uncertaintyResolutionMode = UncertaintyResolutionMode::Unset,
-                    SolutionBounds<SolutionType>* solutionBounds = nullptr) const;
+                    storm::OptionalRef<SolutionBounds<SolutionType>> solutionBounds = storm::NullRef) const;
 
     SolverStatus VI(std::vector<SolutionType>& operand, std::vector<ValueType> const& offsets, bool relative, SolutionType const& precision,
                     std::optional<storm::OptimizationDirection> const& dir = {}, std::function<SolverStatus(SolverStatus const&)> const& iterationCallback = {},
                     MultiplicationStyle mult = MultiplicationStyle::GaussSeidel,
                     UncertaintyResolutionMode const& uncertaintyResolutionMode = UncertaintyResolutionMode::Unset,
-                    SolutionBounds<SolutionType>* solutionBounds = nullptr) const;
+                    storm::OptionalRef<SolutionBounds<SolutionType>> solutionBounds = storm::NullRef) const;
 
    private:
     std::shared_ptr<ValueIterationOperator<ValueType, TrivialRowGrouping, SolutionType>> viOperator;

--- a/src/test/storm/CMakeLists.txt
+++ b/src/test/storm/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${GTEST_INCLUDE_DIR})
 
 # Set split and non-split test directories
 set(NON_SPLIT_TESTS adapter automata builder logic model parser settings simulator solver storage transformer utility)
-set(MODELCHECKER_TEST_SPLITS csl exploration lexicographic multiobjective reachability)
+set(MODELCHECKER_TEST_SPLITS bounds csl exploration lexicographic multiobjective reachability)
 set(MODELCHECKER_PRCTL_TEST_SPLITS dtmc mdp)
 
 function(configure_testsuite_target testsuite)

--- a/src/test/storm/modelchecker/bounds/SolutionBoundsTest.cpp
+++ b/src/test/storm/modelchecker/bounds/SolutionBoundsTest.cpp
@@ -3,18 +3,23 @@
 
 #include "storm-parsers/api/model_descriptions.h"
 #include "storm-parsers/api/properties.h"
+#include "storm-parsers/parser/FormulaParser.h"
 #include "storm/api/builder.h"
 #include "storm/api/properties.h"
+#include "storm/environment/solver/EigenSolverEnvironment.h"
 #include "storm/environment/solver/MinMaxSolverEnvironment.h"
 #include "storm/environment/solver/NativeSolverEnvironment.h"
 #include "storm/environment/solver/SolverEnvironment.h"
 #include "storm/modelchecker/CheckTask.h"
+#include "storm/modelchecker/csl/SparseCtmcCslModelChecker.h"
 #include "storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.h"
 #include "storm/modelchecker/prctl/SparseMdpPrctlModelChecker.h"
 #include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
+#include "storm/models/sparse/Ctmc.h"
 #include "storm/models/sparse/Dtmc.h"
 #include "storm/models/sparse/Mdp.h"
 #include "storm/models/sparse/StandardRewardModel.h"
+#include "storm/storage/SparseMatrix.h"
 #include "storm/utility/constants.h"
 
 /*
@@ -30,9 +35,24 @@
 
 namespace {
 
+class NativeSviEnvironment {
+   public:
+    typedef double ValueType;
+    static const bool isExact = false;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setForceSoundness(true);
+        env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Native);
+        env.solver().native().setMethod(storm::solver::NativeLinearEquationSolverMethod::SoundValueIteration);
+        env.solver().minMax().setMethod(storm::solver::MinMaxMethod::SoundValueIteration);
+        return env;
+    }
+};
+
 class NativeIiEnvironment {
    public:
     typedef double ValueType;
+    static const bool isExact = false;
     static storm::Environment createEnvironment() {
         storm::Environment env;
         env.solver().setForceSoundness(true);
@@ -46,12 +66,68 @@ class NativeIiEnvironment {
 class NativeOviEnvironment {
    public:
     typedef double ValueType;
+    static const bool isExact = false;
     static storm::Environment createEnvironment() {
         storm::Environment env;
         env.solver().setForceSoundness(true);
         env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Native);
         env.solver().native().setMethod(storm::solver::NativeLinearEquationSolverMethod::OptimisticValueIteration);
         env.solver().minMax().setMethod(storm::solver::MinMaxMethod::OptimisticValueIteration);
+        return env;
+    }
+};
+
+class NativeGviEnvironment {
+   public:
+    typedef double ValueType;
+    static const bool isExact = false;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setForceSoundness(true);
+        env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Native);
+        env.solver().native().setMethod(storm::solver::NativeLinearEquationSolverMethod::GuessingValueIteration);
+        env.solver().minMax().setMethod(storm::solver::MinMaxMethod::GuessingValueIteration);
+        return env;
+    }
+};
+
+// The exact configurations end up at the solution rather than approaching it, so their two bounds must not merely
+// enclose the answer but coincide with it. Policy iteration reports whatever its inner linear solver established,
+// which is what makes it exact here.
+class EliminationEnvironment {
+   public:
+    typedef storm::RationalNumber ValueType;
+    static const bool isExact = true;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Elimination);
+        env.solver().minMax().setMethod(storm::solver::MinMaxMethod::PolicyIteration);
+        return env;
+    }
+};
+
+class EigenLuEnvironment {
+   public:
+    typedef storm::RationalNumber ValueType;
+    static const bool isExact = true;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Eigen);
+        env.solver().eigen().setMethod(storm::solver::EigenLinearEquationSolverMethod::SparseLU);
+        env.solver().minMax().setMethod(storm::solver::MinMaxMethod::PolicyIteration);
+        return env;
+    }
+};
+
+class RationalSearchEnvironment {
+   public:
+    typedef storm::RationalNumber ValueType;
+    static const bool isExact = true;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Native);
+        env.solver().native().setMethod(storm::solver::NativeLinearEquationSolverMethod::RationalSearch);
+        env.solver().minMax().setMethod(storm::solver::MinMaxMethod::RationalSearch);
         return env;
     }
 };
@@ -79,14 +155,19 @@ class SolutionBoundsTest : public ::testing::Test {
         return storm::utility::convertNumber<ExtendedValueType>(storm::utility::convertNumber<ValueType>(input));
     }
 
+    ValueType parseValue(std::string const& input) const {
+        return storm::utility::convertNumber<ValueType>(input);
+    }
+
     /*!
      * How far outside the reported enclosure the exact answer may still lie. A bound is only ever as sound as the
      * arithmetic it is computed in: a procedure working in doubles can land a bound an ulp or two on the wrong
-     * side of an answer that is not representable at all. That is the rounding we accept, not a gap in the
-     * reasoning, so the slack is far below the solver precision these configurations ask for.
+     * side of an answer that is not representable at all, as 11/3 is not. That is the rounding we accept, not a
+     * gap in the reasoning, so an inexact configuration is given a slack far below its own solver precision while
+     * an exact one is given none.
      */
     ExtendedValueType tolerance() const {
-        return this->parseNumber("1e-12");
+        return this->parseNumber(TestType::isExact ? "0" : "1e-12");
     }
 
     /*!
@@ -94,15 +175,19 @@ class SolutionBoundsTest : public ::testing::Test {
      */
     template<typename ModelType>
     std::unique_ptr<storm::modelchecker::CheckResult> check(std::string const& modelFile, std::string const& propertyString) const {
-        storm::prism::Program program = storm::api::parseProgram(modelFile);
+        // The CTMC test files spell their rates the way PRISM does, which storm accepts in compatibility mode only.
+        bool const prismCompatibility = std::is_same_v<ModelType, storm::models::sparse::Ctmc<ValueType>>;
+        storm::prism::Program program = storm::api::parseProgram(modelFile, prismCompatibility);
         program = program.preprocess();
         auto formulas = storm::api::extractFormulasFromProperties(storm::api::parsePropertiesForPrismProgram(propertyString, program));
         auto model = storm::api::buildSparseModel<ValueType>(program, formulas)->template as<ModelType>();
         storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> task(*formulas.front(), true);
         if constexpr (std::is_same_v<ModelType, storm::models::sparse::Dtmc<ValueType>>) {
             return storm::modelchecker::SparseDtmcPrctlModelChecker<ModelType>(*model).check(this->env(), task);
-        } else {
+        } else if constexpr (std::is_same_v<ModelType, storm::models::sparse::Mdp<ValueType>>) {
             return storm::modelchecker::SparseMdpPrctlModelChecker<ModelType>(*model).check(this->env(), task);
+        } else {
+            return storm::modelchecker::SparseCtmcCslModelChecker<ModelType>(*model).check(this->env(), task);
         }
     }
 
@@ -122,21 +207,33 @@ class SolutionBoundsTest : public ::testing::Test {
         EXPECT_LE(exact, upper + this->tolerance()) << "The upper bound falls below the exact answer.";
         EXPECT_LE(lower, value) << "The lower bound exceeds the reported value.";
         EXPECT_LE(value, upper) << "The reported value exceeds the upper bound.";
+        if (TestType::isExact) {
+            EXPECT_EQ(exact, lower) << "An exact procedure reported a lower bound strictly below the answer.";
+            EXPECT_EQ(exact, upper) << "An exact procedure reported an upper bound strictly above the answer.";
+        }
     }
 
    private:
     storm::Environment _environment;
 };
 
-typedef ::testing::Types<NativeIiEnvironment, NativeOviEnvironment> TestingTypes;
+typedef ::testing::Types<NativeSviEnvironment, NativeIiEnvironment, NativeOviEnvironment, NativeGviEnvironment, EliminationEnvironment, EigenLuEnvironment,
+                         RationalSearchEnvironment>
+    TestingTypes;
 
 TYPED_TEST_SUITE(SolutionBoundsTest, TestingTypes, );
 
-// The Knuth-Yao die yields a one with probability exactly 1/6.
+// The Knuth-Yao die yields a one with probability exactly 1/6 and takes 11/3 coin flips on average.
 TYPED_TEST(SolutionBoundsTest, DtmcUntilProbabilities) {
     typedef typename TestFixture::ValueType ValueType;
     auto result = this->template check<storm::models::sparse::Dtmc<ValueType>>(STORM_TEST_RESOURCES_DIR "/dtmc/die.pm", "P=? [F s=7 & d=1]");
     this->expectEncloses(result, this->parseNumber("1/6"));
+}
+
+TYPED_TEST(SolutionBoundsTest, DtmcReachabilityRewards) {
+    typedef typename TestFixture::ValueType ValueType;
+    auto result = this->template check<storm::models::sparse::Dtmc<ValueType>>(STORM_TEST_RESOURCES_DIR "/dtmc/die.pm", "R=? [F s=7]");
+    this->expectEncloses(result, this->parseNumber("11/3"));
 }
 
 TYPED_TEST(SolutionBoundsTest, MdpUntilProbabilities) {
@@ -144,6 +241,182 @@ TYPED_TEST(SolutionBoundsTest, MdpUntilProbabilities) {
     auto result = this->template check<storm::models::sparse::Mdp<ValueType>>(STORM_TEST_RESOURCES_DIR "/mdp/coin2-2.nm",
                                                                               "Pmin=? [F \"finished\" & \"all_coins_equal_1\"]");
     this->expectEncloses(result, this->parseNumber("49/128"));
+}
+
+TYPED_TEST(SolutionBoundsTest, MdpReachabilityRewards) {
+    typedef typename TestFixture::ValueType ValueType;
+    auto result = this->template check<storm::models::sparse::Mdp<ValueType>>(STORM_TEST_RESOURCES_DIR "/mdp/coin2-2.nm", "Rmax=? [F \"finished\"]");
+    this->expectEncloses(result, this->parseNumber("75"));
+}
+
+// In the five state CTMC, state three is reached after 91/24 time units and 23/8 units of "rew1" on average.
+TYPED_TEST(SolutionBoundsTest, CtmcReachabilityTimes) {
+    typedef typename TestFixture::ValueType ValueType;
+    auto result = this->template check<storm::models::sparse::Ctmc<ValueType>>(STORM_TEST_RESOURCES_DIR "/ctmc/simple2.sm", "T=? [F s=3]");
+    this->expectEncloses(result, this->parseNumber("91/24"));
+}
+
+TYPED_TEST(SolutionBoundsTest, CtmcReachabilityRewards) {
+    typedef typename TestFixture::ValueType ValueType;
+    auto result = this->template check<storm::models::sparse::Ctmc<ValueType>>(STORM_TEST_RESOURCES_DIR "/ctmc/simple2.sm", "R{\"rew1\"}=? [F s=3]");
+    this->expectEncloses(result, this->parseNumber("23/8"));
+}
+
+/*
+ * A four state CTMC whose reachability probability is not representable in binary:
+ *
+ *   0 --1--> 1 (target)        p(0) = 1/3 + 2/3 p(2)
+ *   0 --2--> 2                 p(2) = 3/4 p(0)         so p(0) = 2/3.
+ *   2 --3--> 0
+ *   2 --1--> 3 (a dead end)
+ */
+TYPED_TEST(SolutionBoundsTest, CtmcUntilProbabilities) {
+    typedef typename TestFixture::ValueType ValueType;
+    storm::storage::SparseMatrixBuilder<ValueType> builder(4, 4, 6);
+    builder.addNextValue(0, 1, this->parseValue("1"));
+    builder.addNextValue(0, 2, this->parseValue("2"));
+    builder.addNextValue(1, 1, this->parseValue("1"));
+    builder.addNextValue(2, 0, this->parseValue("3"));
+    builder.addNextValue(2, 3, this->parseValue("1"));
+    builder.addNextValue(3, 3, this->parseValue("1"));
+
+    storm::models::sparse::StateLabeling labeling(4);
+    labeling.addLabel("init");
+    labeling.addLabelToState("init", 0);
+    labeling.addLabel("target");
+    labeling.addLabelToState("target", 1);
+    storm::models::sparse::Ctmc<ValueType> ctmc(builder.build(), labeling);
+
+    storm::parser::FormulaParser formulaParser;
+    auto formula = formulaParser.parseSingleFormulaFromString("P=? [F \"target\"]");
+    storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> task(*formula, true);
+    auto result = storm::modelchecker::SparseCtmcCslModelChecker<storm::models::sparse::Ctmc<ValueType>>(ctmc).check(this->env(), task);
+    this->expectEncloses(result, this->parseNumber("2/3"));
+}
+
+/*
+ * A property that the graph analysis settles on its own never reaches an equation solver, but its values are
+ * known exactly all the same, so they must be reported as their own bounds rather than as no bound at all. In
+ * this three state chain the target is reached almost surely from the first two states and not at all from the
+ * third, and every configuration must say so exactly.
+ */
+TYPED_TEST(SolutionBoundsTest, QualitativelySettledValuesAreExact) {
+    typedef typename TestFixture::ValueType ValueType;
+    typedef typename TestFixture::ExtendedValueType ExtendedValueType;
+
+    storm::storage::SparseMatrixBuilder<ValueType> builder(3, 3, 3);
+    builder.addNextValue(0, 1, this->parseValue("1"));
+    builder.addNextValue(1, 1, this->parseValue("1"));
+    builder.addNextValue(2, 2, this->parseValue("1"));
+
+    storm::models::sparse::StateLabeling labeling(3);
+    labeling.addLabel("init");
+    labeling.addLabelToState("init", 0);
+    labeling.addLabel("target");
+    labeling.addLabelToState("target", 1);
+    storm::models::sparse::Dtmc<ValueType> dtmc(builder.build(), labeling);
+
+    storm::parser::FormulaParser formulaParser;
+    auto formula = formulaParser.parseSingleFormulaFromString("P=? [F \"target\"]");
+    storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> task(*formula, true);
+    auto result = storm::modelchecker::SparseDtmcPrctlModelChecker<storm::models::sparse::Dtmc<ValueType>>(dtmc).check(this->env(), task);
+
+    auto const& quantitative = result->template asExplicitQuantitativeCheckResult<ValueType>();
+    ASSERT_TRUE(quantitative.hasLowerBounds()) << "No lower bound was reported for a value the graph analysis settled.";
+    ASSERT_TRUE(quantitative.hasUpperBounds()) << "No upper bound was reported for a value the graph analysis settled.";
+    std::vector<ExtendedValueType> const expected{this->parseNumber("1"), this->parseNumber("1"), this->parseNumber("0")};
+    EXPECT_EQ(expected, quantitative.getValueVector());
+    EXPECT_EQ(expected, quantitative.getLowerBoundVector());
+    EXPECT_EQ(expected, quantitative.getUpperBoundVector());
+}
+
+/*
+ * The aggregating filters report the aggregate of each bound alongside the aggregate of the values. Checking that
+ * against a model would only ever exercise whichever enclosure the solver happened to produce, so the result here
+ * is built by hand: three values, each enclosed by a bound that is deliberately loose in both directions.
+ */
+TYPED_TEST(SolutionBoundsTest, AggregationCarriesTheBounds) {
+    typedef typename TestFixture::ValueType ValueType;
+    typedef typename TestFixture::ExtendedValueType ExtendedValueType;
+    using storm::modelchecker::FilterType;
+
+    std::vector<ExtendedValueType> const values{this->parseNumber("1"), this->parseNumber("2"), this->parseNumber("6")};
+    storm::modelchecker::ExplicitQuantitativeCheckResult<ValueType> result(values);
+    result.setLowerBounds({this->parseNumber("0"), this->parseNumber("1"), this->parseNumber("5")});
+    result.setUpperBounds({this->parseNumber("2"), this->parseNumber("4"), this->parseNumber("7")});
+
+    auto const min = result.aggregate(FilterType::MIN);
+    EXPECT_EQ(this->parseNumber("1"), min.value);
+    ASSERT_TRUE(min.hasLower() && min.hasUpper());
+    EXPECT_EQ(this->parseNumber("0"), *min.lower);
+    EXPECT_EQ(this->parseNumber("2"), *min.upper);
+
+    auto const max = result.aggregate(FilterType::MAX);
+    EXPECT_EQ(this->parseNumber("6"), max.value);
+    ASSERT_TRUE(max.hasLower() && max.hasUpper());
+    EXPECT_EQ(this->parseNumber("5"), *max.lower);
+    EXPECT_EQ(this->parseNumber("7"), *max.upper);
+
+    auto const sum = result.aggregate(FilterType::SUM);
+    EXPECT_EQ(this->parseNumber("9"), sum.value);
+    ASSERT_TRUE(sum.hasLower() && sum.hasUpper());
+    EXPECT_EQ(this->parseNumber("6"), *sum.lower);
+    EXPECT_EQ(this->parseNumber("13"), *sum.upper);
+
+    auto const average = result.aggregate(FilterType::AVG);
+    EXPECT_EQ(this->parseNumber("3"), average.value);
+    ASSERT_TRUE(average.hasLower() && average.hasUpper());
+    EXPECT_EQ(this->parseNumber("2"), *average.lower);
+    EXPECT_EQ(this->parseNumber("13/3"), *average.upper);
+}
+
+// A result that carries no bounds must aggregate to an aggregate without any, rather than to one that quietly
+// repeats the value as though it were a bound on itself.
+TYPED_TEST(SolutionBoundsTest, AggregationWithoutBounds) {
+    typedef typename TestFixture::ValueType ValueType;
+    typedef typename TestFixture::ExtendedValueType ExtendedValueType;
+
+    std::vector<ExtendedValueType> const values{this->parseNumber("1"), this->parseNumber("2")};
+    storm::modelchecker::ExplicitQuantitativeCheckResult<ValueType> const result(values);
+    auto const sum = result.aggregate(storm::modelchecker::FilterType::SUM);
+    EXPECT_EQ(this->parseNumber("3"), sum.value);
+    EXPECT_FALSE(sum.hasLower());
+    EXPECT_FALSE(sum.hasUpper());
+}
+
+/*
+ * The whole point of these bounds is that they do not wait for convergence: sound value iteration maintains an
+ * enclosure of the solution at every step, so cutting it short must still yield an enclosure, only a wider one.
+ * This is checked on its own rather than as a typed test because how far a given method gets in a given number of
+ * iterations is a property of that method, not something the other configurations share.
+ */
+TEST(SolutionBoundsTest, AbortedSoundValueIterationStillEncloses) {
+    auto environmentWithIterationCap = [](uint64_t maximalIterations) {
+        storm::Environment env;
+        env.solver().setForceSoundness(true);
+        env.solver().minMax().setMethod(storm::solver::MinMaxMethod::SoundValueIteration);
+        env.solver().minMax().setMaximalNumberOfIterations(maximalIterations);
+        return env;
+    };
+
+    storm::prism::Program program = storm::api::parseProgram(STORM_TEST_RESOURCES_DIR "/mdp/coin2-2.nm").preprocess();
+    auto formulas =
+        storm::api::extractFormulasFromProperties(storm::api::parsePropertiesForPrismProgram("Pmin=? [F \"finished\" & \"all_coins_equal_1\"]", program));
+    auto model = storm::api::buildSparseModel<double>(program, formulas)->as<storm::models::sparse::Mdp<double>>();
+    storm::modelchecker::CheckTask<storm::logic::Formula, double> task(*formulas.front(), true);
+    storm::modelchecker::SparseMdpPrctlModelChecker<storm::models::sparse::Mdp<double>> checker(*model);
+
+    // The answer is 49/128, and twenty iterations are not nearly enough to reach it.
+    double const exact = 49.0 / 128.0;
+    auto const aborted = checker.check(environmentWithIterationCap(20), task)->asExplicitQuantitativeCheckResult<double>().getSolutionBounds();
+    auto const converged = checker.check(environmentWithIterationCap(100), task)->asExplicitQuantitativeCheckResult<double>().getSolutionBounds();
+
+    ASSERT_TRUE(aborted.hasLower() && aborted.hasUpper()) << "An aborted run reported no bounds at all.";
+    ASSERT_TRUE(converged.hasLower() && converged.hasUpper());
+    EXPECT_LE((*aborted.lower)[0], exact) << "The lower bound of an aborted run exceeds the exact answer.";
+    EXPECT_LE(exact, (*aborted.upper)[0]) << "The upper bound of an aborted run falls below the exact answer.";
+    EXPECT_LT((*aborted.lower)[0], (*converged.lower)[0]) << "Stopping earlier did not give a wider enclosure.";
+    EXPECT_LT((*converged.upper)[0], (*aborted.upper)[0]) << "Stopping earlier did not give a wider enclosure.";
 }
 
 }  // namespace

--- a/src/test/storm/modelchecker/bounds/SolutionBoundsTest.cpp
+++ b/src/test/storm/modelchecker/bounds/SolutionBoundsTest.cpp
@@ -65,6 +65,12 @@ class SolutionBoundsTest : public ::testing::Test {
 
     SolutionBoundsTest() : _environment(TestType::createEnvironment()) {}
 
+    void SetUp() override {
+#ifndef STORM_HAVE_Z3
+        GTEST_SKIP() << "Z3 not available.";
+#endif
+    }
+
     storm::Environment const& env() const {
         return _environment;
     }

--- a/src/test/storm/modelchecker/bounds/SolutionBoundsTest.cpp
+++ b/src/test/storm/modelchecker/bounds/SolutionBoundsTest.cpp
@@ -1,0 +1,143 @@
+#include "storm-config.h"
+#include "test/storm_gtest.h"
+
+#include "storm-parsers/api/model_descriptions.h"
+#include "storm-parsers/api/properties.h"
+#include "storm/api/builder.h"
+#include "storm/api/properties.h"
+#include "storm/environment/solver/MinMaxSolverEnvironment.h"
+#include "storm/environment/solver/NativeSolverEnvironment.h"
+#include "storm/environment/solver/SolverEnvironment.h"
+#include "storm/modelchecker/CheckTask.h"
+#include "storm/modelchecker/prctl/SparseDtmcPrctlModelChecker.h"
+#include "storm/modelchecker/prctl/SparseMdpPrctlModelChecker.h"
+#include "storm/modelchecker/results/ExplicitQuantitativeCheckResult.h"
+#include "storm/models/sparse/Dtmc.h"
+#include "storm/models/sparse/Mdp.h"
+#include "storm/models/sparse/StandardRewardModel.h"
+#include "storm/utility/constants.h"
+
+/*
+ * These tests are about the sound bounds that a model checking call reports alongside its values, not about the
+ * values themselves. The claim under test is the one the bounds make, so every property here has an answer that
+ * is known in closed form and each case asserts
+ *
+ *     lower <= exact <= upper   and   lower <= reported value <= upper.
+ *
+ * Every configuration listed below is one that must report both bounds, so a path that silently stops reporting
+ * them fails these tests rather than passing them vacuously.
+ */
+
+namespace {
+
+class NativeIiEnvironment {
+   public:
+    typedef double ValueType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setForceSoundness(true);
+        env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Native);
+        env.solver().native().setMethod(storm::solver::NativeLinearEquationSolverMethod::IntervalIteration);
+        env.solver().minMax().setMethod(storm::solver::MinMaxMethod::IntervalIteration);
+        return env;
+    }
+};
+
+class NativeOviEnvironment {
+   public:
+    typedef double ValueType;
+    static storm::Environment createEnvironment() {
+        storm::Environment env;
+        env.solver().setForceSoundness(true);
+        env.solver().setLinearEquationSolverType(storm::solver::EquationSolverType::Native);
+        env.solver().native().setMethod(storm::solver::NativeLinearEquationSolverMethod::OptimisticValueIteration);
+        env.solver().minMax().setMethod(storm::solver::MinMaxMethod::OptimisticValueIteration);
+        return env;
+    }
+};
+
+template<typename TestType>
+class SolutionBoundsTest : public ::testing::Test {
+   public:
+    typedef typename TestType::ValueType ValueType;
+    typedef storm::utility::ExtendedValueType<ValueType> ExtendedValueType;
+    typedef storm::modelchecker::ExplicitQuantitativeCheckResult<ValueType> QuantitativeResult;
+
+    SolutionBoundsTest() : _environment(TestType::createEnvironment()) {}
+
+    storm::Environment const& env() const {
+        return _environment;
+    }
+
+    ExtendedValueType parseNumber(std::string const& input) const {
+        return storm::utility::convertNumber<ExtendedValueType>(storm::utility::convertNumber<ValueType>(input));
+    }
+
+    /*!
+     * How far outside the reported enclosure the exact answer may still lie. A bound is only ever as sound as the
+     * arithmetic it is computed in: a procedure working in doubles can land a bound an ulp or two on the wrong
+     * side of an answer that is not representable at all. That is the rounding we accept, not a gap in the
+     * reasoning, so the slack is far below the solver precision these configurations ask for.
+     */
+    ExtendedValueType tolerance() const {
+        return this->parseNumber("1e-12");
+    }
+
+    /*!
+     * Builds the given PRISM model and checks the given property on it.
+     */
+    template<typename ModelType>
+    std::unique_ptr<storm::modelchecker::CheckResult> check(std::string const& modelFile, std::string const& propertyString) const {
+        storm::prism::Program program = storm::api::parseProgram(modelFile);
+        program = program.preprocess();
+        auto formulas = storm::api::extractFormulasFromProperties(storm::api::parsePropertiesForPrismProgram(propertyString, program));
+        auto model = storm::api::buildSparseModel<ValueType>(program, formulas)->template as<ModelType>();
+        storm::modelchecker::CheckTask<storm::logic::Formula, ValueType> task(*formulas.front(), true);
+        if constexpr (std::is_same_v<ModelType, storm::models::sparse::Dtmc<ValueType>>) {
+            return storm::modelchecker::SparseDtmcPrctlModelChecker<ModelType>(*model).check(this->env(), task);
+        } else {
+            return storm::modelchecker::SparseMdpPrctlModelChecker<ModelType>(*model).check(this->env(), task);
+        }
+    }
+
+    /*!
+     * Asserts that the bounds the given result reports for the initial state enclose the given exact answer, and
+     * that the value it reports lies between them as well.
+     */
+    void expectEncloses(std::unique_ptr<storm::modelchecker::CheckResult> const& result, ExtendedValueType const& exact) const {
+        QuantitativeResult const& quantitative = result->template asExplicitQuantitativeCheckResult<ValueType>();
+        ASSERT_TRUE(quantitative.hasLowerBounds()) << "No lower bound on the solution was reported at all.";
+        ASSERT_TRUE(quantitative.hasUpperBounds()) << "No upper bound on the solution was reported at all.";
+        uint64_t const offset = 0;
+        ExtendedValueType const& value = quantitative.getValueVector()[offset];
+        ExtendedValueType const& lower = quantitative.getLowerBoundVector()[offset];
+        ExtendedValueType const& upper = quantitative.getUpperBoundVector()[offset];
+        EXPECT_LE(lower, exact + this->tolerance()) << "The lower bound exceeds the exact answer.";
+        EXPECT_LE(exact, upper + this->tolerance()) << "The upper bound falls below the exact answer.";
+        EXPECT_LE(lower, value) << "The lower bound exceeds the reported value.";
+        EXPECT_LE(value, upper) << "The reported value exceeds the upper bound.";
+    }
+
+   private:
+    storm::Environment _environment;
+};
+
+typedef ::testing::Types<NativeIiEnvironment, NativeOviEnvironment> TestingTypes;
+
+TYPED_TEST_SUITE(SolutionBoundsTest, TestingTypes, );
+
+// The Knuth-Yao die yields a one with probability exactly 1/6.
+TYPED_TEST(SolutionBoundsTest, DtmcUntilProbabilities) {
+    typedef typename TestFixture::ValueType ValueType;
+    auto result = this->template check<storm::models::sparse::Dtmc<ValueType>>(STORM_TEST_RESOURCES_DIR "/dtmc/die.pm", "P=? [F s=7 & d=1]");
+    this->expectEncloses(result, this->parseNumber("1/6"));
+}
+
+TYPED_TEST(SolutionBoundsTest, MdpUntilProbabilities) {
+    typedef typename TestFixture::ValueType ValueType;
+    auto result = this->template check<storm::models::sparse::Mdp<ValueType>>(STORM_TEST_RESOURCES_DIR "/mdp/coin2-2.nm",
+                                                                              "Pmin=? [F \"finished\" & \"all_coins_equal_1\"]");
+    this->expectEncloses(result, this->parseNumber("49/128"));
+}
+
+}  // namespace


### PR DESCRIPTION
Builds on top of #1031.

This PR adds bounds for the following algorithms:

- Value iteration (power method) — solver/NativeLinearEquationSolver.cpp (solveEquationsPower), solver/helper/ValueIterationHelper.cpp. A sweep that moved every entry one way proves the operand is a post- or pre-fixpoint, giving that side of the enclosure. Only for in-place (Gauss-Seidel) multiplication.
- Value iteration (MinMax) — solver/IterativeMinMaxLinearEquationSolver.cpp (solveEquationsValueIteration). The same sweep certificate, claimed only when the caller has set hasUniqueSolution().
- Sound value iteration — solver/helper/SoundValueIterationHelper.cpp, plus solveEquationsSoundValueIteration in both solvers. The enclosure SVI maintains, read out before the final averaging step collapses it. Needs both scaling factors to be known.
- Guessing value iteration — solveEquationsGuessingValueIteration in both solvers. The two vectors GVI keeps, which hold verified guesses and so enclose the solution throughout.
- Rational search — solveEquationsRationalSearch in both solvers. The solution as both bounds, once sharpening has verified an exact fixpoint.
- Policy iteration — solver/IterativeMinMaxLinearEquationSolver.cpp (performPolicyIteration). Whatever the inner linear solver established. Optimality of the scheduler says nothing about the accuracy of the values.
- State elimination — solver/EliminationLinearEquationSolver.cpp. The solution as both bounds; the method is direct.
- Eigen SparseLU — solver/EigenLinearEquationSolver.cpp. The solution as both bounds. The iterative Eigen methods are left out.
- Acyclic solving — solver/AcyclicLinearEquationSolver.cpp, solver/AcyclicMinMaxLinearEquationSolver.cpp. The solution as both bounds; values are substituted in topological order and final when written.
- Topological solving — solver/TopologicalLinearEquationSolver.cpp, solver/TopologicalMinMaxLinearEquationSolver.cpp. An interval of ±precision around the result, under --sound only. The per-SCC deviations add to at most the configured precision along any chain.
- Robust value iteration (interval models) — modelchecker/prctl/helper/SparseDtmcPrctlHelper.cpp (computeRobustValuesForMaybeStates). Whatever the MinMax solver produced. Now that is the sweep certificate, so rewards report and probabilities do not.

This is the ones I have tackled so far, I am not entirely certain these bounds are correct, but they all seem logical to me and when possible I tried to read the papers to find if they claim a bound. Please suggest other algorithms I can report bounds for.